### PR TITLE
test: realign script trigger suite with current behavior

### DIFF
--- a/app/triggers/providers/script/Script.test.js
+++ b/app/triggers/providers/script/Script.test.js
@@ -1,11 +1,10 @@
-const { ValidationError } = require('joi');
 const { exec } = require('child_process');
 const event = require('../../../event');
-const storeContainer = require('../../../store/container'); // Add this mock
+const storeContainer = require('../../../store/container');
 
 jest.mock('child_process');
 jest.mock('../../../event');
-jest.mock('../../../store/container'); // Add store container mock
+jest.mock('../../../store/container');
 
 const Script = require('./Script');
 
@@ -14,68 +13,98 @@ const script = new Script();
 const configurationValid = {
     path: '/path/to/script.sh',
     install: true,
-    timeout: 300000
+    timeout: 300000,
 };
 
 beforeEach(() => {
     jest.resetAllMocks();
-    // Mock the exec callback
+
+    // The trigger logs through this.log (set by the component base at init,
+    // which the tests don't run) and through console; stub both so assertions
+    // can target them and the suite stays quiet.
+    script.log = {
+        debug: jest.fn(),
+        info: jest.fn(),
+        warn: jest.fn(),
+        error: jest.fn(),
+        child: jest.fn(),
+    };
+    jest.spyOn(console, 'log').mockImplementation(() => {});
+    jest.spyOn(console, 'warn').mockImplementation(() => {});
+    jest.spyOn(console, 'error').mockImplementation(() => {});
+
+    // Default exec mock: invoke the callback with success and return a process
+    // whose stream/close handlers can be driven by the test.
     exec.mockImplementation((command, options, callback) => {
         callback(null, 'success', '');
         return {
             stdout: { on: jest.fn() },
             stderr: { on: jest.fn() },
-            on: jest.fn((event, handler) => handler(0))
+            on: jest.fn((evt, handler) => handler(0)),
         };
     });
 
-    // Mock store container methods
     storeContainer.getContainer.mockImplementation((id) => ({
         id,
         name: 'test-container',
         image: { id: 'old-image-id' },
-        status: 'running'
+        status: 'running',
     }));
     storeContainer.getContainers.mockImplementation(() => []);
-    storeContainer.updateContainer.mockImplementation(container => container);
+    storeContainer.updateContainer.mockImplementation((container) => container);
     storeContainer.deleteContainer.mockImplementation(() => true);
 });
 
 describe('Script Trigger Tests', () => {
-    // ... existing tests remain the same ...
-
     test('triggerBatch should reject batch operations', async () => {
         script.configuration = configurationValid;
         const containers = [
             { name: 'container1' },
-            { name: 'container2' }
+            { name: 'container2' },
         ];
 
         await script.triggerBatch(containers);
-        
+
         // Verify warning was logged
         expect(script.log.warn).toHaveBeenCalledWith(
-            'Batch operations are not supported by the Script trigger - use individual container triggers instead'
+            'Batch operations are not supported by the Script trigger - use individual container triggers instead',
         );
         // Verify script was not executed
         expect(exec).not.toHaveBeenCalled();
     });
 
-    test('cleanupExistingContainers should handle container deletion verification', async () => {
+    test('cleanupExistingContainers should delete old containers and verify removal', async () => {
         script.configuration = configurationValid;
         const container = {
             name: 'test-container',
-            watcher: 'docker'
+            watcher: 'docker',
         };
 
-        // Mock store to simulate a container that needs cleanup
-        storeContainer.getContainers.mockImplementationOnce(() => ([
-            { id: 'container1', name: 'test-container', status: 'running' }
-        ]));
+        // One container is always preserved (the best running/up-to-date one),
+        // so deletion only happens when a second, stale row exists. Back the
+        // store with a small stateful set so deleteContainer actually removes
+        // the row and the cleanup loop converges instead of retrying.
+        let storeRows = [
+            {
+                id: 'container1', name: 'test-container', watcher: 'docker', status: 'exited',
+            },
+            {
+                id: 'keep', name: 'test-container', watcher: 'docker', status: 'running', updateAvailable: false,
+            },
+        ];
+        storeContainer.getContainers.mockImplementation(() => storeRows.slice());
+        storeContainer.deleteContainer.mockImplementation((id) => {
+            storeRows = storeRows.filter((r) => r.id !== id);
+            return true;
+        });
+        storeContainer.getContainer.mockImplementation(
+            (id) => storeRows.find((r) => r.id === id),
+        );
 
         await script.cleanupExistingContainers(container);
 
         expect(storeContainer.deleteContainer).toHaveBeenCalledWith('container1');
+        // Removal is verified by a follow-up store read.
         expect(storeContainer.getContainer).toHaveBeenCalledWith('container1');
     });
 
@@ -84,24 +113,36 @@ describe('Script Trigger Tests', () => {
         const container = {
             name: 'test-container',
             watcher: 'docker',
-            image: { id: 'old-image-id' }
+            image: { id: 'old-image-id' },
         };
 
-        // Mock store to simulate container update sequence
-        storeContainer.getContainers
-            .mockImplementationOnce(() => []) // First check - no containers
-            .mockImplementationOnce(() => [{ // Second check - new container found
-                id: 'new-container',
-                name: 'test-container',
-                status: 'running',
-                image: { id: 'new-image-id' },
-                watcher: 'docker'
-            }]);
+        // The method polls the watcher's Docker API (not the store) for a new
+        // running container, then waits for a watch cycle before reading the
+        // store. Stub the Docker API, the watcher-stop event and the store read.
+        const fakeDockerApi = {
+            listContainers: jest.fn().mockResolvedValue([{ Id: 'new-container' }]),
+            getContainer: jest.fn(() => ({
+                inspect: jest.fn().mockResolvedValue({
+                    State: { Status: 'running' },
+                    Image: 'new-image-id',
+                }),
+            })),
+        };
+        script.getDockerApiForWatcher = jest.fn(() => fakeDockerApi);
+        event.registerWatcherStop.mockImplementation((cb) => cb({ name: 'watcher.docker.docker' }));
+        storeContainer.getContainer.mockImplementation((id) => ({
+            id,
+            name: 'test-container',
+            status: 'running',
+            image: { id: 'new-image-id' },
+            watcher: 'docker',
+        }));
 
         const result = await script.waitForContainerImageUpdate(container, 'old-image-id');
-        
+
         expect(result).toBeDefined();
         expect(result.image.id).toBe('new-image-id');
+        expect(event.emitTriggerWatch).toHaveBeenCalled();
     });
 
     test('executeScript should properly handle and log script output', async () => {
@@ -112,27 +153,29 @@ describe('Script Trigger Tests', () => {
             watcher: 'docker',
             updateKind: {
                 localValue: '1.0.0',
-                remoteValue: '1.0.1'
-            }
+                remoteValue: '1.0.1',
+            },
         };
 
         // Mock exec with streaming output
         exec.mockImplementation((command, options, callback) => {
             const mockProcess = {
-                stdout: { on: jest.fn((event, handler) => {
-                    handler('Script is running\n');
-                    handler('Progress: 50%\n');
-                    handler('Complete\n');
-                })},
+                stdout: {
+                    on: jest.fn((evt, handler) => {
+                        handler('Script is running\n');
+                        handler('Progress: 50%\n');
+                        handler('Complete\n');
+                    }),
+                },
                 stderr: { on: jest.fn() },
-                on: jest.fn((event, handler) => handler(0))
+                on: jest.fn((evt, handler) => handler(0)),
             };
             callback(null, 'success', '');
             return mockProcess;
         });
 
         await script.executeScript(container, 'install');
-        
+
         const execCall = exec.mock.results[0].value;
         expect(execCall.stdout.on).toHaveBeenCalledWith('data', expect.any(Function));
         // Verify log messages were prefixed with container name
@@ -142,19 +185,19 @@ describe('Script Trigger Tests', () => {
     test('setContainerNotification should update container with notification', async () => {
         const container = {
             id: 'test-container',
-            name: 'test-container'
+            name: 'test-container',
         };
-        
+
         script.setContainerNotification(container, 'Test message', 'info');
-        
+
         expect(storeContainer.updateContainer).toHaveBeenCalledWith(
             expect.objectContaining({
                 id: 'test-container',
                 notification: {
                     message: 'Test message',
-                    level: 'info'
-                }
-            })
+                    level: 'info',
+                },
+            }),
         );
     });
 });


### PR DESCRIPTION
## What

The `script` trigger suite was written against an older implementation
and four of its tests failed on a clean checkout. Test-only changes; no
production code touched.

- **triggerBatch**: the trigger logs through `this.log`, which the base
  component sets at init (not run in unit tests), so `this.log.warn` threw.
  Inject a stub `this.log`.
- **cleanupExistingContainers**: the cleanup loop now always preserves one
  "best" running/up-to-date container, so a single-row fixture is preserved
  and never deleted. Back the store with a small stateful set (a stale
  `exited` row plus a preserved `running` one) so a real deletion happens
  and the retry loop converges instead of spinning.
- **waitForContainerImageUpdate**: the method polls the watcher's Docker
  API (not the store) for the new running container, then waits for a watch
  cycle via the watcher-stop event before reading the store. Stub
  `getDockerApiForWatcher`, the `registerWatcherStop` event, and the store
  read; the old store-only mock could never satisfy it and timed out.
- **executeScript**: asserts on `console.log`, which wasn't a spy. Spy
  `console` in `beforeEach` (also keeps the suite output quiet).

Also removed a dead `ValidationError` import.

## Result

The script suite goes green (5 passing). Combined with the earlier
realignments, the only backend suite still red is the `Docker` watcher,
which is handled in its own follow-up.

## Verification

Full backend suite in a clean `node:18-alpine` container: script suite
`PASS` (5/5); overall failing suites `2 -> 1` (Docker only); no other
suite changed.