### PR TITLE
feat(ui): responsive mobile layout for containers + install dialog

### DIFF
--- a/ui/src/App.vue
+++ b/ui/src/App.vue
@@ -7,9 +7,9 @@
       :timeout="snackbarTimeout"
     />
 
-    <app-bar v-if="authenticated" :user="user" />
+    <app-bar v-if="authenticated" :user="user" @toggle-drawer="drawer = !drawer" />
 
-    <navigation-drawer v-if="authenticated" />
+    <navigation-drawer v-if="authenticated" v-model="drawer" />
 
     <!-- Sizes your content based upon application components -->
     <v-main>
@@ -20,7 +20,7 @@
       </v-row>
     </v-main>
 
-    <app-footer v-if="authenticated" />
+    <app-footer v-if="authenticated && $vuetify.display.mdAndUp" />
   </v-app>
 </template>
 
@@ -44,6 +44,8 @@ export default {
       snackbarShow: false,
       snackbarLevel: "info",
       user: undefined,
+      // Mobile nav drawer open state (ignored on desktop where it is permanent).
+      drawer: false,
     };
   },
   computed: {
@@ -130,5 +132,26 @@ export default {
 <style scoped>
 .main-background {
   /* background-color: #f5f5f5; */
+}
+</style>
+
+<style>
+/* On mobile, pin the app shell to the dynamic viewport and scroll inside
+   v-main instead of the document. A document (body) scroll makes the browser
+   chrome (address bar) collapse/expand at the scroll extremes, and Vuetify's
+   layout reacts to that viewport resize, which stalls the scroll. An inner
+   scroll container keeps the chrome static, so scrolling stays smooth. */
+@media (max-width: 959.98px) {
+  html,
+  body {
+    height: 100%;
+    overflow: hidden;
+  }
+  .v-main {
+    height: 100dvh;
+    overflow-y: auto;
+    overflow-x: hidden;
+    -webkit-overflow-scrolling: touch;
+  }
 }
 </style>

--- a/ui/src/components/AppBar.vue
+++ b/ui/src/components/AppBar.vue
@@ -1,5 +1,11 @@
 <template>
   <v-app-bar flat tile density="compact" theme="dark" color="#272727">
+    <v-app-bar-nav-icon
+      v-if="$vuetify.display.smAndDown"
+      @click.stop="$emit('toggle-drawer')"
+    >
+      <v-icon>mdi-menu</v-icon>
+    </v-app-bar-nav-icon>
     <v-app-bar-nav-icon>
       <v-img :src="logo" alt="logo" width="48" height="48" />
     </v-app-bar-nav-icon>
@@ -35,6 +41,7 @@ export default {
       required: true,
     },
   },
+  emits: ["toggle-drawer"],
   data() {
     return {
       logo,

--- a/ui/src/components/ContainerFilter.vue
+++ b/ui/src/components/ContainerFilter.vue
@@ -1,47 +1,66 @@
 <template>
-  <v-container
-    fluid
-    class="ma-0 mb-3"
-    :class="$vuetify.display.mdAndUp ? 'pa-0' : ''"
-  >
-    <v-row dense>
-      <v-col>
+  <v-container fluid class="ma-0 mb-3 pa-0">
+    <!-- Mobile: collapse the filters behind a toggle so the bar is a single
+         compact row by default; keep Watch now always reachable. -->
+    <div v-if="$vuetify.display.smAndDown" class="d-flex align-center mb-2">
+      <v-btn variant="tonal" size="small" @click.stop="showFilters = !showFilters">
+        <v-icon start>mdi-filter-variant</v-icon>
+        Filters
+        <v-icon end>{{
+          showFilters ? "mdi-chevron-up" : "mdi-chevron-down"
+        }}</v-icon>
+      </v-btn>
+      <v-spacer />
+      <v-btn
+        color="secondary"
+        size="small"
+        @click.stop="refreshAllContainers"
+        :loading="isRefreshing"
+      >
+        Watch now
+        <v-icon end>mdi-refresh</v-icon>
+      </v-btn>
+    </div>
+
+    <v-expand-transition>
+      <v-row dense v-show="$vuetify.display.mdAndUp || showFilters">
+      <v-col cols="6" sm="4" md="2">
         <v-select
           :hide-details="true"
           v-model="watcherSelected"
-          :items="watchers"
+          :items="withEmptyOption(watchers)"
           @update:model-value="emitWatcherChanged"
-          :clearable="true"
+          :clearable="$vuetify.display.mdAndUp"
           label="Watcher"
           variant="outlined"
           density="compact"
         ></v-select>
       </v-col>
-      <v-col>
+      <v-col cols="6" sm="4" md="2">
         <v-select
           :hide-details="true"
           v-model="registrySelected"
-          :items="registries"
+          :items="withEmptyOption(registries)"
           @update:model-value="emitRegistryChanged"
-          :clearable="true"
+          :clearable="$vuetify.display.mdAndUp"
           label="Registry"
           variant="outlined"
           density="compact"
         ></v-select>
       </v-col>
-      <v-col>
+      <v-col cols="6" sm="4" md="2">
         <v-select
           :hide-details="true"
           v-model="updateKindSelected"
-          :items="updateKinds"
+          :items="withEmptyOption(updateKinds)"
           @update:model-value="emitUpdateKindChanged"
-          :clearable="true"
+          :clearable="$vuetify.display.mdAndUp"
           label="Update kind"
           variant="outlined"
           density="compact"
         ></v-select>
       </v-col>
-      <v-col>
+      <v-col cols="6" sm="4" md="2">
         <v-select
           :hide-details="true"
           v-model="sortSelected"
@@ -52,7 +71,7 @@
           density="compact"
         ></v-select>
       </v-col>
-      <v-col>
+      <v-col cols="6" sm="4" md="2" class="d-flex align-center">
         <v-switch
           class="switch-top"
           color="secondary"
@@ -63,7 +82,13 @@
           density="compact"
         />
       </v-col>
-      <v-col class="text-right">
+      <v-col
+        v-if="$vuetify.display.mdAndUp"
+        cols="6"
+        sm="4"
+        md="2"
+        class="text-right d-flex align-center justify-end"
+      >
         <v-btn
           color="secondary"
           @click.stop="refreshAllContainers"
@@ -72,9 +97,9 @@
           Watch now
           <v-icon> mdi-refresh</v-icon>
         </v-btn>
-        <br />
       </v-col>
-    </v-row>
+      </v-row>
+    </v-expand-transition>
   </v-container>
 </template>
 
@@ -120,6 +145,7 @@ export default {
   data() {
     return {
       isRefreshing: false,
+      showFilters: false,
       registrySelected: "",
       watcherSelected: "",
       updateKindSelected: "",
@@ -133,6 +159,12 @@ export default {
   },
 
   methods: {
+    // Mobile has no clear (X) button on the selects; prepend an empty option so
+    // the user can pick the blank row to reset a filter (matches the unselected
+    // empty state). Desktop keeps the native clear button and the plain list.
+    withEmptyOption(items) {
+      return this.$vuetify.display.smAndDown ? ["", ...items] : items;
+    },
     emitRegistryChanged() {
       this.$emit("registry-changed", this.registrySelected);
     },

--- a/ui/src/components/ContainerItem.vue
+++ b/ui/src/components/ContainerItem.vue
@@ -1,6 +1,8 @@
 <template>
   <v-card>
+    <!-- Desktop: single dense toolbar row with full chip set. -->
     <v-toolbar
+      v-if="$vuetify.display.mdAndUp"
       flat
       density="compact"
       @click="collapseDetail()"
@@ -8,13 +10,13 @@
     >
       <v-toolbar-title class="text-body-3">
         <v-chip label color="info" variant="outlined" disabled
-          ><v-icon start v-if="$vuetify.display.mdAndUp">mdi-update</v-icon
+          ><v-icon start>mdi-update</v-icon
           >{{ container.watcher }}
         </v-chip>
         /
-        <span v-if="$vuetify.display.mdAndUp && !selfhstContainerIconUrl">
+        <span v-if="!selfhstContainerIconUrl">
           <v-chip label color="info" variant="outlined" disabled
-            ><v-icon start v-if="$vuetify.display.mdAndUp">{{
+            ><v-icon start>{{
               registryIcon
             }}</v-icon
             >{{ container.image.registry.name }}
@@ -22,25 +24,21 @@
           /
         </span>
         <v-chip label color="info" variant="outlined" disabled>
-          <span v-if="$vuetify.display.mdAndUp">
-            <img
-              :src="selfhstContainerIconUrl"
-              style="width: 24px; height: 24px"
-              class="v-icon v-icon--start"
-              v-if="isSelfhstContainerIcon"
-            />
-            <v-icon start v-else>
-              {{ containerIcon }}
-            </v-icon>
-          </span>
+          <img
+            :src="selfhstContainerIconUrl"
+            style="width: 24px; height: 24px"
+            class="v-icon v-icon--start"
+            v-if="isSelfhstContainerIcon"
+          />
+          <v-icon start v-else>
+            {{ containerIcon }}
+          </v-icon>
           {{ container.displayName }}
         </v-chip>
-        <span v-if="$vuetify.display.mdAndUp">
-          :
-          <v-chip label variant="outlined" color="info" disabled>
-            {{ container.image.tag.value }}
-          </v-chip>
-        </span>
+        :
+        <v-chip label variant="outlined" color="info" disabled>
+          {{ container.image.tag.value }}
+        </v-chip>
       </v-toolbar-title>
       <v-spacer />
       <v-chip
@@ -53,7 +51,7 @@
       >
         Update
       </v-chip>
-      <v-tooltip location="bottom" v-if="$vuetify.display.mdAndUp">
+      <v-tooltip location="bottom">
         <template v-slot:activator="{ props }">
           <v-chip
             v-if="container.updateAvailable"
@@ -74,6 +72,58 @@
       </v-tooltip>
       <v-icon>{{ showDetail ? "mdi-chevron-up" : "mdi-chevron-down" }}</v-icon>
     </v-toolbar>
+
+    <!-- Mobile: a purpose-built two-line row. Line 1 (name) toggles the detail;
+         line 2 surfaces the target version and a finger-sized Update button kept
+         clear of the expand chevron so it can't be mis-tapped. -->
+    <div v-else class="mobile-header">
+      <div
+        class="d-flex align-center px-3 py-2"
+        @click="collapseDetail()"
+        style="cursor: pointer"
+      >
+        <img
+          :src="selfhstContainerIconUrl"
+          style="width: 20px; height: 20px"
+          class="mr-2 flex-shrink-0"
+          v-if="isSelfhstContainerIcon"
+        />
+        <v-icon v-else size="small" color="info" class="mr-2 flex-shrink-0">
+          {{ containerIcon }}
+        </v-icon>
+        <span class="text-info text-truncate flex-grow-1">
+          {{ container.displayName }}
+        </span>
+        <v-icon class="ml-2 flex-shrink-0">{{
+          showDetail ? "mdi-chevron-up" : "mdi-chevron-down"
+        }}</v-icon>
+      </div>
+      <div
+        v-if="container.updateAvailable"
+        class="d-flex align-center px-3 pb-2"
+      >
+        <span class="text-caption text-truncate">
+          <span class="text-medium-emphasis">{{
+            container.image.tag.value
+          }}</span>
+          <v-icon size="x-small" :color="newVersionClass" class="mx-1"
+            >mdi-arrow-right</v-icon
+          >
+          <span :class="'text-' + newVersionClass">{{ newVersion }}</span>
+        </span>
+        <v-spacer />
+        <v-btn
+          v-if="(container.install === true || container.install === 'multiple')"
+          color="success"
+          variant="tonal"
+          size="small"
+          class="ml-2 flex-shrink-0"
+          @click.stop="installContainer"
+        >
+          Update
+        </v-btn>
+      </div>
+    </div>
     <v-expand-transition>
       <div v-show="showDetail">
         <v-tabs fixed-tabs v-model="tab" ref="tabs">
@@ -264,7 +314,6 @@ export default {
     },
 
     isSelfhstContainerIcon() {
-      console.log(this.container.displayIcon);
       return (
         this.container.displayIcon.startsWith("sh-") ||
         this.container.displayIcon.startsWith("sh:")
@@ -461,9 +510,6 @@ export default {
   },
     beforeUnmount() {
         this.$bus.off('refresh-containers', this.refreshContainer);
-        if (this.checkInterval) {
-            clearInterval(this.checkInterval);
-        }
     }
 };
 </script>

--- a/ui/src/components/NavigationDrawer.vue
+++ b/ui/src/components/NavigationDrawer.vue
@@ -1,11 +1,17 @@
 <template>
-  <v-navigation-drawer v-model:rail="mini" permanent theme="dark" color="#363636">
+  <v-navigation-drawer
+    v-model="drawerOpen"
+    :permanent="$vuetify.display.mdAndUp"
+    :temporary="$vuetify.display.smAndDown"
+    :rail="isRail"
+    theme="dark"
+    color="#363636"
+  >
     <v-toolbar flat class="ma-0 pa-0">
-      <v-app-bar-nav-icon @click.stop="mini = !mini">
-        <v-icon v-if="!mini">mdi-close</v-icon>
-        <v-icon v-else>mdi-menu</v-icon>
+      <v-app-bar-nav-icon @click.stop="onNavIconClick">
+        <v-icon>{{ navIcon }}</v-icon>
       </v-app-bar-nav-icon>
-      <v-toolbar-title v-if="!mini" class="text-body-1">WUD</v-toolbar-title>
+      <v-toolbar-title v-if="!isRail" class="text-body-1">WUD</v-toolbar-title>
     </v-toolbar>
     <v-list nav class="pt-0 pb-0">
       <v-list-item to="/" key="home" class="mb-0" prepend-icon="mdi-home">
@@ -22,7 +28,7 @@
 
       <v-divider key="divider" class="mb-0" />
 
-      <v-list-group v-if="!mini" value="configuration">
+      <v-list-group v-if="!isRail" value="configuration">
         <template v-slot:activator="{ props }">
           <v-list-item
             v-bind="props"
@@ -56,7 +62,7 @@
       </v-list-item>
     </v-list>
 
-    <template v-slot:append v-if="!mini">
+    <template v-slot:append v-if="!isRail">
       <v-list>
         <v-list-item class="ml-2 mb-2">
           <v-switch
@@ -87,6 +93,13 @@ import { getAuthenticationIcon } from "@/services/authentication";
 import logo from "@/assets/wud_logo_white.png";
 
 export default {
+  props: {
+    modelValue: {
+      type: Boolean,
+      default: false,
+    },
+  },
+  emits: ["update:modelValue"],
   data: () => ({
     logo,
     mini: true,
@@ -127,9 +140,48 @@ export default {
         item1.name.localeCompare(item2.name),
       );
     },
+    // Open/close state, proxied to the parent v-model (only drives visibility on
+    // mobile where the drawer is temporary; ignored while permanent on desktop).
+    drawerOpen: {
+      get() {
+        // On desktop the drawer is permanent and always visible; only the mobile
+        // overlay follows the parent model.
+        return this.$vuetify.display.mdAndUp ? true : this.modelValue;
+      },
+      set(value) {
+        this.$emit("update:modelValue", value);
+      },
+    },
+    // Rail (icon-only) collapse applies on desktop only; on mobile the drawer is
+    // a full overlay, never a rail.
+    isRail() {
+      return this.$vuetify.display.mdAndUp && this.mini;
+    },
+    navIcon() {
+      if (this.$vuetify.display.smAndDown) {
+        return "mdi-close";
+      }
+      return this.mini ? "mdi-menu" : "mdi-close";
+    },
+  },
+
+  watch: {
+    // Close the overlay after navigating on mobile.
+    $route() {
+      if (this.$vuetify.display.smAndDown) {
+        this.drawerOpen = false;
+      }
+    },
   },
 
   methods: {
+    onNavIconClick() {
+      if (this.$vuetify.display.smAndDown) {
+        this.drawerOpen = false;
+      } else {
+        this.mini = !this.mini;
+      }
+    },
     toggleDarkMode: function () {
       localStorage.darkMode = this.darkMode;
       this.setDarkMode(this.darkMode);

--- a/ui/src/components/ScriptOutputDialog.vue
+++ b/ui/src/components/ScriptOutputDialog.vue
@@ -1,7 +1,9 @@
 <template>
   <v-dialog
     v-model="dialogVisible"
-    max-width="800px"
+    width="70%"
+    max-width="1000px"
+    :fullscreen="$vuetify.display.smAndDown"
     @click:outside="close"
     persistent
   >
@@ -20,15 +22,22 @@
         </div>
 
         <v-card-text class="pa-2">
-          <pre ref="logContainer" class="log-output"><span v-for="(log, index) in logs" :key="index" :class="getLogClass(log)">{{log.message}}</span><template v-if="error">
-<span class="error-text">Error: {{ error }}</span></template><template v-if="isComplete && scriptExitCode === 0">
-<span class="success-text">Script executed successfully</span></template></pre>
+          <div ref="logContainer" class="log-output log-wrap" :style="logStyle">
+            <template v-for="(line, index) in displayLines" :key="index">
+              <hr v-if="line.kind === 'rule'" class="log-rule" />
+              <div v-else-if="line.kind === 'title'" class="log-title">{{ line.text }}</div>
+              <div v-else class="log-line" :class="line.cls">{{ line.text }}</div>
+            </template>
+            <div v-if="error" class="log-line error-text">Error: {{ error }}</div>
+            <div v-if="isComplete && scriptExitCode === 0" class="log-line success-text">Script executed successfully</div>
+          </div>
         </v-card-text>
 
         <v-card-actions v-if="isComplete || error || scriptExitCode !== null" class="pa-4" style="background-color: #2D2D2D;">
           <v-spacer></v-spacer>
           <v-btn
-            :color="scriptExitCode === 0 ? 'primary' : 'error'"
+            variant="flat"
+            :color="scriptExitCode === 0 ? 'secondary' : 'error'"
             @click="handleClose"
           >
             {{ scriptExitCode === 0 ? 'Close Script Output' : 'Close' }}
@@ -70,6 +79,53 @@ export default {
   },
 
   computed: {
+    // Fill the screen when the dialog is fullscreen (mobile); on desktop scale
+    // the log with the viewport instead of a fixed height. The reserved space
+    // covers the top close bar plus the bottom actions bar when the script
+    // finishes.
+    logStyle() {
+      if (this.$vuetify.display.smAndDown) {
+        return {
+          height: 'calc(100dvh - 130px)',
+          fontSize: '10px',
+          lineHeight: '1.3',
+          padding: '8px',
+        };
+      }
+      return { height: '75dvh' };
+    },
+
+    // Flatten the log messages into per-line items so the fixed-width ASCII
+    // banner (solid #/- rows + centered title) renders as a CSS hairline +
+    // heading instead of raw characters. Used for all viewport sizes.
+    displayLines() {
+      const out = [];
+      this.logs.forEach((log) => {
+        (log.message || '').split('\n').forEach((line) => {
+          const stripped = line.trim();
+          if (stripped === '') return;
+          // Solid border rows -> hairline rule.
+          if (/^#{3,}$/.test(stripped) || /^-{3,}$/.test(stripped)) {
+            out.push({ kind: 'rule' });
+            return;
+          }
+          // Centered banner title -> bold heading.
+          if (stripped.includes('SCRIPT EXECUTION START')
+            || stripped.includes('SCRIPT EXECUTION END')) {
+            out.push({ kind: 'title', text: stripped.replace(/#/g, '').trim() });
+            return;
+          }
+          // Classify on the raw line (patterns rely on the leading #), then
+          // strip a single leading "# " decoration for display.
+          const cls = this.getLogClass({ message: line });
+          const text = line.replace(/^#\s?/, '');
+          if (text.trim() === '') return;
+          out.push({ kind: 'text', text, cls });
+        });
+      });
+      return out;
+    },
+
     dialogVisible: {
       get() {
         return this.modelValue;
@@ -323,8 +379,24 @@ export default {
   line-height: 1.2;
 }
 
-.log-output span {
-  white-space: pre;
+/* Wrap long lines instead of forcing horizontal scroll. */
+.log-wrap {
+  white-space: pre-wrap;
+  overflow-wrap: anywhere;
+}
+
+/* Render the ASCII banner as a CSS hairline + heading. */
+.log-rule {
+  border: none;
+  border-top: 1px solid #555555;
+  margin: 6px 8px;
+}
+
+.log-title {
+  text-align: center;
+  font-weight: bold;
+  color: #F5F5F5;
+  padding: 2px 0;
 }
 
 /* Clean slate - remove Vuetify's color overrides */

--- a/ui/src/views/ContainersView.vue
+++ b/ui/src/views/ContainersView.vue
@@ -21,17 +21,19 @@
       </v-col>
     </v-row>
 
-    <v-fade-transition group hide-on-leave mode="in-out">
-      <v-row v-for="container in containersSorted" :key="container.id">
-        <v-col class="pt-2 pb-2">
-          <container-item
-            :container="container"
-            @delete-container="deleteContainer(container)"
-            @container-deleted="removeContainerFromList(container)"
-          />
-        </v-col>
-      </v-row>
-    </v-fade-transition>
+    <v-row
+      v-for="container in containersSorted"
+      :key="container.id"
+      no-gutters
+    >
+      <v-col :class="$vuetify.display.smAndDown ? 'py-1' : 'pt-2 pb-2'">
+        <container-item
+          :container="container"
+          @delete-container="deleteContainer(container)"
+          @container-deleted="removeContainerFromList(container)"
+        />
+      </v-col>
+    </v-row>
     <v-row v-if="containersSorted.length === 0">
       <v-card-subtitle class="text-h6">No containers found</v-card-subtitle>
     </v-row>
@@ -201,30 +203,51 @@ export default {
     },
     // Insert or replace a container pushed over the SSE stream. A recreated
     // container arrives with a new id, so fall back to name+watcher matching.
+    // A watch cycle emits an `updated` event for every container it re-saves,
+    // even when nothing changed; replacing the row with an equal-but-new object
+    // would re-render that (heavy) row for nothing, so a burst of such events
+    // blocks the main thread. Skip the splice when the payload is unchanged.
     upsertContainer(container) {
       const byId = this.containers.findIndex((c) => c.id === container.id);
       if (byId !== -1) {
-        this.containers.splice(byId, 1, container);
+        if (JSON.stringify(this.containers[byId]) !== JSON.stringify(container)) {
+          this.containers.splice(byId, 1, container);
+        }
         return;
       }
       const byName = this.containers.findIndex(
         (c) => c.name === container.name && c.watcher === container.watcher,
       );
       if (byName !== -1) {
-        this.containers.splice(byName, 1, container);
+        if (JSON.stringify(this.containers[byName]) !== JSON.stringify(container)) {
+          this.containers.splice(byName, 1, container);
+        }
         return;
       }
       this.containers.push(container);
     },
+    // Resync the full list from the API while keeping the existing object
+    // reference for any container whose data is unchanged. Replacing the whole
+    // array with fresh objects forces every (heavy) row to re-render, which
+    // blocks the main thread for seconds with a large list; reusing references
+    // means only genuinely-changed rows re-render.
+    async resyncContainers() {
+      try {
+        const fresh = await getAllContainers();
+        const prevById = new Map(this.containers.map((c) => [c.id, c]));
+        this.containers = fresh.map((f) => {
+          const prev = prevById.get(f.id);
+          return prev && JSON.stringify(prev) === JSON.stringify(f) ? prev : f;
+        });
+      } catch (e) {
+        console.error("Error resyncing containers:", e);
+      }
+    },
     connectStream() {
       this.eventSource = new EventSource("/api/containers/stream");
       // On (re)connect, resync the full list to recover any missed events.
-      this.eventSource.onopen = async () => {
-        try {
-          this.containers = await getAllContainers();
-        } catch (e) {
-          console.error("Error resyncing containers:", e);
-        }
+      this.eventSource.onopen = () => {
+        this.resyncContainers();
       };
       // A row with an open install dialog is pinned: skip stream-driven churn
       // (the script recreates the container, which would otherwise remove/
@@ -260,11 +283,7 @@ export default {
       this.busyKeys.delete(`${watcher}::${name}`);
       // Pull the latest state the row missed while it was pinned (the recreated
       // container has a new id and updated version).
-      try {
-        this.containers = await getAllContainers();
-      } catch (e) {
-        console.error("Error resyncing containers:", e);
-      }
+      await this.resyncContainers();
     },
     async deleteContainer(container) {
       try {


### PR DESCRIPTION
Mobile sub-PR of the UI-polish track (follows #9 sort, #10 prerelease color, #11 live SSE state). Branch the markup by breakpoint (\`\$vuetify.display\`) so desktop stays byte-identical while phones get a usable layout.

## Mobile layout
- **ContainerItem**: desktop keeps the dense \`v-toolbar\` chip row (\`v-if mdAndUp\`); mobile gets a two-line header — line 1 icon + name + chevron (toggles detail), line 2 (when an update exists) \`current -> new\` colored by semver rung + a touch-sized Update button kept off the chevron.
- **ContainerFilter**: collapses behind a Filters toggle on mobile; cols \`6 / sm4 / md2\` (single row on desktop); no clear-X on mobile, a blank option resets the filter instead.
- **NavigationDrawer / App / AppBar**: nav is a temporary overlay on mobile toggled by an AppBar hamburger, permanent rail on desktop. \`html/body\` pinned and \`v-main\` made the scroller to stop the mobile address-bar scroll-seize. Footer hidden on mobile.

## Install dialog (ScriptOutputDialog)
- Fullscreen on mobile; long log lines wrap instead of forcing horizontal scroll.
- The fixed-width \`#\`/\`-\` ASCII banner wrapped badly, so the log now renders per-line (a \`displayLines\` computed): solid rows become a CSS hairline, the centered \`SCRIPT EXECUTION START/END\` becomes a heading, other lines drop the leading \`#\`. Applied on all viewports.
- Desktop dialog scales with the viewport (\`70%\` / max \`1000px\`, log height \`75dvh\`) instead of fixed 800/400px.
- Close button is a flat \`secondary\` (cyan) so it is visible on the dark action bar (was \`primary\` navy = invisible).

## Fix: install-completion jank
Installing recreates the container; the resulting watch emits an \`updated\` SSE event for **every** container (~165 for ~60, almost all unchanged). \`upsertContainer\` replaced each row with a new object → the whole list re-rendered → a single **~18s** main-thread block landing exactly when the dialog's close button appeared, so the click was starved.

- \`upsertContainer\` now skips the splice when the incoming payload equals the existing row (no-op events cause zero re-renders).
- New \`resyncContainers\` helper (used by the stream \`onopen\` resync and \`onContainerIdle\`) preserves existing object references for unchanged rows, so a full resync only re-renders changed rows.

Verified on devtest via a real it-tools install (Playwright + a \`PerformanceObserver\` longtask): completion block **18.3s → 0**, close button instant, list still reconciles live. The backend over-emitting \`updated\` for unchanged containers is the root cause and is tracked as a separate deferred perf item; this client guard makes it harmless meanwhile.

## Testing
Desktop verified pixel-identical at 1280x800; mobile verified at 390x844 (overlay open/close-on-nav, two-line rows, expand, filters, wrapped log, banner). UI builds clean in \`node:20-alpine\`; 0 console errors.