### PR TITLE
fix(store): only emit container updated on real state change

### DIFF
--- a/app/store/container.js
+++ b/app/store/container.js
@@ -1,6 +1,7 @@
 /**
  * Container store.
  */
+const { isDeepStrictEqual } = require('util');
 const { byString, byValues } = require('sort-es');
 const log = require('../log').child({ component: 'store' });
 const { validate: validateContainer } = require('../model/container');
@@ -79,21 +80,35 @@ function updateContainer(container) {
         })
         .data();
 
+    let removedStaleDuplicate = false;
     for (const existing of existingContainers) {
         if (existing.data.id !== container.id) {
             console.log(`Removing old container record ${existing.data.id} for ${container.name}`);
             containers.remove(existing);
+            removedStaleDuplicate = true;
         }
     }
 
     // Now update/insert the new container
     const existingContainer = containers.findOne({ 'data.id': container.id });
+
+    // The watch loop re-saves every container each cycle even when nothing
+    // changed. Only emit an "updated" event when the persisted state actually
+    // differs from the stored row, otherwise SSE clients are flooded with no-op
+    // updates. The validated container is the persisted state (its computed
+    // getters compare by value), so a deep compare detects real changes.
+    const changed = removedStaleDuplicate
+        || !existingContainer
+        || !isDeepStrictEqual(existingContainer.data, containerToReturn);
+
     if (existingContainer) {
         containers.chain().find({ 'data.id': container.id }).remove();
     }
 
     containers.insert({ data: containerToReturn });
-    emitContainerUpdated(containerToReturn);
+    if (changed) {
+        emitContainerUpdated(containerToReturn);
+    }
     return containerToReturn;
 }
 

--- a/app/store/container.test.js
+++ b/app/store/container.test.js
@@ -1,5 +1,6 @@
 const container = require('./container');
 const event = require('../event');
+const { validate: validateContainer } = require('../model/container');
 
 jest.mock('./migrate');
 jest.mock('../event');
@@ -78,11 +79,41 @@ test('insertContainer should insert doc and emit an event', () => {
     expect(spyEvent).toHaveBeenCalled();
 });
 
-test('updateContainer should update doc and emit an event', () => {
+const updateContainerExample = {
+    id: 'container-123456789',
+    name: 'test',
+    watcher: 'test',
+    image: {
+        id: 'image-123456789',
+        registry: {
+            name: 'registry',
+            url: 'https://hub',
+        },
+        name: 'organization/image',
+        tag: {
+            value: 'version',
+            semver: false,
+        },
+        digest: {
+            watch: false,
+            repo: undefined,
+        },
+        architecture: 'arch',
+        os: 'os',
+        created: '2021-06-12T05:33:38.440Z',
+    },
+    result: {
+        tag: 'version',
+    },
+};
+
+test('updateContainer should update doc and emit an event when the row is new', () => {
     const collection = {
         insert: () => {},
+        findOne: () => null,
         chain: () => ({
             find: () => ({
+                data: () => [],
                 remove: () => ({}),
             }),
         }),
@@ -91,39 +122,59 @@ test('updateContainer should update doc and emit an event', () => {
         getCollection: () => collection,
         addCollection: () => null,
     };
-    const containerToSave = {
-        id: 'container-123456789',
-        name: 'test',
-        watcher: 'test',
-        image: {
-            id: 'image-123456789',
-            registry: {
-                name: 'registry',
-                url: 'https://hub',
-            },
-            name: 'organization/image',
-            tag: {
-                value: 'version',
-                semver: false,
-            },
-            digest: {
-                watch: false,
-                repo: undefined,
-            },
-            architecture: 'arch',
-            os: 'os',
-            created: '2021-06-12T05:33:38.440Z',
-        },
-        result: {
-            tag: 'version',
-        },
-    };
     const spyInsert = jest.spyOn(collection, 'insert');
     const spyEvent = jest.spyOn(event, 'emitContainerUpdated');
     container.createCollections(db);
-    container.updateContainer(containerToSave);
+    container.updateContainer({ ...updateContainerExample });
     expect(spyInsert).toHaveBeenCalled();
     expect(spyEvent).toHaveBeenCalled();
+});
+
+test('updateContainer should update doc and emit an event when the state changed', () => {
+    const stored = validateContainer({ ...updateContainerExample });
+    const collection = {
+        insert: () => {},
+        findOne: () => ({ data: stored }),
+        chain: () => ({
+            find: () => ({
+                data: () => [],
+                remove: () => ({}),
+            }),
+        }),
+    };
+    const db = {
+        getCollection: () => collection,
+        addCollection: () => null,
+    };
+    const spyEvent = jest.spyOn(event, 'emitContainerUpdated');
+    container.createCollections(db);
+    container.updateContainer({
+        ...updateContainerExample,
+        result: { tag: 'new-version' },
+    });
+    expect(spyEvent).toHaveBeenCalled();
+});
+
+test('updateContainer should not emit an event when nothing changed', () => {
+    const stored = validateContainer({ ...updateContainerExample });
+    const collection = {
+        insert: () => {},
+        findOne: () => ({ data: stored }),
+        chain: () => ({
+            find: () => ({
+                data: () => [],
+                remove: () => ({}),
+            }),
+        }),
+    };
+    const db = {
+        getCollection: () => collection,
+        addCollection: () => null,
+    };
+    const spyEvent = jest.spyOn(event, 'emitContainerUpdated');
+    container.createCollections(db);
+    container.updateContainer({ ...updateContainerExample });
+    expect(spyEvent).not.toHaveBeenCalled();
 });
 
 test('getContainers should return all containers sorted by name', () => {


### PR DESCRIPTION
## What

The store emitted a `container-updated` event on every `updateContainer`
call. The watch loop re-saves every container each cycle (and a single
container recreation triggers a full watch), so one cycle fanned out
~120 no-op `updated` SSE events for a 120-container stack, even though
nothing about most rows had changed.

This gates the emit on a deep compare (`util.isDeepStrictEqual`) of the
freshly validated container against the stored row. The validated
container is exactly the persisted state and its computed getters
(`updateAvailable`/`updateKind`/`link`) compare by value, so only a
genuine change emits. A removed stale duplicate (same name/watcher, new
id = a recreation) also counts as a change.

The store write itself is unchanged; only the event emission is gated.
This is the backend counterpart to the client-side render guard already
shipped; clients now simply receive fewer, accurate events.

## Verification

- Unit: `store/container.test.js` covers new-row emit, changed-state
  emit, and the no-op (no emit) case. The suite was red at baseline (the
  old `updateContainer` test threw on an incomplete mock) and is now
  green; no other suite changes (delta is store red to green only).
- Live on a 120-container devtest stack:
  - no-change watch: `updated` events ~120+ -> **2** (the two rows that
    genuinely differed), `added`/`removed` 0
  - immediate second watch: **0** events (confirms no per-cycle-varying
    field re-emits; the two changed rows saved once and went quiet)