### PR TITLE
test: realign model, http and basic auth suites with current behavior

### DIFF
--- a/app/authentications/providers/basic/Basic.test.js
+++ b/app/authentications/providers/basic/Basic.test.js
@@ -1,4 +1,13 @@
 const { ValidationError } = require('joi');
+
+// The pass lib shells out to the openssl binary to verify htpasswd hashes,
+// which is not present in the test container. Mock it so the provider's
+// accept/reject wiring can be tested without the binary; the real hash
+// verification is the pass lib's own (upstream-tested) responsibility.
+jest.mock('pass', () => ({
+    validate: (pass, hash, cb) => cb(null, pass === 'doe'),
+}));
+
 const Basic = require('./Basic');
 
 const configurationValid = {

--- a/app/model/container.test.js
+++ b/app/model/container.test.js
@@ -37,6 +37,7 @@ test('model should be validated when compliant', () => {
     expect(containerValidated).toStrictEqual({
         id: 'container-123456789',
         status: 'unknown',
+        compose_project: null,
         image: {
             architecture: 'arch',
             created: '2021-06-12T05:33:38.440Z',
@@ -289,8 +290,10 @@ test('flatten should be flatten the nested properties with underscores when call
     expect(container.flatten(containerValidated)).toEqual({
         id: 'container-123456789',
         status: 'unknown',
+        compose_project: null,
         image_architecture: 'arch',
         image_created: '2021-06-12T05:33:38.440Z',
+        image_digest_repo: undefined,
         image_digest_watch: false,
         image_id: 'image-123456789',
         image_name: 'organization/image',

--- a/app/triggers/providers/http/Http.test.js
+++ b/app/triggers/providers/http/Http.test.js
@@ -18,6 +18,7 @@ const configurationValid = {
     simplebody: 'Container ${name} running with ${kind} ${local} can be updated to ${kind} ${remote}\n${link}',
     // eslint-disable-next-line no-template-curly-in-string
     batchtitle: '${count} updates available',
+    install: false,
 };
 
 beforeEach(() => {
@@ -57,10 +58,10 @@ test('trigger should send GET http request when configured like that', async () 
     expect(rp).toHaveBeenCalledWith({
         qs: {
             name: 'container1',
+            actionType: 'trigger',
         },
         method: 'GET',
         uri: 'https:///test',
-        auth: undefined,
     });
 });
 
@@ -77,6 +78,7 @@ test('trigger should send POST http request when configured like that', async ()
     expect(rp).toHaveBeenCalledWith({
         body: {
             name: 'container1',
+            actionType: 'trigger',
         },
         json: true,
         method: 'POST',
@@ -97,6 +99,7 @@ test('trigger should use basic auth when configured like that', async () => {
     expect(rp).toHaveBeenCalledWith({
         body: {
             name: 'container1',
+            actionType: 'trigger',
         },
         method: 'POST',
         json: true,
@@ -118,6 +121,7 @@ test('trigger should use bearer auth when configured like that', async () => {
     expect(rp).toHaveBeenCalledWith({
         body: {
             name: 'container1',
+            actionType: 'trigger',
         },
         method: 'POST',
         json: true,
@@ -139,6 +143,7 @@ test('trigger should use proxy when configured like that', async () => {
     expect(rp).toHaveBeenCalledWith({
         body: {
             name: 'container1',
+            actionType: 'trigger',
         },
         method: 'POST',
         json: true,


### PR DESCRIPTION
## What

Three unit suites had drifted from the code they cover and were failing
on a clean checkout. This realigns them; no production code changes.

- **model/container**: `validate`/`flatten` output now includes
  `compose_project` (joi default `null`) and the flattened
  `image_digest_repo` key. Added both to the expected objects.
- **http trigger**: requests now carry an `actionType` in the body/query,
  and the config schema defaults `install: false`. Updated the
  `trigger`/`validateConfiguration` expectations to match.
- **basic auth**: the `pass` lib shells out to the `openssl` binary to
  verify htpasswd hashes; the test container has no `openssl`, so the two
  password tests hung until timeout. Mocked `pass` so the provider's
  accept/reject wiring is tested without the binary (real hash
  verification is the upstream lib's responsibility; `BasicStrategy` is
  separately covered).

## Result

Backend suite goes from 6 failing suites to 2. The remaining two
(`Docker` watcher and `Script` trigger) are larger, fork-specific test
rewrites and will be handled in their own follow-up PRs.

## Verification

Ran the full backend suite in a clean `node:18-alpine` container:
`6 failed -> 2 failed`, the three touched suites all green (34 tests), no
other suite changed.