### PR TITLE
Fix: distinct color for prerelease updates

### DIFF
--- a/ui/src/components/ContainerItem.vue
+++ b/ui/src/components/ContainerItem.vue
@@ -359,6 +359,9 @@ export default {
           case "patch":
             color = "success";
             break;
+          case "prerelease":
+            color = "prerelease";
+            break;
         }
       }
       return color;

--- a/ui/src/components/ContainerUpdate.vue
+++ b/ui/src/components/ContainerUpdate.vue
@@ -53,6 +53,11 @@
           <v-icon v-else-if="updateKind.semverDiff === 'major'" color="error"
             >mdi-alert-decagram</v-icon
           >
+          <v-icon
+            v-else-if="updateKind.semverDiff === 'prerelease'"
+            color="prerelease"
+            >mdi-information-outline</v-icon
+          >
           <v-icon v-else color="warning">mdi-alert</v-icon>
         </template>
         <v-list-item-title>Update kind</v-list-item-title>

--- a/ui/src/plugins/vuetify.js
+++ b/ui/src/plugins/vuetify.js
@@ -19,6 +19,9 @@ const colors = {
   secondary: "#0096C7",
   accent: "#06D6A0",
   error: "#E53935",
+  // Prerelease is the least-severe update rung; cyan keeps it distinct from
+  // the info-blue metadata chips and the major/minor/patch severity colors.
+  prerelease: "#00BCD4",
 };
 
 export default createVuetify({


### PR DESCRIPTION
The backend (`app/model/container.js`) emits four `semverDiff` values: `major`, `minor`, `patch`, `prerelease`. The UI color maps only handled three, so `prerelease` fell through to the default `warning` (orange) and was indistinguishable from a `minor` update.

## Changes
- **`vuetify.js`**: new `prerelease` theme token, cyan `#00BCD4` (kept distinct from the `info`-blue metadata chips and the major/minor/patch severity colors). Added to the shared `colors` object so it applies to both light and dark themes.
- **`ContainerItem.vue`**: `newVersionClass` maps `prerelease` to the `prerelease` color (version chip in the list row).
- **`ContainerUpdate.vue`**: new branch for `prerelease` in the update-kind icon (`mdi-information-outline`, `prerelease` color), so it no longer shares the `minor` icon/color.

Resulting ladder: major=red, minor=orange, patch=green, **prerelease=cyan**.

## Verification
- `npm run build` (node:20-alpine): clean. `eslint` on changed components: 0 errors.
- Tested live on devtest (port 3009).
- Backend untouched.