### PR TITLE
Add container sort control (name / update type / watcher)

### DIFF
--- a/ui/src/components/ContainerFilter.vue
+++ b/ui/src/components/ContainerFilter.vue
@@ -127,6 +127,7 @@ export default {
       sortOptions: [
         { title: "Name", value: "name" },
         { title: "Update type", value: "update-type" },
+        { title: "Watcher", value: "watcher" },
       ],
     };
   },

--- a/ui/src/components/ContainerFilter.vue
+++ b/ui/src/components/ContainerFilter.vue
@@ -42,6 +42,17 @@
         ></v-select>
       </v-col>
       <v-col>
+        <v-select
+          :hide-details="true"
+          v-model="sortSelected"
+          :items="sortOptions"
+          @update:model-value="emitSortChanged"
+          label="Sort"
+          variant="outlined"
+          density="compact"
+        ></v-select>
+      </v-col>
+      <v-col>
         <v-switch
           class="switch-top"
           color="secondary"
@@ -100,6 +111,10 @@ export default {
       type: Boolean,
       required: true,
     },
+    sortSelectedInit: {
+      type: String,
+      required: true,
+    },
   },
 
   data() {
@@ -108,6 +123,11 @@ export default {
       registrySelected: "",
       watcherSelected: "",
       updateKindSelected: "",
+      sortSelected: "name",
+      sortOptions: [
+        { title: "Name", value: "name" },
+        { title: "Update type", value: "update-type" },
+      ],
     };
   },
 
@@ -123,6 +143,9 @@ export default {
     },
     emitUpdateAvailableChanged() {
       this.$emit("update-available-changed");
+    },
+    emitSortChanged() {
+      this.$emit("sort-changed", this.sortSelected);
     },
     async refreshAllContainers() {
       this.isRefreshing = true;
@@ -145,6 +168,7 @@ export default {
     this.registrySelected = this.registrySelectedInit;
     this.watcherSelected = this.watcherSelectedInit;
     this.updateKindSelected = this.updateKindSelectedInit;
+    this.sortSelected = this.sortSelectedInit;
   },
 };
 </script>

--- a/ui/src/views/ContainersView.vue
+++ b/ui/src/views/ContainersView.vue
@@ -10,17 +10,19 @@
           :update-kinds="updateKinds"
           :update-kind-selected-init="updateKindSelected"
           :updateAvailable="updateAvailableSelected"
+          :sort-selected-init="sortSelected"
           @registry-changed="onRegistryChanged"
           @watcher-changed="onWatcherChanged"
           @update-available-changed="onUpdateAvailableChanged"
           @update-kind-changed="onUpdateKindChanged"
+          @sort-changed="onSortChanged"
           @refresh-all-containers="onRefreshAllContainers"
         />
       </v-col>
     </v-row>
 
     <v-fade-transition group hide-on-leave mode="in-out">
-      <v-row v-for="container in containersFiltered" :key="container.id">
+      <v-row v-for="container in containersSorted" :key="container.id">
         <v-col class="pt-2 pb-2">
           <container-item
             :container="container"
@@ -30,7 +32,7 @@
         </v-col>
       </v-row>
     </v-fade-transition>
-    <v-row v-if="containersFiltered.length === 0">
+    <v-row v-if="containersSorted.length === 0">
       <v-card-subtitle class="text-h6">No containers found</v-card-subtitle>
     </v-row>
   </v-container>
@@ -55,6 +57,7 @@ export default {
       watcherSelected: "",
       updateKindSelected: "",
       updateAvailableSelected: false,
+      sortSelected: "name",
     };
   },
 
@@ -109,6 +112,33 @@ export default {
           this.updateAvailableSelected ? container.updateAvailable : true,
         );
     },
+    containersSorted() {
+      const byName = (a, b) =>
+        (a.displayName || a.name).localeCompare(b.displayName || b.name);
+      const rank = (container) => {
+        if (
+          container.updateAvailable &&
+          container.updateKind &&
+          container.updateKind.kind === "tag"
+        ) {
+          switch (container.updateKind.semverDiff) {
+            case "major":
+              return 0;
+            case "minor":
+              return 1;
+            case "patch":
+              return 2;
+          }
+        }
+        return 3;
+      };
+      // Sort a copy: the computed must not mutate the source array in place.
+      const containers = [...this.containersFiltered];
+      if (this.sortSelected === "update-type") {
+        return containers.sort((a, b) => rank(a) - rank(b) || byName(a, b));
+      }
+      return containers.sort(byName);
+    },
   },
 
   methods: {
@@ -128,6 +158,10 @@ export default {
       this.updateKindSelected = updateKindSelected;
       this.updateQueryParams();
     },
+    onSortChanged(sortSelected) {
+      this.sortSelected = sortSelected;
+      this.updateQueryParams();
+    },
     updateQueryParams() {
       const query = {};
       if (this.registrySelected) {
@@ -141,6 +175,9 @@ export default {
       }
       if (this.updateAvailableSelected) {
         query["update-available"] = this.updateAvailableSelected;
+      }
+      if (this.sortSelected && this.sortSelected !== "name") {
+        query["sort"] = this.sortSelected;
       }
       this.$router.push({ query });
     },
@@ -168,6 +205,7 @@ export default {
     const watcherSelected = to.query["watcher"];
     const updateKindSelected = to.query["update-kind"];
     const updateAvailable = to.query["update-available"];
+    const sortSelected = to.query["sort"];
     try {
       const containers = await getAllContainers();
       next((vm) => {
@@ -182,6 +220,9 @@ export default {
         }
         if (updateAvailable) {
           vm.updateAvailableSelected = updateAvailable.toLowerCase() === "true";
+        }
+        if (sortSelected) {
+          vm.sortSelected = sortSelected;
         }
         vm.containers = containers;
       });

--- a/ui/src/views/ContainersView.vue
+++ b/ui/src/views/ContainersView.vue
@@ -137,6 +137,11 @@ export default {
       if (this.sortSelected === "update-type") {
         return containers.sort((a, b) => rank(a) - rank(b) || byName(a, b));
       }
+      if (this.sortSelected === "watcher") {
+        return containers.sort(
+          (a, b) => a.watcher.localeCompare(b.watcher) || byName(a, b),
+        );
+      }
       return containers.sort(byName);
     },
   },


### PR DESCRIPTION
First sub-PR of Track 3 (Mobile + UI polish). Adds a **Sort** control to the `/containers` list.

## Changes
- **`ContainerFilter.vue`**: new "Sort" `v-select` with options **Name** (default), **Update type**, and **Watcher**. Adds `sortSelectedInit` prop and `sort-changed` event, following the existing init/emit pattern of the other filters.
- **`ContainersView.vue`**: new `containersSorted` computed wraps `containersFiltered` and sorts a **copy** of the array (computeds must not mutate their source):
  - **Name:** `localeCompare` on `displayName` (falls back to `name`).
  - **Update type:** rank `major (0) -> minor (1) -> patch (2) -> none (3)` from `updateKind.semverDiff` (only when `updateAvailable` and `kind === 'tag'`), with name as the tiebreak.
  - **Watcher:** `localeCompare` on `watcher`, with name as the tiebreak.
  - Selection persists in the `sort` query param (omitted when default `name`), read back in `beforeRouteEnter`.

## Verification
- `npm run build` (node:20-alpine, per the repo's container build note): clean.
- `eslint` on both changed files: clean (exit 0).
- Tested live on devtest (port 3009) against prod-seeded state.
- Backend untouched.

## Out of scope (later Track 3 PRs)
- Live container state via SSE (kills the full-page reloads in `ContainerItem.vue`).
- Mobile responsive layout for `ContainerItem.vue` (will also fold in the stray `console.log` / dead `checkInterval` cleanup there).