### PR TITLE
feat(ui): live container state via SSE, no full-page reload

### DIFF
--- a/app/api/container.js
+++ b/app/api/container.js
@@ -2,6 +2,11 @@ const express = require('express');
 const nocache = require('nocache');
 const storeContainer = require('../store/container');
 const registry = require('../registry');
+const {
+    registerContainerAdded,
+    registerContainerUpdated,
+    registerContainerRemoved,
+} = require('../event');
 const { getServerConfiguration, getTriggerConfigurations } = require('../configuration');
 const HttpTrigger = require('../triggers/providers/http/Http');
 const ScriptTrigger = require('../triggers/providers/script/Script');
@@ -56,6 +61,22 @@ function getTriggersWithInstall() {
 }
 
 /**
+ * Resolve the install flag shared by the REST list and the SSE stream.
+ * @returns {boolean|String} true, false, or 'multiple'.
+ */
+function getInstallEnabled() {
+    const triggersWithInstall = getTriggersWithInstall();
+    if (triggersWithInstall.length === 1) {
+        return true;
+    }
+    if (triggersWithInstall.length > 1) {
+        console.warn('Multiple triggers have install enabled; install action will be disabled.');
+        return 'multiple';
+    }
+    return false;
+}
+
+/**
  * Get all containers with 'install' flags.
  * @param {Object} req
  * @param {Object} res
@@ -71,15 +92,7 @@ function getContainers(req, res) {
         'Expires': '0'
     });
 
-    const triggersWithInstall = getTriggersWithInstall();
-    let installEnabled = false;
-
-    if (triggersWithInstall.length === 1) {
-        installEnabled = true;
-    } else if (triggersWithInstall.length > 1) {
-        installEnabled = 'multiple';
-        console.warn('Multiple triggers have install enabled; install action will be disabled.');
-    }
+    const installEnabled = getInstallEnabled();
 
     const containersWithInstallFlag = containers.map((container) => ({
         ...container,
@@ -415,6 +428,66 @@ function setupScriptHandlers(id, containerName) {
     return { onOutput, onComplete };
 }
 
+// Connected SSE clients for the live container stream. A single set of store
+// event handlers (registered once in init) fans out to every client, so the
+// number of EventEmitter listeners stays constant regardless of open tabs.
+const streamClients = new Set();
+
+/**
+ * Send a container event to every connected SSE client.
+ * @param {String} eventName added | updated | removed
+ * @param {Object} container
+ */
+function broadcastContainerEvent(eventName, container) {
+    if (streamClients.size === 0) {
+        return;
+    }
+    const payload = JSON.stringify({ ...container, install: getInstallEnabled() });
+    streamClients.forEach((client) => {
+        try {
+            client.write(`event: ${eventName}\ndata: ${payload}\n\n`);
+        } catch (e) {
+            console.warn(`Error writing to container stream: ${e.message}`);
+        }
+    });
+}
+
+/**
+ * SSE endpoint streaming live container add/update/remove events. The client
+ * keeps its list in sync without polling or full-page reloads; on (re)connect it
+ * re-fetches the full list to recover any events missed while disconnected.
+ * @param {Object} req
+ * @param {Object} res
+ */
+function streamContainers(req, res) {
+    res.writeHead(200, {
+        'Content-Type': 'text/event-stream',
+        'Cache-Control': 'no-cache',
+        'Connection': 'keep-alive',
+        'X-Accel-Buffering': 'no' // Disable nginx buffering
+    });
+    res.write(': connected\n\n');
+
+    streamClients.add(res);
+
+    // Heartbeat keeps the connection alive through idle proxy timeouts.
+    const heartbeat = setInterval(() => {
+        try {
+            res.write(': ping\n\n');
+        } catch (e) {
+            console.warn(`Error writing container stream heartbeat: ${e.message}`);
+        }
+    }, 25000);
+
+    const cleanup = () => {
+        clearInterval(heartbeat);
+        streamClients.delete(res);
+    };
+
+    req.on('close', cleanup);
+    req.on('error', cleanup);
+}
+
 /**
  * Force refresh a container's status and image information directly from Docker.
  * This is a more aggressive refresh that ensures the container shows the correct
@@ -455,8 +528,14 @@ async function refreshContainer(req, res) {
  * @returns {Router}
  */
 function init() {
+    // Bridge store events to all connected SSE clients (registered once).
+    registerContainerAdded((container) => broadcastContainerEvent('added', container));
+    registerContainerUpdated((container) => broadcastContainerEvent('updated', container));
+    registerContainerRemoved((container) => broadcastContainerEvent('removed', container));
+
     router.use(nocache());
     router.get('/', getContainers);
+    router.get('/stream', streamContainers);
     router.post('/watch', watchContainers);
     router.get('/:id', getContainer);
     router.delete('/:id', deleteContainer);

--- a/ui/src/components/ContainerItem.vue
+++ b/ui/src/components/ContainerItem.vue
@@ -196,32 +196,6 @@
       @update-complete="handleUpdateComplete"
       @dialog-closed="handleDialogClosed"
     />
-    <v-dialog
-      v-if="showUpdateProgress"
-      v-model="showUpdateProgress"
-      persistent
-      max-width="400px"
-    >
-      <v-card>
-        <v-card-text class="pa-4">
-          <div class="d-flex align-center mb-3">
-            <v-progress-circular
-              indeterminate
-              color="primary"
-              size="24"
-              class="mr-3"
-            ></v-progress-circular>
-            <span class="text-body-1"
-              >Waiting for container update to complete...</span
-            >
-          </div>
-          <div class="text-caption text-grey">
-            The script has completed successfully. Waiting for the container to
-            finish updating before refreshing the view.
-          </div>
-        </v-card-text>
-      </v-card>
-    </v-dialog>
   </v-card>
 </template>
 
@@ -257,11 +231,6 @@ export default {
       tab: 0,
       showScriptOutput: false,
       updateInProgress: false,
-      showUpdateProgress: false,
-      updateCheckInterval: null,
-      pollInterval: null,
-      pollAttempts: 0,
-      maxPollAttempts: 30
     };
   },
   computed: {
@@ -368,201 +337,45 @@ export default {
     },
   },
 
-  methods: {
-    async checkContainerUpdate() {
-      try {
-        const response = await axios.get(`/api/containers/${this.container.id}`, {
-          headers: {
-            'Cache-Control': 'no-cache',
-            'Pragma': 'no-cache'
-          }
-        });
-
-        if (response.data && !response.data.updateAvailable) {
-          // Container update detected
-          this.showUpdateProgress = false;
-          clearInterval(this.updateCheckInterval);
-
-          // Show success message
-          this.$bus.emit('notify', {
-            message: 'Container update completed successfully. Refreshing view...',
-            level: 'success',
-            timeout: 3000,
-          });
-
-          // Brief delay then refresh
-          setTimeout(() => {
-            window.location.replace(window.location.href);
-          }, 2000);
-        }
-      } catch (error) {
-        console.error('Error checking container update:', error);
-      }
+  watch: {
+    // Pin this row in the parent list while the install dialog is open so a
+    // mid-script container recreation (new id over SSE) cannot remove/remount
+    // the row and destroy the dialog. Released when the dialog closes.
+    showScriptOutput(open) {
+      this.$bus.emit(open ? "container-busy" : "container-idle", {
+        name: this.container.name,
+        watcher: this.container.watcher,
+      });
     },
+  },
 
+  methods: {
     async handleUpdateComplete() {
-        console.log('[ContainerItem] Update completed');
         this.showScriptOutput = false;
-        this.showUpdateProgress = true;
+        this.updateInProgress = false;
 
         try {
-            // Wait a bit for the container to fully restart
-            await new Promise(resolve => setTimeout(resolve, 2000));
-
-            // Clear any existing notifications
+            // Clear the install notification, then re-watch the container so the
+            // backend emits its new state. The live SSE stream delivers the
+            // refreshed row to the list, so no poll or page reload is needed.
             if (this.container.notification) {
                 await axios.post(`/api/containers/${this.container.id}/clear-notification`);
             }
-
-            // Use the refresh endpoint to update container state from Docker
-            // This now uses watchContainer with skipRegistryCheck=true (no rate limiting)
-            console.log(`Triggering direct container refresh for ${this.container.name}`);
-            const refreshResponse = await axios.post('/api/containers/refresh', null, {
+            await axios.post('/api/containers/refresh', null, {
                 params: {
                     name: this.container.name,
-                    watcher: this.container.watcher
-                }
+                    watcher: this.container.watcher,
+                },
             });
-
-            const refreshedContainer = refreshResponse.data;
-            console.log('Refresh response:', refreshedContainer);
-
-            // Check if the refresh detected the update
-            const updateDetected =
-                // Container was recreated with new ID
-                (refreshedContainer.id !== this.container.id) ||
-                // Container image changed
-                (refreshedContainer.image?.id !== this.container.image?.id) ||
-                // Update flag was reset to false
-                (this.container.updateAvailable && !refreshedContainer.updateAvailable);
-
-            if (updateDetected) {
-                console.log('Update detected from refresh response, finishing update');
-                this.finishUpdate(true);
-            } else {
-                // Refresh didn't detect the update yet - poll as fallback
-                // This handles edge cases where Docker is still processing
-                console.log('Update not detected from refresh, starting poll as fallback');
-                this.pollForContainerUpdate();
-            }
         } catch (error) {
             console.error('Error during update completion:', error);
-            // On error, try polling as fallback
-            console.log('Refresh failed, trying poll as fallback');
-            this.pollForContainerUpdate();
         }
-    },
-
-    async pollForContainerUpdate() {
-        this.pollAttempts = 0;
-        this.maxPollAttempts = 10;
-
-        // Clear any existing interval
-        if (this.pollInterval) {
-            clearInterval(this.pollInterval);
-        }
-
-        this.pollInterval = setInterval(async () => {
-            this.pollAttempts++;
-            console.log(`Polling for container update (attempt ${this.pollAttempts}/${this.maxPollAttempts})`);
-
-            try {
-                // Instead of polling the old container directly,
-                // first check if there's a container with the same name
-                const allContainersResponse = await axios.get('/api/containers', {
-                    headers: {
-                        'Cache-Control': 'no-cache, no-store, must-revalidate',
-                        'Pragma': 'no-cache',
-                        'Expires': '0'
-                    }
-                });
-
-                // Find our container by name and watcher
-                const updatedContainer = allContainersResponse.data.find(c =>
-                    c.name === this.container.name &&
-                    c.watcher === this.container.watcher
-                );
-
-                // If we found a container with the same name but different ID, it was updated
-                if (updatedContainer && updatedContainer.id !== this.container.id) {
-                    console.log('Container recreated with new ID, refreshing page');
-                    this.finishUpdate(true);
-                    return;
-                }
-
-                // If we're still looking at the same container ID, check if its image changed
-                if (updatedContainer && updatedContainer.id === this.container.id) {
-                    // Check if the image has changed
-                    if (updatedContainer.image &&
-                        this.container.image &&
-                        updatedContainer.image.id !== this.container.image.id) {
-
-                        console.log('Container image updated, refreshing page');
-                        this.finishUpdate(true);
-                        return;
-                    }
-
-                    // Check if the updateAvailable flag has been reset to false
-                    if (this.container.updateAvailable && !updatedContainer.updateAvailable) {
-                        console.log('Container update status reset, refreshing page');
-                        this.finishUpdate(true);
-                        return;
-                    }
-                }
-
-                // After max attempts, give up and just refresh the page
-                if (this.pollAttempts >= this.maxPollAttempts) {
-                    console.log('Max poll attempts reached, forcing refresh');
-                    this.finishUpdate(false);
-                }
-            } catch (error) {
-                console.error('Error polling for container update:', error);
-                // Don't give up on errors, keep trying until max attempts
-                if (this.pollAttempts >= this.maxPollAttempts) {
-                    this.finishUpdate(false);
-                }
-            }
-        }, 3000);
-    },
-
-    finishUpdate(updateDetected) {
-        // Clean up polling
-        if (this.pollInterval) {
-            clearInterval(this.pollInterval);
-            this.pollInterval = null;
-        }
-
-        // Hide progress indicator
-        this.showUpdateProgress = false;
-
-        // Show appropriate notification
-        if (updateDetected) {
-            this.$bus.emit('notify', {
-                message: 'Container update detected! Refreshing view...',
-                level: 'success',
-                timeout: 3000,
-            });
-        } else {
-            this.$bus.emit('notify', {
-                message: 'Container update completed, refreshing view...',
-                level: 'info',
-                timeout: 3000,
-            });
-        }
-
-        // Refresh the page to show updated state
-        setTimeout(() => {
-            window.location.replace(window.location.href);
-        }, 1000);
     },
 
     handleDialogClosed({ success }) {
-        console.log('[ContainerItem] Dialog closed with success:', success);
         if (!success) {
-            this.stopPolling();
             this.updateInProgress = false;
             this.showScriptOutput = false;
-            this.showUpdateProgress = false;
         }
     },
 
@@ -636,15 +449,11 @@ export default {
       }
 
       try {
-        // Trigger a watch before refreshing
+        // Trigger a watch; the resulting store updates arrive over the SSE stream.
         await axios.post('/api/containers/watch');
-        await new Promise(resolve => setTimeout(resolve, 2000));
       } catch (error) {
         console.error('Error triggering watch:', error);
       }
-
-      // Force reload bypassing cache
-      window.location.replace(window.location.href);
     }
 },
   mounted() {

--- a/ui/src/views/ContainersView.vue
+++ b/ui/src/views/ContainersView.vue
@@ -58,6 +58,8 @@ export default {
       updateKindSelected: "",
       updateAvailableSelected: false,
       sortSelected: "name",
+      eventSource: null,
+      busyKeys: new Set(),
     };
   },
 
@@ -192,6 +194,78 @@ export default {
     removeContainerFromList(container) {
       this.containers = this.containers.filter((c) => c.id !== container.id);
     },
+    // Identity that survives a container recreation (id changes, name+watcher
+    // does not). Used to pin a row while its install dialog is open.
+    containerKey(container) {
+      return `${container.watcher}::${container.name}`;
+    },
+    // Insert or replace a container pushed over the SSE stream. A recreated
+    // container arrives with a new id, so fall back to name+watcher matching.
+    upsertContainer(container) {
+      const byId = this.containers.findIndex((c) => c.id === container.id);
+      if (byId !== -1) {
+        this.containers.splice(byId, 1, container);
+        return;
+      }
+      const byName = this.containers.findIndex(
+        (c) => c.name === container.name && c.watcher === container.watcher,
+      );
+      if (byName !== -1) {
+        this.containers.splice(byName, 1, container);
+        return;
+      }
+      this.containers.push(container);
+    },
+    connectStream() {
+      this.eventSource = new EventSource("/api/containers/stream");
+      // On (re)connect, resync the full list to recover any missed events.
+      this.eventSource.onopen = async () => {
+        try {
+          this.containers = await getAllContainers();
+        } catch (e) {
+          console.error("Error resyncing containers:", e);
+        }
+      };
+      // A row with an open install dialog is pinned: skip stream-driven churn
+      // (the script recreates the container, which would otherwise remove/
+      // remount the row and destroy the dialog mid-run). State is resynced when
+      // the dialog closes (onContainerIdle).
+      const onUpsert = (event) => {
+        const container = JSON.parse(event.data);
+        if (this.busyKeys.has(this.containerKey(container))) {
+          return;
+        }
+        this.upsertContainer(container);
+      };
+      this.eventSource.addEventListener("added", onUpsert);
+      this.eventSource.addEventListener("updated", onUpsert);
+      this.eventSource.addEventListener("removed", (event) => {
+        const container = JSON.parse(event.data);
+        if (this.busyKeys.has(this.containerKey(container))) {
+          return;
+        }
+        this.removeContainerFromList(container);
+      });
+    },
+    disconnectStream() {
+      if (this.eventSource) {
+        this.eventSource.close();
+        this.eventSource = null;
+      }
+    },
+    onContainerBusy({ name, watcher }) {
+      this.busyKeys.add(`${watcher}::${name}`);
+    },
+    async onContainerIdle({ name, watcher }) {
+      this.busyKeys.delete(`${watcher}::${name}`);
+      // Pull the latest state the row missed while it was pinned (the recreated
+      // container has a new id and updated version).
+      try {
+        this.containers = await getAllContainers();
+      } catch (e) {
+        console.error("Error resyncing containers:", e);
+      }
+    },
     async deleteContainer(container) {
       try {
         await deleteContainer(container.id);
@@ -203,6 +277,18 @@ export default {
         });
       }
     },
+  },
+
+  mounted() {
+    this.connectStream();
+    this.$bus.on("container-busy", this.onContainerBusy);
+    this.$bus.on("container-idle", this.onContainerIdle);
+  },
+
+  beforeUnmount() {
+    this.disconnectStream();
+    this.$bus.off("container-busy", this.onContainerBusy);
+    this.$bus.off("container-idle", this.onContainerIdle);
   },
 
   async beforeRouteEnter(to, from, next) {


### PR DESCRIPTION
## Summary

Replaces the poll-and-reload container update flow with a server-sent events stream, so the list reflects watch results and post-install state without a full-page refresh.

## Backend
- New `GET /api/containers/stream`. A single shared set of SSE clients plus one-time registration of the store's container `added`/`updated`/`removed` events fans out to every client, keeping the EventEmitter listener count constant regardless of open tabs.
- Each pushed container carries the same `install` flag as the REST list (extracted into a shared `getInstallEnabled` helper).
- The store already emits these events, so no new event plumbing was needed.

## UI
- `ContainersView` opens the `EventSource` in `mounted`, reconciles the list (upsert by id, fall back to name+watcher for recreations; remove by id), and re-fetches the full list on (re)connect to recover events missed while disconnected.
- `ContainerItem` drops the poll / refresh / `window.location.replace` machinery. `handleUpdateComplete` now clears the notification and triggers a single re-watch, letting the stream deliver the new state.
- A row is pinned while its install dialog is open: a mid-script container recreation arrives over the stream as a remove of the old id, which would otherwise unmount the row and destroy the still-open script-output dialog. `ContainerItem` signals busy/idle on the event bus; `ContainersView` suppresses stream-driven churn for that container until the dialog closes, then resyncs.

## Testing
- UI builds clean (node:20); backend suite zero-delta vs baseline.
- Verified on the dev-test instance with a real script install (it-tools `2024.5.13-a0bc346` to `2024.10.22-7ca5933`): the script-output dialog stays open through the container recreation, the row updates live on close with no page reload, and the console stays error-free.