### PR TITLE
Rename project to Hosaka

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -45,7 +45,7 @@ jobs:
 
       - name: Build and push
         env:
-          WUD_VERSION: ${{ github.event.release.tag_name }}
+          HOSAKA_VERSION: ${{ github.event.release.tag_name }}
         uses: docker/build-push-action@v6
         with:
           context: .
@@ -54,4 +54,4 @@ jobs:
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           build-args: |
-            WUD_VERSION=${{ env.WUD_VERSION }}
+            HOSAKA_VERSION=${{ env.HOSAKA_VERSION }}

--- a/Docker.entrypoint.sh
+++ b/Docker.entrypoint.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 set -e
 
-if [ $1 == "node" ] && [ $2 == "index" ] && [ ${WUD_LOG_FORMAT} != "json" ]; then
+if [ $1 == "node" ] && [ $2 == "index" ] && [ ${HOSAKA_LOG_FORMAT} != "json" ]; then
   exec "$@" | ./node_modules/.bin/bunyan -L  -o short
 else
   exec "$@"

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,11 +4,11 @@ FROM node:18-alpine as base
 LABEL maintainer="fmartinou"
 EXPOSE 3000
 
-ARG WUD_VERSION=unknown
+ARG HOSAKA_VERSION=unknown
 
 ENV WORKDIR=/home/node/app
-ENV WUD_LOG_FORMAT=text
-ENV WUD_VERSION=$WUD_VERSION
+ENV HOSAKA_LOG_FORMAT=text
+ENV HOSAKA_VERSION=$HOSAKA_VERSION
 
 WORKDIR /home/node/app
 

--- a/README.md
+++ b/README.md
@@ -1,27 +1,14 @@
-# WUD (aka What's up Docker?)
-
-![Travis](https://img.shields.io/travis/com/getwud/wud)
-![Maintainability](https://img.shields.io/codeclimate/maintainability/getwud/wud)
-![Coverage](https://img.shields.io/codeclimate/coverage/getwud/wud)
-![Docker pulls](https://img.shields.io/docker/pulls/getwud/wud)
-[![Donate](https://img.shields.io/badge/Donate-PayPal-green.svg)](https://www.paypal.com/donate/?business=ZSDMEC3ZE8DQ8&no_recurring=0&currency_code=EUR)
-[![Donate](https://img.shields.io/badge/-buy_me_a%C2%A0coffee-gray?logo=buy-me-a-coffee)](https://www.buymeacoffee.com/61rUNMm)
-
-#### [:blue_book: User documentation](https://getwud.github.io/wud/)
-
-![](docs/wud_logo_250.png)
+# Hosaka
 
 Gets you notified when new versions of your Docker containers are available and lets you react the way you want.
 
-### WUD is built on 3 concepts:
+### Hosaka is built on 3 concepts:
 
 > `WATCHERS` query your Docker hosts to get the containers to watch
 
 > `REGISTRIES` query the Docker registries to find available updates
 
 > `TRIGGERS` perform actions when updates are available
-
-![image](docs/introduction/wud_arch.png)
 
 ## Many supported triggers
 > Send notifications using **Smtp**, [**Apprise**](https://github.com/caronc/apprise-api), [**Ifttt**](https://ifttt.com), [**Pushover**](https://pushover.net), [**Slack**](https://slack.com), [**Telegram**](https://telegram.org/), [**Discord**](https://discord.com/)...
@@ -58,7 +45,6 @@ Gets you notified when new versions of your Docker containers are available and 
 > [**Self-hosted Docker Registry**](https://docs.docker.com/registry/)
 
 ## REST API & Web UI
-![image](docs/ui/ui.png)
 
 ## Flexible authentication strategies
 - [Openid Connect](https://openid.net/connect/)
@@ -80,16 +66,9 @@ Gets you notified when new versions of your Docker containers are available and 
 
 > ...
 
-## Ready to go?
-> **Check out the [documentation](https://getwud.github.io/wud/) to get started!**
-
 ## Contact & Support
-- Create a [GitHub issue](https://github.com/getwud/wud/issues) for bug reports, feature requests, or questions
-- Add a ⭐️ [star on GitHub](https://github.com/getwud/wud) or [Buy me coffee](https://www.buymeacoffee.com/61rUNMm)&nbsp;to support the project!
-
-<a href="https://www.buymeacoffee.com/61rUNMm" target="_blank"><img src="https://www.buymeacoffee.com/assets/img/custom_images/orange_img.png" alt="Buy Me A Coffee" style="height: 41px !important;width: 174px !important;box-shadow: 0px 3px 2px 0px rgba(190, 190, 190, 0.5) !important;-webkit-box-shadow: 0px 3px 2px 0px rgba(190, 190, 190, 0.5) !important;" ></a>
-
-
+- Create a [GitHub issue](https://github.com/nopoz/hosaka/issues) for bug reports, feature requests, or questions
+- Add a star on [GitHub](https://github.com/nopoz/hosaka) to support the project!
 
 ## License
-This project is licensed under the [MIT license](https://github.com/getwud/wud/blob/main/LICENSE).
+This project is licensed under the [MIT license](https://github.com/nopoz/hosaka/blob/main/LICENSE).

--- a/app/api/auth.js
+++ b/app/api/auth.js
@@ -14,8 +14,8 @@ const router = express.Router();
 // The configured strategy ids.
 const STRATEGY_IDS = [];
 
-// Constant WUD namespace for uuid v5 bound sessions.
-const WUD_NAMESPACE = 'dee41e92-5fc4-460e-beec-528c9ea7d760';
+// Constant Hosaka namespace for uuid v5 bound sessions.
+const HOSAKA_NAMESPACE = 'dee41e92-5fc4-460e-beec-528c9ea7d760';
 
 /**
  * Get all strategies id.
@@ -35,12 +35,12 @@ function getCookieMaxAge(days) {
 }
 
 /**
- * Get session secret key (bound to wud version).
+ * Get session secret key (bound to hosaka version).
  * @returns {string}
  */
 function getSessionSecretKey() {
-    const stringToHash = `wud.${getVersion()}.${getmac()}`;
-    return uuidV5(stringToHash, WUD_NAMESPACE);
+    const stringToHash = `hosaka.${getVersion()}.${getmac()}`;
+    return uuidV5(stringToHash, HOSAKA_NAMESPACE);
 }
 
 /**

--- a/app/configuration/index.js
+++ b/app/configuration/index.js
@@ -24,51 +24,51 @@ function get(prop, env = process.env) {
 
 /**
  * Lookup external secrets defined in files.
- * @param wudEnvVars
+ * @param hosakaEnvVars
  */
 /* eslint-disable no-param-reassign */
-function replaceSecrets(wudEnvVars) {
-    const secretFileEnvVars = Object.keys(wudEnvVars)
-        .filter((wudEnvVar) => wudEnvVar.toUpperCase().endsWith(VAR_FILE_SUFFIX));
+function replaceSecrets(hosakaEnvVars) {
+    const secretFileEnvVars = Object.keys(hosakaEnvVars)
+        .filter((hosakaEnvVar) => hosakaEnvVar.toUpperCase().endsWith(VAR_FILE_SUFFIX));
     secretFileEnvVars.forEach((secretFileEnvVar) => {
         const secretKey = secretFileEnvVar.replace(VAR_FILE_SUFFIX, '');
-        const secretFilePath = wudEnvVars[secretFileEnvVar];
+        const secretFilePath = hosakaEnvVars[secretFileEnvVar];
         const secretFileValue = fs.readFileSync(secretFilePath, 'utf-8');
-        delete wudEnvVars[secretFileEnvVar];
-        wudEnvVars[secretKey] = secretFileValue;
+        delete hosakaEnvVars[secretFileEnvVar];
+        hosakaEnvVars[secretKey] = secretFileValue;
     });
 }
 
-// 1. Get a copy of all wud related env vars
-const wudEnvVars = {};
+// 1. Get a copy of all hosaka related env vars
+const hosakaEnvVars = {};
 Object.keys(process.env)
-    .filter((envVar) => envVar.toUpperCase().startsWith('WUD'))
-    .forEach((wudEnvVar) => {
-        wudEnvVars[wudEnvVar] = process.env[wudEnvVar];
+    .filter((envVar) => envVar.toUpperCase().startsWith('HOSAKA'))
+    .forEach((hosakaEnvVar) => {
+        hosakaEnvVars[hosakaEnvVar] = process.env[hosakaEnvVar];
     });
 
 // 2. Replace all secret files referenced by their secret values
-replaceSecrets(wudEnvVars);
+replaceSecrets(hosakaEnvVars);
 
 function getVersion() {
-    return wudEnvVars.WUD_VERSION || 'unknown';
+    return hosakaEnvVars.HOSAKA_VERSION || 'unknown';
 }
 
 function getLogLevel() {
-    return wudEnvVars.WUD_LOG_LEVEL || 'info';
+    return hosakaEnvVars.HOSAKA_LOG_LEVEL || 'info';
 }
 /**
  * Get watcher configuration.
  */
 function getWatcherConfigurations() {
-    return get('wud.watcher', wudEnvVars);
+    return get('hosaka.watcher', hosakaEnvVars);
 }
 
 /**
  * Get trigger configurations.
  */
 function getTriggerConfigurations() {
-    return get('wud.trigger', wudEnvVars);
+    return get('hosaka.trigger', hosakaEnvVars);
 }
 
 /**
@@ -76,7 +76,7 @@ function getTriggerConfigurations() {
  * @returns {*}
  */
 function getRegistryConfigurations() {
-    return get('wud.registry', wudEnvVars);
+    return get('hosaka.registry', hosakaEnvVars);
 }
 
 /**
@@ -84,21 +84,21 @@ function getRegistryConfigurations() {
  * @returns {*}
  */
 function getAuthenticationConfigurations() {
-    return get('wud.auth', wudEnvVars);
+    return get('hosaka.auth', hosakaEnvVars);
 }
 
 /**
  * Get Input configurations.
  */
 function getStoreConfiguration() {
-    return get('wud.store', wudEnvVars);
+    return get('hosaka.store', hosakaEnvVars);
 }
 
 /**
  * Get Server configurations.
  */
 function getServerConfiguration() {
-    const configurationFromEnv = get('wud.server', wudEnvVars);
+    const configurationFromEnv = get('hosaka.server', hosakaEnvVars);
     const configurationSchema = joi.object().keys({
         enabled: joi.boolean().default(true),
         port: joi.number().default(3000).integer().min(0)
@@ -129,7 +129,7 @@ function getServerConfiguration() {
 }
 
 function getPublicUrl(req) {
-    const publicUrl = wudEnvVars.WUD_PUBLIC_URL;
+    const publicUrl = hosakaEnvVars.HOSAKA_PUBLIC_URL;
     if (publicUrl) {
         return publicUrl;
     }
@@ -138,7 +138,7 @@ function getPublicUrl(req) {
 }
 
 module.exports = {
-    wudEnvVars,
+    hosakaEnvVars,
     get,
     replaceSecrets,
     getVersion,

--- a/app/configuration/index.test.js
+++ b/app/configuration/index.test.js
@@ -1,33 +1,33 @@
 const configuration = require('./index');
 
-test('getVersion should return wud version', () => {
-    configuration.wudEnvVars.WUD_VERSION = 'x.y.z';
+test('getVersion should return hosaka version', () => {
+    configuration.hosakaEnvVars.HOSAKA_VERSION = 'x.y.z';
     expect(configuration.getVersion()).toStrictEqual('x.y.z');
 });
 
 test('getLogLevel should return info by default', () => {
-    delete configuration.wudEnvVars.WUD_LOG_LEVEL;
+    delete configuration.hosakaEnvVars.HOSAKA_LOG_LEVEL;
     expect(configuration.getLogLevel()).toStrictEqual('info');
 });
 
 test('getLogLevel should return debug when overridden', () => {
-    configuration.wudEnvVars.WUD_LOG_LEVEL = 'debug';
+    configuration.hosakaEnvVars.HOSAKA_LOG_LEVEL = 'debug';
     expect(configuration.getLogLevel()).toStrictEqual('debug');
 });
 
 test('getWatcherConfiguration should return empty object by default', () => {
-    delete configuration.wudEnvVars.WUD_WATCHER_WATCHER1_X;
-    delete configuration.wudEnvVars.WUD_WATCHER_WATCHER1_Y;
-    delete configuration.wudEnvVars.WUD_WATCHER_WATCHER2_X;
-    delete configuration.wudEnvVars.WUD_WATCHER_WATCHER2_Y;
+    delete configuration.hosakaEnvVars.HOSAKA_WATCHER_WATCHER1_X;
+    delete configuration.hosakaEnvVars.HOSAKA_WATCHER_WATCHER1_Y;
+    delete configuration.hosakaEnvVars.HOSAKA_WATCHER_WATCHER2_X;
+    delete configuration.hosakaEnvVars.HOSAKA_WATCHER_WATCHER2_Y;
     expect(configuration.getWatcherConfigurations()).toStrictEqual({});
 });
 
 test('getWatcherConfiguration should return configured watchers when overridden', () => {
-    configuration.wudEnvVars.WUD_WATCHER_WATCHER1_X = 'x';
-    configuration.wudEnvVars.WUD_WATCHER_WATCHER1_Y = 'y';
-    configuration.wudEnvVars.WUD_WATCHER_WATCHER2_X = 'x';
-    configuration.wudEnvVars.WUD_WATCHER_WATCHER2_Y = 'y';
+    configuration.hosakaEnvVars.HOSAKA_WATCHER_WATCHER1_X = 'x';
+    configuration.hosakaEnvVars.HOSAKA_WATCHER_WATCHER1_Y = 'y';
+    configuration.hosakaEnvVars.HOSAKA_WATCHER_WATCHER2_X = 'x';
+    configuration.hosakaEnvVars.HOSAKA_WATCHER_WATCHER2_Y = 'y';
     expect(configuration.getWatcherConfigurations()).toStrictEqual({
         watcher1: { x: 'x', y: 'y' },
         watcher2: { x: 'x', y: 'y' },
@@ -35,18 +35,18 @@ test('getWatcherConfiguration should return configured watchers when overridden'
 });
 
 test('getTriggerConfigurations should return empty object by default', () => {
-    delete configuration.wudEnvVars.WUD_TRIGGER_TRIGGER1_X;
-    delete configuration.wudEnvVars.WUD_TRIGGER_TRIGGER1_Y;
-    delete configuration.wudEnvVars.WUD_TRIGGER_TRIGGER2_X;
-    delete configuration.wudEnvVars.WUD_TRIGGER_TRIGGER2_Y;
+    delete configuration.hosakaEnvVars.HOSAKA_TRIGGER_TRIGGER1_X;
+    delete configuration.hosakaEnvVars.HOSAKA_TRIGGER_TRIGGER1_Y;
+    delete configuration.hosakaEnvVars.HOSAKA_TRIGGER_TRIGGER2_X;
+    delete configuration.hosakaEnvVars.HOSAKA_TRIGGER_TRIGGER2_Y;
     expect(configuration.getTriggerConfigurations()).toStrictEqual({});
 });
 
 test('getTriggerConfigurations should return configured triggers when overridden', () => {
-    configuration.wudEnvVars.WUD_TRIGGER_TRIGGER1_X = 'x';
-    configuration.wudEnvVars.WUD_TRIGGER_TRIGGER1_Y = 'y';
-    configuration.wudEnvVars.WUD_TRIGGER_TRIGGER2_X = 'x';
-    configuration.wudEnvVars.WUD_TRIGGER_TRIGGER2_Y = 'y';
+    configuration.hosakaEnvVars.HOSAKA_TRIGGER_TRIGGER1_X = 'x';
+    configuration.hosakaEnvVars.HOSAKA_TRIGGER_TRIGGER1_Y = 'y';
+    configuration.hosakaEnvVars.HOSAKA_TRIGGER_TRIGGER2_X = 'x';
+    configuration.hosakaEnvVars.HOSAKA_TRIGGER_TRIGGER2_Y = 'y';
     expect(configuration.getTriggerConfigurations()).toStrictEqual({
         trigger1: { x: 'x', y: 'y' },
         trigger2: { x: 'x', y: 'y' },
@@ -54,18 +54,18 @@ test('getTriggerConfigurations should return configured triggers when overridden
 });
 
 test('getRegistryConfigurations should return empty object by default', () => {
-    delete configuration.wudEnvVars.WUD_REGISTRY_REGISTRY1_X;
-    delete configuration.wudEnvVars.WUD_REGISTRY_REGISTRY1_Y;
-    delete configuration.wudEnvVars.WUD_REGISTRY_REGISTRY1_X;
-    delete configuration.wudEnvVars.WUD_REGISTRY_REGISTRY1_Y;
+    delete configuration.hosakaEnvVars.HOSAKA_REGISTRY_REGISTRY1_X;
+    delete configuration.hosakaEnvVars.HOSAKA_REGISTRY_REGISTRY1_Y;
+    delete configuration.hosakaEnvVars.HOSAKA_REGISTRY_REGISTRY1_X;
+    delete configuration.hosakaEnvVars.HOSAKA_REGISTRY_REGISTRY1_Y;
     expect(configuration.getRegistryConfigurations()).toStrictEqual({});
 });
 
 test('getRegistryConfigurations should return configured registries when overridden', () => {
-    configuration.wudEnvVars.WUD_REGISTRY_REGISTRY1_X = 'x';
-    configuration.wudEnvVars.WUD_REGISTRY_REGISTRY1_Y = 'y';
-    configuration.wudEnvVars.WUD_REGISTRY_REGISTRY2_X = 'x';
-    configuration.wudEnvVars.WUD_REGISTRY_REGISTRY2_Y = 'y';
+    configuration.hosakaEnvVars.HOSAKA_REGISTRY_REGISTRY1_X = 'x';
+    configuration.hosakaEnvVars.HOSAKA_REGISTRY_REGISTRY1_Y = 'y';
+    configuration.hosakaEnvVars.HOSAKA_REGISTRY_REGISTRY2_X = 'x';
+    configuration.hosakaEnvVars.HOSAKA_REGISTRY_REGISTRY2_Y = 'y';
     expect(configuration.getRegistryConfigurations()).toStrictEqual({
         registry1: { x: 'x', y: 'y' },
         registry2: { x: 'x', y: 'y' },
@@ -73,13 +73,13 @@ test('getRegistryConfigurations should return configured registries when overrid
 });
 
 test('getStoreConfiguration should return configured store', () => {
-    configuration.wudEnvVars.WUD_STORE_X = 'x';
-    configuration.wudEnvVars.WUD_STORE_Y = 'y';
+    configuration.hosakaEnvVars.HOSAKA_STORE_X = 'x';
+    configuration.hosakaEnvVars.HOSAKA_STORE_Y = 'y';
     expect(configuration.getStoreConfiguration()).toStrictEqual({ x: 'x', y: 'y' });
 });
 
 test('getServerConfiguration should return configured api (new vars)', () => {
-    configuration.wudEnvVars.WUD_SERVER_PORT = '4000';
+    configuration.hosakaEnvVars.HOSAKA_SERVER_PORT = '4000';
     expect(configuration.getServerConfiguration()).toStrictEqual({
         cors: {},
         enabled: true,
@@ -93,10 +93,10 @@ test('getServerConfiguration should return configured api (new vars)', () => {
 
 test('replaceSecrets must read secret in file', () => {
     const vars = {
-        WUD_SERVER_X__FILE: `${__dirname}/secret.txt`,
+        HOSAKA_SERVER_X__FILE: `${__dirname}/secret.txt`,
     };
     configuration.replaceSecrets(vars);
     expect(vars).toStrictEqual({
-        WUD_SERVER_X: 'super_secret',
+        HOSAKA_SERVER_X: 'super_secret',
     });
 });

--- a/app/event/index.js
+++ b/app/event/index.js
@@ -4,25 +4,25 @@ const events = require('events');
 const eventEmitter = new events.EventEmitter();
 
 // Container related events
-const WUD_CONTAINER_ADDED = 'wud:container-added';
-const WUD_CONTAINER_UPDATED = 'wud:container-updated';
-const WUD_CONTAINER_REMOVED = 'wud:container-removed';
-const WUD_CONTAINER_REPORT = 'wud:container-report';
-const WUD_CONTAINER_REPORTS = 'wud:container-reports';
+const HOSAKA_CONTAINER_ADDED = 'hosaka:container-added';
+const HOSAKA_CONTAINER_UPDATED = 'hosaka:container-updated';
+const HOSAKA_CONTAINER_REMOVED = 'hosaka:container-removed';
+const HOSAKA_CONTAINER_REPORT = 'hosaka:container-report';
+const HOSAKA_CONTAINER_REPORTS = 'hosaka:container-reports';
 
 // Watcher related events
-const WUD_WATCHER_START = 'wud:watcher-start';
-const WUD_WATCHER_STOP = 'wud:watcher-stop';
+const HOSAKA_WATCHER_START = 'hosaka:watcher-start';
+const HOSAKA_WATCHER_STOP = 'hosaka:watcher-stop';
 
 // New event constant
-const WUD_TRIGGER_WATCH = 'wud:trigger-watch';
+const HOSAKA_TRIGGER_WATCH = 'hosaka:trigger-watch';
 
 /**
  * Emit ContainerReports event.
  * @param containerReports
  */
 function emitContainerReports(containerReports) {
-    eventEmitter.emit(WUD_CONTAINER_REPORTS, containerReports);
+    eventEmitter.emit(HOSAKA_CONTAINER_REPORTS, containerReports);
 }
 
 /**
@@ -30,7 +30,7 @@ function emitContainerReports(containerReports) {
  * @param handler
  */
 function registerContainerReports(handler) {
-    eventEmitter.on(WUD_CONTAINER_REPORTS, handler);
+    eventEmitter.on(HOSAKA_CONTAINER_REPORTS, handler);
 }
 
 /**
@@ -38,7 +38,7 @@ function registerContainerReports(handler) {
  * @param containerReport
  */
 function emitContainerReport(containerReport) {
-    eventEmitter.emit(WUD_CONTAINER_REPORT, containerReport);
+    eventEmitter.emit(HOSAKA_CONTAINER_REPORT, containerReport);
 }
 
 /**
@@ -46,7 +46,7 @@ function emitContainerReport(containerReport) {
  * @param handler
  */
 function registerContainerReport(handler) {
-    eventEmitter.on(WUD_CONTAINER_REPORT, handler);
+    eventEmitter.on(HOSAKA_CONTAINER_REPORT, handler);
 }
 
 /**
@@ -54,7 +54,7 @@ function registerContainerReport(handler) {
  * @param containerAdded
  */
 function emitContainerAdded(containerAdded) {
-    eventEmitter.emit(WUD_CONTAINER_ADDED, containerAdded);
+    eventEmitter.emit(HOSAKA_CONTAINER_ADDED, containerAdded);
 }
 
 /**
@@ -62,7 +62,7 @@ function emitContainerAdded(containerAdded) {
  * @param handler
  */
 function registerContainerAdded(handler) {
-    eventEmitter.on(WUD_CONTAINER_ADDED, handler);
+    eventEmitter.on(HOSAKA_CONTAINER_ADDED, handler);
 }
 
 /**
@@ -70,7 +70,7 @@ function registerContainerAdded(handler) {
  * @param containerUpdated
  */
 function emitContainerUpdated(containerUpdated) {
-    eventEmitter.emit(WUD_CONTAINER_UPDATED, containerUpdated);
+    eventEmitter.emit(HOSAKA_CONTAINER_UPDATED, containerUpdated);
 }
 
 /**
@@ -78,7 +78,7 @@ function emitContainerUpdated(containerUpdated) {
  * @param handler
  */
 function registerContainerUpdated(handler) {
-    eventEmitter.on(WUD_CONTAINER_UPDATED, handler);
+    eventEmitter.on(HOSAKA_CONTAINER_UPDATED, handler);
 }
 
 /**
@@ -86,7 +86,7 @@ function registerContainerUpdated(handler) {
  * @param containerRemoved
  */
 function emitContainerRemoved(containerRemoved) {
-    eventEmitter.emit(WUD_CONTAINER_REMOVED, containerRemoved);
+    eventEmitter.emit(HOSAKA_CONTAINER_REMOVED, containerRemoved);
 }
 
 /**
@@ -94,42 +94,42 @@ function emitContainerRemoved(containerRemoved) {
  * @param handler
  */
 function registerContainerRemoved(handler) {
-    eventEmitter.on(WUD_CONTAINER_REMOVED, handler);
+    eventEmitter.on(HOSAKA_CONTAINER_REMOVED, handler);
 }
 
 function emitWatcherStart(watcher) {
-    eventEmitter.emit(WUD_WATCHER_START, watcher);
+    eventEmitter.emit(HOSAKA_WATCHER_START, watcher);
 }
 
 function registerWatcherStart(handler) {
-    eventEmitter.on(WUD_WATCHER_START, handler);
+    eventEmitter.on(HOSAKA_WATCHER_START, handler);
 }
 
 function emitWatcherStop(watcher) {
-    eventEmitter.emit(WUD_WATCHER_STOP, watcher);
+    eventEmitter.emit(HOSAKA_WATCHER_STOP, watcher);
 }
 
 function registerWatcherStop(handler) {
-    eventEmitter.on(WUD_WATCHER_STOP, handler);
+    eventEmitter.on(HOSAKA_WATCHER_STOP, handler);
 }
 
 // New function to emit trigger_watch
 function emitTriggerWatch() {
-    eventEmitter.emit(WUD_TRIGGER_WATCH);
+    eventEmitter.emit(HOSAKA_TRIGGER_WATCH);
 }
 
 // New function to register a handler for trigger_watch
 function registerTriggerWatch(handler) {
-    eventEmitter.on(WUD_TRIGGER_WATCH, handler);
+    eventEmitter.on(HOSAKA_TRIGGER_WATCH, handler);
 }
 
 // New function to unregister a handler for trigger_watch
 function unregisterTriggerWatch(handler) {
-    eventEmitter.off(WUD_TRIGGER_WATCH, handler);
+    eventEmitter.off(HOSAKA_TRIGGER_WATCH, handler);
 }
 
 function unregisterWatcherStop(handler) {
-    eventEmitter.off(WUD_WATCHER_STOP, handler);
+    eventEmitter.off(HOSAKA_WATCHER_STOP, handler);
 }
 
 

--- a/app/index.js
+++ b/app/index.js
@@ -26,7 +26,7 @@ async function shutdown(signal) {
 }
 
 async function main() {
-    log.info(`WUD is starting (version = ${getVersion()})`);
+    log.info(`Hosaka is starting (version = ${getVersion()})`);
 
     // Init store
     await store.init();

--- a/app/log/index.js
+++ b/app/log/index.js
@@ -3,6 +3,6 @@ const { getLogLevel } = require('../configuration');
 
 // Init Bunyan logger
 module.exports = bunyan.createLogger({
-    name: 'whats-up-docker',
+    name: 'hosaka',
     level: getLogLevel(),
 });

--- a/app/model/container.js
+++ b/app/model/container.js
@@ -199,7 +199,7 @@ function addUpdateKindProperty(container) {
                 ) {
                     if (container.image.tag.value !== container.result.tag) {
                         updateKind.kind = 'tag';
-                        let semverDiffWud = 'unknown';
+                        let semverDiffValue = 'unknown';
                         const isSemver = container.image.tag.semver;
                         if (isSemver) {
                             const semverDiff = diffSemver(
@@ -209,26 +209,26 @@ function addUpdateKindProperty(container) {
                             switch (semverDiff) {
                             case 'major':
                             case 'premajor':
-                                semverDiffWud = 'major';
+                                semverDiffValue = 'major';
                                 break;
                             case 'minor':
                             case 'preminor':
-                                semverDiffWud = 'minor';
+                                semverDiffValue = 'minor';
                                 break;
                             case 'patch':
                             case 'prepatch':
-                                semverDiffWud = 'patch';
+                                semverDiffValue = 'patch';
                                 break;
                             case 'prerelease':
-                                semverDiffWud = 'prerelease';
+                                semverDiffValue = 'prerelease';
                                 break;
                             default:
-                                semverDiffWud = 'unknown';
+                                semverDiffValue = 'unknown';
                             }
                         }
                         updateKind.localValue = container.image.tag.value;
                         updateKind.remoteValue = container.result.tag;
-                        updateKind.semverDiff = semverDiffWud;
+                        updateKind.semverDiff = semverDiffValue;
                     } else if (container.image.digest
                         && container.image.digest.value !== container.result.digest
                     ) {

--- a/app/nodemon.json
+++ b/app/nodemon.json
@@ -1,9 +1,9 @@
 {
   "env": {
-    "WUD_VERSION": "dev",
-    "WUD_STORE_PATH": ".store",
-    "WUD_WATCHER_LOCAL_WATCHBYDEFAULT": "true",
-    "WUD_AUTH_BASIC_JOHN_USER": "john",
-    "WUD_AUTH_BASIC_JOHN_HASH": "$apr1$aefKbZEa$ZSA5Y3zv9vDQOxr283NGx/"
+    "HOSAKA_VERSION": "dev",
+    "HOSAKA_STORE_PATH": ".store",
+    "HOSAKA_WATCHER_LOCAL_WATCHBYDEFAULT": "true",
+    "HOSAKA_AUTH_BASIC_JOHN_USER": "john",
+    "HOSAKA_AUTH_BASIC_JOHN_HASH": "$apr1$aefKbZEa$ZSA5Y3zv9vDQOxr283NGx/"
   }
 }

--- a/app/package.json
+++ b/app/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "wud-app",
+  "name": "hosaka-app",
   "version": "1.0.0",
   "description": "What'up Docker? the app",
   "main": "index.js",
@@ -10,7 +10,7 @@
     "test": "jest --coverage"
   },
   "author": "fmartinou",
-  "repository": "getwud/wud",
+  "repository": "nopoz/hosaka",
   "license": "MIT",
   "dependencies": {
     "@slack/web-api": "7.16.0",

--- a/app/prometheus/container.js
+++ b/app/prometheus/container.js
@@ -36,7 +36,7 @@ function init() {
         register.removeSingleMetric(gaugeContainer.name);
     }
     gaugeContainer = new Gauge({
-        name: 'wud_containers',
+        name: 'hosaka_containers',
         help: 'The watched containers',
         labelNames: [
             'id',

--- a/app/prometheus/registry.js
+++ b/app/prometheus/registry.js
@@ -8,7 +8,7 @@ function init() {
         register.removeSingleMetric(summaryGetTags.name);
     }
     summaryGetTags = new Summary({
-        name: 'wud_registry_response',
+        name: 'hosaka_registry_response',
         help: 'The Registry response time (in second)',
         labelNames: ['type', 'name'],
     });

--- a/app/prometheus/registry.test.js
+++ b/app/prometheus/registry.test.js
@@ -3,6 +3,6 @@ const registry = require('./registry');
 test('registry histogram should be properly configured', () => {
     registry.init();
     const summary = registry.getSummaryTags();
-    expect(summary.name).toStrictEqual('wud_registry_response');
+    expect(summary.name).toStrictEqual('hosaka_registry_response');
     expect(summary.labelNames).toStrictEqual(['type', 'name']);
 });

--- a/app/prometheus/trigger.js
+++ b/app/prometheus/trigger.js
@@ -8,7 +8,7 @@ function init() {
         register.removeSingleMetric(triggerCounter.name);
     }
     triggerCounter = new Counter({
-        name: 'wud_trigger_count',
+        name: 'hosaka_trigger_count',
         help: 'Total count of trigger events',
         labelNames: ['type', 'name', 'status'],
     });

--- a/app/prometheus/trigger.test.js
+++ b/app/prometheus/trigger.test.js
@@ -3,6 +3,6 @@ const trigger = require('./trigger');
 test('trigger counter should be properly configured', () => {
     trigger.init();
     const summary = trigger.getTriggerCounter();
-    expect(summary.name).toStrictEqual('wud_trigger_count');
+    expect(summary.name).toStrictEqual('hosaka_trigger_count');
     expect(summary.labelNames).toStrictEqual(['type', 'name', 'status']);
 });

--- a/app/prometheus/watcher.js
+++ b/app/prometheus/watcher.js
@@ -8,7 +8,7 @@ function init() {
         register.removeSingleMetric(watchContainerGauge.name);
     }
     watchContainerGauge = new Gauge({
-        name: 'wud_watcher_total',
+        name: 'hosaka_watcher_total',
         help: 'The number of watched containers',
         labelNames: ['type', 'name'],
     });

--- a/app/prometheus/watcher.test.js
+++ b/app/prometheus/watcher.test.js
@@ -3,6 +3,6 @@ const watcher = require('./watcher');
 test('watcher counter should be properly configured', () => {
     watcher.init();
     const gauge = watcher.getWatchContainerGauge();
-    expect(gauge.name).toStrictEqual('wud_watcher_total');
+    expect(gauge.name).toStrictEqual('hosaka_watcher_total');
     expect(gauge.labelNames).toStrictEqual(['type', 'name']);
 });

--- a/app/store/app.js
+++ b/app/store/app.js
@@ -9,7 +9,7 @@ let app;
 
 function saveAppInfosAndMigrate() {
     const appInfosCurrent = {
-        name: 'wud',
+        name: 'hosaka',
         version: getVersion(),
     };
     const appInfosSaved = app.findOne({});

--- a/app/store/app.test.js
+++ b/app/store/app.test.js
@@ -41,7 +41,7 @@ test('createCollections should call migrate when versions are different', () => 
     const db = {
         getCollection: () => ({
             findOne: () => ({
-                name: 'wud',
+                name: 'hosaka',
                 version: '1.0.0',
             }),
             insert: () => {},
@@ -58,7 +58,7 @@ test('createCollections should not call migrate when versions are identical', ()
     const db = {
         getCollection: () => ({
             findOne: () => ({
-                name: 'wud',
+                name: 'hosaka',
                 version: '2.0.0',
             }),
             insert: () => {},
@@ -75,7 +75,7 @@ test('getAppInfos should return collection content', () => {
     const db = {
         getCollection: () => ({
             findOne: () => ({
-                name: 'wud',
+                name: 'hosaka',
                 version: '1.0.0',
             }),
             insert: () => {},
@@ -85,7 +85,7 @@ test('getAppInfos should return collection content', () => {
     };
     app.createCollections(db);
     expect(app.getAppInfos(db)).toStrictEqual({
-        name: 'wud',
+        name: 'hosaka',
         version: '1.0.0',
     });
 });

--- a/app/store/index.js
+++ b/app/store/index.js
@@ -10,7 +10,7 @@ const container = require('./container');
 // Store Configuration Schema
 const configurationSchema = joi.object().keys({
     path: joi.string().default('/store'),
-    file: joi.string().default('wud.json'),
+    file: joi.string().default('hosaka.json'),
 });
 
 // Validate Configuration

--- a/app/triggers/providers/discord/Discord.js
+++ b/app/triggers/providers/discord/Discord.js
@@ -15,7 +15,7 @@ class Discord extends Trigger {
             url: this.joi.string().uri({
                 scheme: ['https'],
             }).required(),
-            botusername: this.joi.string().default('WUD'),
+            botusername: this.joi.string().default('Hosaka'),
             cardcolor: this.joi.number().default(65280),
             cardlabel: this.joi.string().default(''),
         });

--- a/app/triggers/providers/ifttt/Ifttt.js
+++ b/app/triggers/providers/ifttt/Ifttt.js
@@ -13,7 +13,7 @@ class Ifttt extends Trigger {
     getConfigurationSchema() {
         return this.joi.object().keys({
             key: this.joi.string().required(),
-            event: this.joi.string().default('wud-image'),
+            event: this.joi.string().default('hosaka-image'),
         });
     }
 

--- a/app/triggers/providers/ifttt/Ifttt.test.js
+++ b/app/triggers/providers/ifttt/Ifttt.test.js
@@ -9,7 +9,7 @@ const ifttt = new Ifttt();
 
 const configurationValid = {
     key: 'secret',
-    event: 'wud-image',
+    event: 'hosaka-image',
     threshold: 'all',
     mode: 'simple',
     once: true,

--- a/app/triggers/providers/kafka/Kafka.js
+++ b/app/triggers/providers/kafka/Kafka.js
@@ -12,8 +12,8 @@ class Kafka extends Trigger {
     getConfigurationSchema() {
         return this.joi.object().keys({
             brokers: this.joi.string().required(),
-            topic: this.joi.string().default('wud-container'),
-            clientId: this.joi.string().default('wud'),
+            topic: this.joi.string().default('hosaka-container'),
+            clientId: this.joi.string().default('hosaka'),
             ssl: this.joi.boolean().default(false),
             authentication: this.joi.object({
                 type: this.joi.string()

--- a/app/triggers/providers/kafka/Kafka.test.js
+++ b/app/triggers/providers/kafka/Kafka.test.js
@@ -9,8 +9,8 @@ const kafka = new Kafka();
 
 const configurationValid = {
     brokers: 'broker1:9000, broker2:9000',
-    topic: 'wud-container',
-    clientId: 'wud',
+    topic: 'hosaka-container',
+    clientId: 'hosaka',
     ssl: false,
     threshold: 'all',
     mode: 'simple',
@@ -69,8 +69,8 @@ test('validateConfiguration should throw error when invalid', () => {
 test('maskConfiguration should mask sensitive data', () => {
     kafka.configuration = {
         brokers: 'broker1:9000, broker2:9000',
-        topic: 'wud-image',
-        clientId: 'wud',
+        topic: 'hosaka-image',
+        clientId: 'hosaka',
         ssl: false,
         authentication: {
             type: 'PLAIN',
@@ -80,8 +80,8 @@ test('maskConfiguration should mask sensitive data', () => {
     };
     expect(kafka.maskConfiguration()).toEqual({
         brokers: 'broker1:9000, broker2:9000',
-        topic: 'wud-image',
-        clientId: 'wud',
+        topic: 'hosaka-image',
+        clientId: 'hosaka',
         ssl: false,
         authentication: {
             type: 'PLAIN',
@@ -94,14 +94,14 @@ test('maskConfiguration should mask sensitive data', () => {
 test('maskConfiguration should not fail if no auth provided', () => {
     kafka.configuration = {
         brokers: 'broker1:9000, broker2:9000',
-        topic: 'wud-image',
-        clientId: 'wud',
+        topic: 'hosaka-image',
+        clientId: 'hosaka',
         ssl: false,
     };
     expect(kafka.maskConfiguration()).toEqual({
         brokers: 'broker1:9000, broker2:9000',
-        topic: 'wud-image',
-        clientId: 'wud',
+        topic: 'hosaka-image',
+        clientId: 'hosaka',
         ssl: false,
     });
 });
@@ -109,14 +109,14 @@ test('maskConfiguration should not fail if no auth provided', () => {
 test('initTrigger should init kafka client', async () => {
     kafka.configuration = {
         brokers: 'broker1:9000, broker2:9000',
-        topic: 'wud-image',
-        clientId: 'wud',
+        topic: 'hosaka-image',
+        clientId: 'hosaka',
         ssl: false,
     };
     await kafka.initTrigger();
     expect(KafkaClient).toHaveBeenCalledWith({
         brokers: ['broker1:9000', 'broker2:9000'],
-        clientId: 'wud',
+        clientId: 'hosaka',
         ssl: false,
     });
 });
@@ -124,8 +124,8 @@ test('initTrigger should init kafka client', async () => {
 test('initTrigger should init kafka client with auth when configured', async () => {
     kafka.configuration = {
         brokers: 'broker1:9000, broker2:9000',
-        topic: 'wud-image',
-        clientId: 'wud',
+        topic: 'hosaka-image',
+        clientId: 'hosaka',
         ssl: false,
         authentication: {
             type: 'PLAIN',
@@ -136,7 +136,7 @@ test('initTrigger should init kafka client with auth when configured', async () 
     await kafka.initTrigger();
     expect(KafkaClient).toHaveBeenCalledWith({
         brokers: ['broker1:9000', 'broker2:9000'],
-        clientId: 'wud',
+        clientId: 'hosaka',
         ssl: false,
         sasl: {
             mechanism: 'PLAIN',

--- a/app/triggers/providers/mqtt/Hass.js
+++ b/app/triggers/providers/mqtt/Hass.js
@@ -8,9 +8,9 @@ const {
 } = require('../../../event');
 const containerStore = require('../../../store/container');
 
-const HASS_DEVICE_ID = 'wud';
-const HASS_DEVICE_NAME = 'wud';
-const HASS_MANUFACTURER = 'wud';
+const HASS_DEVICE_ID = 'hosaka';
+const HASS_DEVICE_NAME = 'hosaka';
+const HASS_MANUFACTURER = 'hosaka';
 const HASS_ENTITY_VALUE_TEMPLATE = '{{ value_json.image_tag_value }}';
 const HASS_LATEST_VERSION_TEMPLATE = '{% if value_json.update_kind_kind == "digest" %}{{ value_json.result_digest[:15] }}{% else %}{{ value_json.result_tag }}{% endif %}';
 
@@ -24,7 +24,7 @@ function getHassEntityId(topic) {
 }
 
 /**
- * Get HA wud device info.
+ * Get HA hosaka device info.
  * @returns {*}
  */
 function getHaDevice() {
@@ -254,7 +254,7 @@ class Hass {
             name: name || entityId,
             device: getHaDevice(),
             icon: icon || sanitizeIcon('mdi:docker'),
-            entity_picture: 'https://github.com/getwud/wud/raw/main/docs/wud_logo.png',
+            entity_picture: 'https://github.com/nopoz/hosaka/raw/main/docs/wud_logo.png',
             state_topic: stateTopic,
             ...options,
         }), {

--- a/app/triggers/providers/mqtt/Hass.test.js
+++ b/app/triggers/providers/mqtt/Hass.test.js
@@ -36,14 +36,14 @@ test('publishDiscoveryMessage must publish a discovery message expected by HA', 
         object_id: 'my_state',
         name: 'My state',
         device: {
-            identifiers: ['wud'],
-            manufacturer: 'wud',
-            model: 'wud',
-            name: 'wud',
+            identifiers: ['hosaka'],
+            manufacturer: 'hosaka',
+            model: 'hosaka',
+            name: 'hosaka',
             sw_version: 'unknown',
         },
         icon: 'mdi:docker',
-        entity_picture: 'https://github.com/getwud/wud/raw/main/docs/wud_logo.png',
+        entity_picture: 'https://github.com/nopoz/hosaka/raw/main/docs/wud_logo.png',
         state_topic: 'my/state',
         myOption: true,
     }), { retain: true });
@@ -61,15 +61,15 @@ test('addContainerSensor must publish sensor discovery message expected by HA', 
         name: 'topic_watcher-name_container-name',
         device: {
             identifiers: [
-                'wud',
+                'hosaka',
             ],
-            manufacturer: 'wud',
-            model: 'wud',
-            name: 'wud',
+            manufacturer: 'hosaka',
+            model: 'hosaka',
+            name: 'hosaka',
             sw_version: 'unknown',
         },
         icon: 'mdi:docker',
-        entity_picture: 'https://github.com/getwud/wud/raw/main/docs/wud_logo.png',
+        entity_picture: 'https://github.com/nopoz/hosaka/raw/main/docs/wud_logo.png',
         state_topic: 'topic/watcher-name/container-name',
         force_update: true,
         value_template: '{{ value_json.image_tag_value }}',
@@ -101,10 +101,10 @@ test('updateContainerSensors must publish all sensors expected by HA', async () 
         object_id: 'topic_total_count',
         name: 'Total container count',
         device: {
-            identifiers: ['wud'], manufacturer: 'wud', model: 'wud', name: 'wud', sw_version: 'unknown',
+            identifiers: ['hosaka'], manufacturer: 'hosaka', model: 'hosaka', name: 'hosaka', sw_version: 'unknown',
         },
         icon: 'mdi:docker',
-        entity_picture: 'https://github.com/getwud/wud/raw/main/docs/wud_logo.png',
+        entity_picture: 'https://github.com/nopoz/hosaka/raw/main/docs/wud_logo.png',
         state_topic: 'topic/total_count',
     }), { retain: true });
 
@@ -113,10 +113,10 @@ test('updateContainerSensors must publish all sensors expected by HA', async () 
         object_id: 'topic_update_count',
         name: 'Total container update count',
         device: {
-            identifiers: ['wud'], manufacturer: 'wud', model: 'wud', name: 'wud', sw_version: 'unknown',
+            identifiers: ['hosaka'], manufacturer: 'hosaka', model: 'hosaka', name: 'hosaka', sw_version: 'unknown',
         },
         icon: 'mdi:docker',
-        entity_picture: 'https://github.com/getwud/wud/raw/main/docs/wud_logo.png',
+        entity_picture: 'https://github.com/nopoz/hosaka/raw/main/docs/wud_logo.png',
         state_topic: 'topic/update_count',
     }), { retain: true });
 
@@ -125,10 +125,10 @@ test('updateContainerSensors must publish all sensors expected by HA', async () 
         object_id: 'topic_update_status',
         name: 'Total container update status',
         device: {
-            identifiers: ['wud'], manufacturer: 'wud', model: 'wud', name: 'wud', sw_version: 'unknown',
+            identifiers: ['hosaka'], manufacturer: 'hosaka', model: 'hosaka', name: 'hosaka', sw_version: 'unknown',
         },
         icon: 'mdi:docker',
-        entity_picture: 'https://github.com/getwud/wud/raw/main/docs/wud_logo.png',
+        entity_picture: 'https://github.com/nopoz/hosaka/raw/main/docs/wud_logo.png',
         state_topic: 'topic/update_status',
         payload_on: 'true',
         payload_off: 'false',
@@ -139,10 +139,10 @@ test('updateContainerSensors must publish all sensors expected by HA', async () 
         object_id: 'topic_watcher-name_total_count',
         name: 'Watcher watcher-name container count',
         device: {
-            identifiers: ['wud'], manufacturer: 'wud', model: 'wud', name: 'wud', sw_version: 'unknown',
+            identifiers: ['hosaka'], manufacturer: 'hosaka', model: 'hosaka', name: 'hosaka', sw_version: 'unknown',
         },
         icon: 'mdi:docker',
-        entity_picture: 'https://github.com/getwud/wud/raw/main/docs/wud_logo.png',
+        entity_picture: 'https://github.com/nopoz/hosaka/raw/main/docs/wud_logo.png',
         state_topic: 'topic/watcher-name/total_count',
     }), { retain: true });
 
@@ -151,10 +151,10 @@ test('updateContainerSensors must publish all sensors expected by HA', async () 
         object_id: 'topic_watcher-name_update_count',
         name: 'Watcher watcher-name container update count',
         device: {
-            identifiers: ['wud'], manufacturer: 'wud', model: 'wud', name: 'wud', sw_version: 'unknown',
+            identifiers: ['hosaka'], manufacturer: 'hosaka', model: 'hosaka', name: 'hosaka', sw_version: 'unknown',
         },
         icon: 'mdi:docker',
-        entity_picture: 'https://github.com/getwud/wud/raw/main/docs/wud_logo.png',
+        entity_picture: 'https://github.com/nopoz/hosaka/raw/main/docs/wud_logo.png',
         state_topic: 'topic/watcher-name/update_count',
     }), { retain: true });
 
@@ -163,10 +163,10 @@ test('updateContainerSensors must publish all sensors expected by HA', async () 
         object_id: 'topic_watcher-name_update_status',
         name: 'Watcher watcher-name container update status',
         device: {
-            identifiers: ['wud'], manufacturer: 'wud', model: 'wud', name: 'wud', sw_version: 'unknown',
+            identifiers: ['hosaka'], manufacturer: 'hosaka', model: 'hosaka', name: 'hosaka', sw_version: 'unknown',
         },
         icon: 'mdi:docker',
-        entity_picture: 'https://github.com/getwud/wud/raw/main/docs/wud_logo.png',
+        entity_picture: 'https://github.com/nopoz/hosaka/raw/main/docs/wud_logo.png',
         state_topic: 'topic/watcher-name/update_status',
         payload_on: 'true',
         payload_off: 'false',
@@ -204,10 +204,10 @@ test('updateWatcherSensors must publish all watcher sensor messages expected by 
         object_id: 'topic_watcher-name_running',
         name: 'Watcher watcher-name running status',
         device: {
-            identifiers: ['wud'], manufacturer: 'wud', model: 'wud', name: 'wud', sw_version: 'unknown',
+            identifiers: ['hosaka'], manufacturer: 'hosaka', model: 'hosaka', name: 'hosaka', sw_version: 'unknown',
         },
         icon: 'mdi:docker',
-        entity_picture: 'https://github.com/getwud/wud/raw/main/docs/wud_logo.png',
+        entity_picture: 'https://github.com/nopoz/hosaka/raw/main/docs/wud_logo.png',
         state_topic: 'topic/watcher-name/running',
         payload_on: 'true',
         payload_off: 'false',

--- a/app/triggers/providers/mqtt/Mqtt.js
+++ b/app/triggers/providers/mqtt/Mqtt.js
@@ -8,7 +8,7 @@ const {
 } = require('../../../event');
 const { flatten } = require('../../../model/container');
 
-const containerDefaultTopic = 'wud/container';
+const containerDefaultTopic = 'hosaka/container';
 const hassDefaultPrefix = 'homeassistant';
 
 /**
@@ -35,7 +35,7 @@ class Mqtt extends Trigger {
                 scheme: ['mqtt', 'mqtts', 'tcp', 'tls', 'ws', 'wss'],
             }).required(),
             topic: this.joi.string().default(containerDefaultTopic),
-            clientid: this.joi.string().default(`wud_${Math.random().toString(16).substring(2, 10)}`),
+            clientid: this.joi.string().default(`hosaka_${Math.random().toString(16).substring(2, 10)}`),
             user: this.joi.string(),
             password: this.joi.string(),
             hass: this.joi.object({

--- a/app/triggers/providers/mqtt/Mqtt.test.js
+++ b/app/triggers/providers/mqtt/Mqtt.test.js
@@ -10,8 +10,8 @@ mqtt.log = log;
 
 const configurationValid = {
     url: 'mqtt://host:1883',
-    topic: 'wud/container',
-    clientid: 'wud',
+    topic: 'hosaka/container',
+    clientid: 'hosaka',
     hass: {
         discovery: false,
         enabled: false,
@@ -46,7 +46,7 @@ test('validateConfiguration should return validated configuration when valid', (
 test('validateConfiguration should apply_default_configuration', () => {
     const validatedConfiguration = mqtt.validateConfiguration({
         url: configurationValid.url,
-        clientid: 'wud',
+        clientid: 'hosaka',
     });
     expect(validatedConfiguration).toStrictEqual(configurationValid);
 });
@@ -64,7 +64,7 @@ test('maskConfiguration should mask sensitive data', () => {
     mqtt.configuration = {
         password: 'password',
         url: 'mqtt://host:1883',
-        topic: 'wud/container',
+        topic: 'hosaka/container',
         hass: {
             discovery: false,
             enabled: false,
@@ -78,7 +78,7 @@ test('maskConfiguration should mask sensitive data', () => {
             prefix: 'homeassistant',
         },
         password: 'p******d',
-        topic: 'wud/container',
+        topic: 'hosaka/container',
         url: 'mqtt://host:1883',
     });
 });
@@ -88,7 +88,7 @@ test('initTrigger should init Mqtt client', async () => {
         ...configurationValid,
         user: 'user',
         password: 'password',
-        clientid: 'wud',
+        clientid: 'hosaka',
         hass: {
             enabled: true,
             discovery: true,
@@ -98,7 +98,7 @@ test('initTrigger should init Mqtt client', async () => {
     const spy = jest.spyOn(mqttClient, 'connectAsync');
     await mqtt.initTrigger();
     expect(spy).toHaveBeenCalledWith('mqtt://host:1883', {
-        clientId: 'wud',
+        clientId: 'hosaka',
         username: 'user',
         password: 'password',
         rejectUnauthorized: true,
@@ -107,7 +107,7 @@ test('initTrigger should init Mqtt client', async () => {
 
 test('trigger should format json message payload as expected', async () => {
     mqtt.configuration = {
-        topic: 'wud/container',
+        topic: 'hosaka/container',
     };
     mqtt.client = {
         publish: (topic, message) => ({

--- a/app/triggers/providers/script/Script.js
+++ b/app/triggers/providers/script/Script.js
@@ -133,15 +133,15 @@ async install(container) {
         console.log(`Setting up Docker API for watcher: ${watcherName}`);
         
         try {
-            const envPrefix = `WUD_WATCHER_${watcherName.toUpperCase()}_`;
+            const envPrefix = `HOSAKA_WATCHER_${watcherName.toUpperCase()}_`;
             console.log(`Looking for environment variables with prefix: ${envPrefix}`);
 
             // Log all relevant environment variables for debugging
             const relevantEnvVars = Object.entries(process.env)
-                .filter(([key]) => key.startsWith('WUD_WATCHER'))
+                .filter(([key]) => key.startsWith('HOSAKA_WATCHER'))
                 .map(([key, value]) => `${key}=${value}`);
-            
-            console.log('Available WUD_WATCHER environment variables:', relevantEnvVars);
+
+            console.log('Available HOSAKA_WATCHER environment variables:', relevantEnvVars);
 
             const socketPath = process.env[`${envPrefix}SOCKET`];
             const host = process.env[`${envPrefix}HOST`];
@@ -311,7 +311,7 @@ async install(container) {
         }
         
         // Add artificial delay for local watcher to match remote behavior
-        const envPrefix = `WUD_WATCHER_${originalWatcher.toUpperCase()}_`;
+        const envPrefix = `HOSAKA_WATCHER_${originalWatcher.toUpperCase()}_`;
         const socketPath = process.env[`${envPrefix}SOCKET`];
         if (socketPath) {  // This indicates a local watcher
             console.log(`Adding delay for local watcher ${originalWatcher}`);

--- a/app/watchers/providers/docker/Docker.js
+++ b/app/watchers/providers/docker/Docker.js
@@ -230,7 +230,7 @@ function getRepoDigest(containerImage) {
 
 /**
  * Return true if container must be watched.
- * @param wudWatchLabelValue the value of the wud.watch label
+ * @param wudWatchLabelValue the value of the hosaka.watch label
  * @param watchByDefault true if containers must be watched by default
  * @returns {boolean}
  */
@@ -240,7 +240,7 @@ function isContainerToWatch(wudWatchLabelValue, watchByDefault) {
 
 /**
  * Return true if container digest must be watched.
- * @param wudWatchDigestLabelValue the value of wud.watch.digest label
+ * @param wudWatchDigestLabelValue the value of hosaka.watch.digest label
  * @param isSemver if image is semver
  * @returns {boolean|*}
  */
@@ -288,7 +288,7 @@ class Docker extends Component {
         this.eventReconnectDelay = 0;
         this.initWatcher();
         if (this.configuration.watchdigest !== undefined) {
-            this.log.warn('WUD_WATCHER_{watcher_name}_WATCHDIGEST environment variable is deprecated and won\'t be supported in upcoming versions');
+            this.log.warn('HOSAKA_WATCHER_{watcher_name}_WATCHDIGEST environment variable is deprecated and won\'t be supported in upcoming versions');
         }
         this.log.info(`Cron scheduled (${this.configuration.cron})`);
         this.watchCron = cron.schedule(this.configuration.cron, () => this.watchFromCron());

--- a/app/watchers/providers/docker/Docker.js
+++ b/app/watchers/providers/docker/Docker.js
@@ -7,14 +7,14 @@ const debounce = require('just-debounce');
 const { parse: parseSemver, isGreater: isGreaterSemver, transform: transformTag } = require('../../../tag');
 const event = require('../../../event');
 const {
-    wudWatch,
-    wudTagInclude,
-    wudTagExclude,
-    wudTagTransform,
-    wudWatchDigest,
-    wudLinkTemplate,
-    wudDisplayName,
-    wudDisplayIcon,
+    hosakaWatch,
+    hosakaTagInclude,
+    hosakaTagExclude,
+    hosakaTagTransform,
+    hosakaWatchDigest,
+    hosakaLinkTemplate,
+    hosakaDisplayName,
+    hosakaDisplayIcon,
 } = require('./label');
 const storeContainer = require('../../../store/container');
 const log = require('../../../log');
@@ -230,30 +230,30 @@ function getRepoDigest(containerImage) {
 
 /**
  * Return true if container must be watched.
- * @param wudWatchLabelValue the value of the hosaka.watch label
+ * @param hosakaWatchLabelValue the value of the hosaka.watch label
  * @param watchByDefault true if containers must be watched by default
  * @returns {boolean}
  */
-function isContainerToWatch(wudWatchLabelValue, watchByDefault) {
-    return wudWatchLabelValue !== undefined && wudWatchLabelValue !== '' ? wudWatchLabelValue.toLowerCase() === 'true' : watchByDefault;
+function isContainerToWatch(hosakaWatchLabelValue, watchByDefault) {
+    return hosakaWatchLabelValue !== undefined && hosakaWatchLabelValue !== '' ? hosakaWatchLabelValue.toLowerCase() === 'true' : watchByDefault;
 }
 
 /**
  * Return true if container digest must be watched.
- * @param wudWatchDigestLabelValue the value of hosaka.watch.digest label
+ * @param hosakaWatchDigestLabelValue the value of hosaka.watch.digest label
  * @param isSemver if image is semver
  * @returns {boolean|*}
  */
-function isDigestToWatch(wudWatchDigestLabelValue, isSemver) {
+function isDigestToWatch(hosakaWatchDigestLabelValue, isSemver) {
     let result = false;
     if (isSemver) {
-        if (wudWatchDigestLabelValue !== undefined && wudWatchDigestLabelValue !== '') {
-            result = wudWatchDigestLabelValue.toLowerCase() === 'true';
+        if (hosakaWatchDigestLabelValue !== undefined && hosakaWatchDigestLabelValue !== '') {
+            result = hosakaWatchDigestLabelValue.toLowerCase() === 'true';
         }
     } else {
         result = true;
-        if (wudWatchDigestLabelValue !== undefined && wudWatchDigestLabelValue !== '') {
-            result = wudWatchDigestLabelValue.toLowerCase() === 'true';
+        if (hosakaWatchDigestLabelValue !== undefined && hosakaWatchDigestLabelValue !== '') {
+            result = hosakaWatchDigestLabelValue.toLowerCase() === 'true';
         }
     }
     return result;
@@ -629,19 +629,19 @@ async watchContainer(container, skipRegistryCheck = false) {
         const filteredContainers = containers
             .filter(
                 (container) => isContainerToWatch(
-                    container.Labels[wudWatch],
+                    container.Labels[hosakaWatch],
                     this.configuration.watchbydefault,
                 ),
             );
         const containerPromises = filteredContainers
             .map((container) => this.addImageDetailsToContainer(
                 container,
-                container.Labels[wudTagInclude],
-                container.Labels[wudTagExclude],
-                container.Labels[wudTagTransform],
-                container.Labels[wudLinkTemplate],
-                container.Labels[wudDisplayName],
-                container.Labels[wudDisplayIcon],
+                container.Labels[hosakaTagInclude],
+                container.Labels[hosakaTagExclude],
+                container.Labels[hosakaTagTransform],
+                container.Labels[hosakaLinkTemplate],
+                container.Labels[hosakaDisplayName],
+                container.Labels[hosakaDisplayIcon],
             ));
         let containersWithImage = await Promise.all(containerPromises);
 
@@ -846,12 +846,12 @@ async watchContainer(container, skipRegistryCheck = false) {
         const parsedTag = parseSemver(transformTag(transformTags, tagName));
         const isSemver = parsedTag !== null && parsedTag !== undefined;
         const watchDigest = isDigestToWatch(
-            container.Labels[wudWatchDigest],
+            container.Labels[hosakaWatchDigest],
             isSemver,
         );
         
         if (!isSemver && !watchDigest) {
-            this.log.warn('Image is not a semver and digest watching is disabled so wud won\'t report any update. Please review the configuration to enable digest watching for this container or exclude this container from being watched');
+            this.log.warn('Image is not a semver and digest watching is disabled so Hosaka won\'t report any update. Please review the configuration to enable digest watching for this container or exclude this container from being watched');
         }
 
         return normalizeContainer({

--- a/app/watchers/providers/docker/Docker.test.js
+++ b/app/watchers/providers/docker/Docker.test.js
@@ -712,7 +712,7 @@ const containerToWatchTestCases = [{
 }];
 
 test.each(containerToWatchTestCases)(
-    'isContainerToWatch should return $result when wud.watch label = $label and watchbydefault = $default ',
+    'isContainerToWatch should return $result when hosaka.watch label = $label and watchbydefault = $default ',
     (item) => {
         const isContainerToWatch = Docker.__get__('isContainerToWatch');
         expect(isContainerToWatch(item.label, item.default)).toEqual(item.result);
@@ -754,7 +754,7 @@ const digestToWatchTestCases = [{
 }];
 
 test.each(digestToWatchTestCases)(
-    'isDigestToWatch should return $result when wud.watch label = $label and semver = semver ',
+    'isDigestToWatch should return $result when hosaka.watch label = $label and semver = semver ',
     (item) => {
         const isDigestToWatch = Docker.__get__('isDigestToWatch');
         expect(isDigestToWatch(item.label, item.semver)).toEqual(item.result);

--- a/app/watchers/providers/docker/label.js
+++ b/app/watchers/providers/docker/label.js
@@ -6,41 +6,41 @@ module.exports = {
     /**
      * Should the container be tracked? (true | false).
      */
-    wudWatch: 'hosaka.watch',
+    hosakaWatch: 'hosaka.watch',
 
     /**
      * Optional regex indicating what tags to consider.
      */
-    wudTagInclude: 'hosaka.tag.include',
+    hosakaTagInclude: 'hosaka.tag.include',
 
     /**
      * Optional regex indicating what tags to not consider.
      */
-    wudTagExclude: 'hosaka.tag.exclude',
+    hosakaTagExclude: 'hosaka.tag.exclude',
 
     /**
      * Optional transform function to apply to the tag.
      */
-    wudTagTransform: 'hosaka.tag.transform',
+    hosakaTagTransform: 'hosaka.tag.transform',
 
     /**
      * Should container digest be tracked? (true | false).
      */
-    wudWatchDigest: 'hosaka.watch.digest',
+    hosakaWatchDigest: 'hosaka.watch.digest',
 
     /**
      * Optional templated string pointing to a browsable link.
      */
-    wudLinkTemplate: 'hosaka.link.template',
+    hosakaLinkTemplate: 'hosaka.link.template',
 
     /**
      * Optional friendly name to display.
      */
-    wudDisplayName: 'hosaka.display.name',
+    hosakaDisplayName: 'hosaka.display.name',
 
     /**
      * Optional friendly icon to display.
      */
-    wudDisplayIcon: 'hosaka.display.icon',
+    hosakaDisplayIcon: 'hosaka.display.icon',
 
 };

--- a/app/watchers/providers/docker/label.js
+++ b/app/watchers/providers/docker/label.js
@@ -1,46 +1,46 @@
 /**
- * WUD supported Docker labels.
+ * Hosaka supported Docker labels.
  */
 module.exports = {
 
     /**
      * Should the container be tracked? (true | false).
      */
-    wudWatch: 'wud.watch',
+    wudWatch: 'hosaka.watch',
 
     /**
      * Optional regex indicating what tags to consider.
      */
-    wudTagInclude: 'wud.tag.include',
+    wudTagInclude: 'hosaka.tag.include',
 
     /**
      * Optional regex indicating what tags to not consider.
      */
-    wudTagExclude: 'wud.tag.exclude',
+    wudTagExclude: 'hosaka.tag.exclude',
 
     /**
      * Optional transform function to apply to the tag.
      */
-    wudTagTransform: 'wud.tag.transform',
+    wudTagTransform: 'hosaka.tag.transform',
 
     /**
      * Should container digest be tracked? (true | false).
      */
-    wudWatchDigest: 'wud.watch.digest',
+    wudWatchDigest: 'hosaka.watch.digest',
 
     /**
      * Optional templated string pointing to a browsable link.
      */
-    wudLinkTemplate: 'wud.link.template',
+    wudLinkTemplate: 'hosaka.link.template',
 
     /**
      * Optional friendly name to display.
      */
-    wudDisplayName: 'wud.display.name',
+    wudDisplayName: 'hosaka.display.name',
 
     /**
      * Optional friendly icon to display.
      */
-    wudDisplayIcon: 'wud.display.icon',
+    wudDisplayIcon: 'hosaka.display.icon',
 
 };

--- a/docker-compose.example.yml
+++ b/docker-compose.example.yml
@@ -1,44 +1,44 @@
-# Reference docker-compose for What's Up Docker (WUD).
+# Reference docker-compose for Hosaka.
 # Watches a Docker host for container image updates and triggers notify/update
 # actions. Copy to docker-compose.yml (kept untracked), adjust the env vars and
 # labels, then `docker compose up -d`. Full config reference: see the docs/ dir.
 #
 # This stack talks to Docker through a read-only socket proxy rather than
-# mounting the socket directly into WUD. Every WUD_* value below is an example.
+# mounting the socket directly into Hosaka. Every HOSAKA_* value below is an example.
 
 services:
-  whatsupdocker:
-    image: ghcr.io/nopoz/wud:latest
-    container_name: whatsupdocker
+  hosaka:
+    image: ghcr.io/nopoz/hosaka:latest
+    container_name: hosaka
     restart: unless-stopped
     depends_on:
       dockerproxy:
         condition: service_healthy
     environment:
       - TZ=Etc/UTC
-      - WUD_LOG_LEVEL=info            # error | info | debug | trace
-      - WUD_SERVER_PORT=3000
+      - HOSAKA_LOG_LEVEL=info            # error | info | debug | trace
+      - HOSAKA_SERVER_PORT=3000
 
       # Watchers: where to look for running containers.
       # The local watcher points at the socket proxy below. Add remote hosts by
-      # declaring extra watchers, e.g. WUD_WATCHER_<NAME>_HOST.
-      - WUD_WATCHER_LOCAL_HOST=dockerproxy
-      # - WUD_WATCHER_REMOTE_HOST=192.0.2.10
+      # declaring extra watchers, e.g. HOSAKA_WATCHER_<NAME>_HOST.
+      - HOSAKA_WATCHER_LOCAL_HOST=dockerproxy
+      # - HOSAKA_WATCHER_REMOTE_HOST=192.0.2.10
 
       # Registries: credentials for private repositories (optional).
-      # - WUD_REGISTRY_HUB_LOGIN=your-docker-hub-user
-      # - WUD_REGISTRY_HUB_PASSWORD=your-docker-hub-token
+      # - HOSAKA_REGISTRY_HUB_LOGIN=your-docker-hub-user
+      # - HOSAKA_REGISTRY_HUB_PASSWORD=your-docker-hub-token
 
       # Triggers: actions to run when an update is found (optional).
-      # - WUD_TRIGGER_HTTP_EXAMPLE_URL=https://example.com/webhook
-      # - WUD_TRIGGER_PUSHOVER_EXAMPLE_TOKEN=your-app-token
-      # - WUD_TRIGGER_PUSHOVER_EXAMPLE_USER=your-user-key
+      # - HOSAKA_TRIGGER_HTTP_EXAMPLE_URL=https://example.com/webhook
+      # - HOSAKA_TRIGGER_PUSHOVER_EXAMPLE_TOKEN=your-app-token
+      # - HOSAKA_TRIGGER_PUSHOVER_EXAMPLE_USER=your-user-key
     volumes:
-      - ./store:/store               # persisted container state (wud.json)
+      - ./store:/store               # persisted container state (hosaka.json)
     ports:
       - 3000:3000
     labels:
-      wud.watch: false               # don't watch WUD itself
+      hosaka.watch: false               # don't watch Hosaka itself
     healthcheck:
       test: wget --spider http://127.0.0.1:3000/ || exit 1
       interval: 30s
@@ -46,14 +46,14 @@ services:
       retries: 3
       start_period: 30s
 
-  # Read-only Docker socket proxy: exposes just the endpoints WUD needs.
+  # Read-only Docker socket proxy: exposes just the endpoints Hosaka needs.
   dockerproxy:
     image: ghcr.io/tecnativa/docker-socket-proxy:latest
-    container_name: wud_dockerproxy
+    container_name: hosaka_dockerproxy
     restart: unless-stopped
     environment:
       - CONTAINERS=1                 # list/inspect containers
-      - IMAGES=1                     # inspect images (required by WUD)
+      - IMAGES=1                     # inspect images (required by Hosaka)
       - POST=0                       # read-only: block all write operations
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock:ro

--- a/e2e/config/index.js
+++ b/e2e/config/index.js
@@ -1,7 +1,7 @@
 module.exports = {
-    protocol: process.env.WUD_PROTOCOL || 'http',
-    host: process.env.WUD_HOST || 'localhost',
-    port: process.env.WUD_PORT || 3000,
-    username: process.env.WUD_USERNAME || 'john',
-    password: process.env.WUD_PASSWORD || 'doe',
+    protocol: process.env.HOSAKA_PROTOCOL || 'http',
+    host: process.env.HOSAKA_HOST || 'localhost',
+    port: process.env.HOSAKA_PORT || 3000,
+    username: process.env.HOSAKA_USERNAME || 'john',
+    password: process.env.HOSAKA_PASSWORD || 'doe',
 };

--- a/e2e/features/api-app.feature
+++ b/e2e/features/api-app.feature
@@ -1,6 +1,6 @@
-Feature: WUD App infos API Exposure
-  Scenario: WUD must allow to get App infos
+Feature: Hosaka App infos API Exposure
+  Scenario: Hosaka must allow to get App infos
     When I GET /api/app
     Then response code should be 200
     And response body should be valid json
-    And response body path $.name should be wud
+    And response body path $.name should be hosaka

--- a/e2e/features/api-auth.feature
+++ b/e2e/features/api-auth.feature
@@ -1,6 +1,6 @@
-Feature: WUD auth API Exposure
+Feature: Hosaka auth API Exposure
 
-  Scenario: WUD must allow to get all available strategies
+  Scenario: Hosaka must allow to get all available strategies
     When I GET /auth/strategies
     Then response code should be 200
     And response body should be valid json
@@ -8,19 +8,19 @@ Feature: WUD auth API Exposure
     And response body path $[0].type should be basic
     And response body path $[0].name should be Login
 
-  Scenario: WUD must allow to login with basic auth
+  Scenario: Hosaka must allow to login with basic auth
     When I POST to /auth/login
     Then response code should be 200
     And response body should be valid json
     And response body path $.username should be john
 
-  Scenario: WUD must allow to get current user
+  Scenario: Hosaka must allow to get current user
     When I GET /auth/user
     Then response code should be 200
     And response body should be valid json
     And response body path $.username should be john
 
-  Scenario: WUD must allow to logout
+  Scenario: Hosaka must allow to logout
     When I POST to /auth/logout
     Then response code should be 200
     And response body should be valid json

--- a/e2e/features/api-authentications.feature
+++ b/e2e/features/api-authentications.feature
@@ -1,6 +1,6 @@
-Feature: WUD Authentications API Exposure
+Feature: Hosaka Authentications API Exposure
 
-  Scenario: WUD must allow to get all Authentications state
+  Scenario: Hosaka must allow to get all Authentications state
     When I GET /api/authentications
     Then response code should be 200
     And response body should be valid json
@@ -11,7 +11,7 @@ Feature: WUD Authentications API Exposure
     And response body path $[0].configuration.user should be john
     And response body path $[0].configuration.hash should be .\*.*.
 
-  Scenario: WUD must allow to get specific Authentication state
+  Scenario: Hosaka must allow to get specific Authentication state
     When I GET /api/authentications/authentication.basic.john
     Then response code should be 200
     And response body should be valid json

--- a/e2e/features/api-container.feature
+++ b/e2e/features/api-container.feature
@@ -1,10 +1,10 @@
-Feature: WUD Container API Exposure
+Feature: Hosaka Container API Exposure
     When I GET /api/containers
     Then response code should be 200
     And response body should be valid json
     And response body path $ should be of type array with length 19
 
-  Scenario Outline: WUD must allow to get all containers
+  Scenario Outline: Hosaka must allow to get all containers
     When I GET /api/containers
     Then response code should be 200
     And response body should be valid json
@@ -39,7 +39,7 @@ Feature: WUD Container API Exposure
       | 18    | lscr     | lscr_radarr              | https://lscr.io/v2                                      | linuxserver/radarr                  | 3.2.1.5070-ls105   | 5.12.2.9335-ls242  | true            |
       | 19    | quay     | quay_prometheus          | https://quay.io/v2                                      | prometheus/prometheus               | v2.52.0            | v2.54.1            | true            |
 
-  Scenario: WUD must allow to get a container with semver
+  Scenario: Hosaka must allow to get a container with semver
     Given I GET /api/containers
     And I store the value of body path $[0].id as containerId in scenario scope
     When I GET /api/containers/`containerId`
@@ -57,7 +57,7 @@ Feature: WUD Container API Exposure
     And response body path $.result.tag should be 2.0.0
     And response body path $.updateAvailable should be true
 
-  Scenario: WUD must allow to get a container with digest
+  Scenario: Hosaka must allow to get a container with digest
     Given I GET /api/containers
     And I store the value of body path $[8].id as containerId in scenario scope
     When I GET /api/containers/`containerId`
@@ -78,7 +78,7 @@ Feature: WUD Container API Exposure
     And response body path $.result.digest should be sha256:367678a80c0be120f67f3adfccc2f408bd2c1319ed98c1975ac88e750d0efe26
     And response body path $.updateAvailable should be true
 
-  Scenario: WUD must allow to get a container with its link
+  Scenario: Hosaka must allow to get a container with its link
     Given I GET /api/containers
     And I store the value of body path $[5].id as containerId in scenario scope
     When I GET /api/containers/`containerId`
@@ -87,7 +87,7 @@ Feature: WUD Container API Exposure
     And response body path $.link should be https://github.com/home-assistant/core/releases/tag/2021.6.1
     And response body path $.result.link should be https://github.com/home-assistant/core/releases/tag/2024.10.3
 
-  Scenario: WUD must allow to trigger a watch on a container
+  Scenario: Hosaka must allow to trigger a watch on a container
     Given I GET /api/containers
     And I store the value of body path $[0].id as containerId in scenario scope
     When I POST to /api/containers/`containerId`/watch

--- a/e2e/features/api-log.feature
+++ b/e2e/features/api-log.feature
@@ -1,5 +1,5 @@
-Feature: WUD Log API Exposure
-  Scenario: WUD must allow to get Log state
+Feature: Hosaka Log API Exposure
+  Scenario: Hosaka must allow to get Log state
     When I GET /api/log
     Then response code should be 200
     And response body should be valid json

--- a/e2e/features/api-not-found.feature
+++ b/e2e/features/api-not-found.feature
@@ -1,5 +1,5 @@
-Feature: WUD API 404 management
+Feature: Hosaka API 404 management
 
-  Scenario: WUD must respond 404 if no API endpoint matches
+  Scenario: Hosaka must respond 404 if no API endpoint matches
     When I GET /api/nowhere
     Then response code should be 404

--- a/e2e/features/api-registry.feature
+++ b/e2e/features/api-registry.feature
@@ -1,6 +1,6 @@
-Feature: WUD Registry API Exposure
+Feature: Hosaka Registry API Exposure
 
-  Scenario: WUD must allow to get all Registries
+  Scenario: Hosaka must allow to get all Registries
     When I GET /api/registries
     Then response code should be 200
     And response body should be valid json
@@ -22,7 +22,7 @@ Feature: WUD Registry API Exposure
     And response body path $[2].id should be gcr
     And response body path $[2].type should be gcr
     And response body path $[2].name should be gcr
-    And response body path $[2].configuration.clientemail should be gcr@wud-test.iam.gserviceaccount.com
+    And response body path $[2].configuration.clientemail should be gcr@hosaka-test.iam.gserviceaccount.com
     And response body path $[2].configuration.privatekey should be .\*.*.
 
     And response body path $[3].id should be ghcr
@@ -45,7 +45,7 @@ Feature: WUD Registry API Exposure
     And response body path $[7].type should be quay
     And response body path $[7].name should be quay
 
-  Scenario: WUD must allow to get specific Registry state
+  Scenario: Hosaka must allow to get specific Registry state
     When I GET /api/registries/acr
     Then response code should be 200
     And response body should be valid json

--- a/e2e/features/api-store.feature
+++ b/e2e/features/api-store.feature
@@ -1,7 +1,7 @@
-Feature: WUD Store API Exposure
-  Scenario: WUD must allow to get Store state
+Feature: Hosaka Store API Exposure
+  Scenario: Hosaka must allow to get Store state
     When I GET /api/store
     Then response code should be 200
     And response body should be valid json
     And response body path $.configuration.path should be .store
-    And response body path $.configuration.file should be wud.json
+    And response body path $.configuration.file should be hosaka.json

--- a/e2e/features/api-trigger.feature
+++ b/e2e/features/api-trigger.feature
@@ -1,6 +1,6 @@
-Feature: WUD Trigger API Exposure
+Feature: Hosaka Trigger API Exposure
 
-  Scenario: WUD must allow to get all Triggers state
+  Scenario: Hosaka must allow to get all Triggers state
     When I GET /api/triggers
     Then response code should be 200
     And response body should be valid json
@@ -15,7 +15,7 @@ Feature: WUD Trigger API Exposure
     And response body path $[0].configuration.batchtitle should be \$\{count\} updates available
     And response body path $[0].configuration.mock should be mock
 
-  Scenario: WUD must allow to get specific Triggers state
+  Scenario: Hosaka must allow to get specific Triggers state
     When I GET /api/triggers/trigger.mock.example
     Then response code should be 200
     And response body should be valid json

--- a/e2e/features/api-watcher.feature
+++ b/e2e/features/api-watcher.feature
@@ -1,6 +1,6 @@
-Feature: WUD Watcher API Exposure
+Feature: Hosaka Watcher API Exposure
 
-  Scenario: WUD must allow to get all Watchers state
+  Scenario: Hosaka must allow to get all Watchers state
     When I GET /api/watchers
     Then response code should be 200
     And response body should be valid json
@@ -12,7 +12,7 @@ Feature: WUD Watcher API Exposure
     And response body path $[0].configuration.cron should be 0 * * * *
     And response body path $[0].configuration.watchbydefault should be false
 
-  Scenario: WUD must allow to get specific Watcher state
+  Scenario: Hosaka must allow to get specific Watcher state
     When I GET /api/watchers/watcher.docker.local
     Then response code should be 200
     And response body should be valid json

--- a/e2e/features/health.feature
+++ b/e2e/features/health.feature
@@ -1,5 +1,5 @@
 Feature: Healthcheck exposure
-    Scenario: WUD must expose health endpoint
+    Scenario: Hosaka must expose health endpoint
     When I GET /health
     Then response code should be 200
     And response body should be valid json

--- a/e2e/features/prometheus.feature
+++ b/e2e/features/prometheus.feature
@@ -1,16 +1,16 @@
 Feature: Prometheus exposure
 
-  Scenario: WUD must expose prometheus metrics
+  Scenario: Hosaka must expose prometheus metrics
     When I GET /metrics
     Then response code should be 200
-    And response body should contain wud_watcher_total
-    And response body should contain wud_registry_response
-    And response body should contain wud_trigger_count
+    And response body should contain hosaka_watcher_total
+    And response body should contain hosaka_registry_response
+    And response body should contain hosaka_trigger_count
     And response body should contain process_cpu_user_seconds_total
     And response body should contain nodejs_eventloop_lag_seconds
-    And response body should contain wud_containers{id=
+    And response body should contain hosaka_containers{id=
 
-  Scenario Outline: WUD must expose watched containers
+  Scenario Outline: Hosaka must expose watched containers
     When I GET /metrics
     Then response code should be 200
     And response body should contain name="<containerName>"

--- a/e2e/features/ui.feature
+++ b/e2e/features/ui.feature
@@ -1,11 +1,11 @@
-Feature: WUD UI Exposure
+Feature: Hosaka UI Exposure
 
-  Scenario: WUD must serve the ui
+  Scenario: Hosaka must serve the ui
     When I GET /
     Then response code should be 200
     And response header Content-Type should be text/html
 
-  Scenario: WUD must redirect to the ui if resource not found
+  Scenario: Hosaka must redirect to the ui if resource not found
     When I GET /nowhere
     Then response code should be 200
     And response header Content-Type should be text/html

--- a/e2e/package.json
+++ b/e2e/package.json
@@ -1,14 +1,14 @@
 {
-  "name": "wud-e2e",
+  "name": "hosaka-e2e",
   "version": "1.0.0",
-  "description": "WUD - e2e",
+  "description": "Hosaka - e2e",
   "main": "index.js",
   "scripts": {
     "lint": "eslint '**/*.js'",
     "cucumber": "cucumber-js **/*.feature"
   },
   "author": "fmartinou",
-  "repository": "getwud/wud",
+  "repository": "nopoz/hosaka",
   "license": "MIT",
   "dependencies": {
     "@cucumber/cucumber": "11.0.1",

--- a/test/prometheus/prometheus.yml
+++ b/test/prometheus/prometheus.yml
@@ -10,7 +10,7 @@ scrape_configs:
     static_configs:
       - targets: ['127.0.0.1:9090']
 
-  - job_name: 'wud'
+  - job_name: 'hosaka'
     metrics_path: '/metrics'
     scrape_interval: 5s
     static_configs:

--- a/test/test.sh
+++ b/test/test.sh
@@ -16,14 +16,14 @@ docker tag nginx:1.10-alpine 229211676173.dkr.ecr.eu-west-1.amazonaws.com/sub/te
 docker tag nginx:1.10-alpine 229211676173.dkr.ecr.eu-west-1.amazonaws.com/sub/sub/test:1.0.0
 
 # GCR
-docker tag nginx:1.10-alpine gcr.io/wud-test/test:1.0.0
-docker tag nginx:1.10-alpine gcr.io/wud-test/sub/test:1.0.0
-docker tag nginx:1.10-alpine gcr.io/wud-test/sub/sub/test:1.0.0
+docker tag nginx:1.10-alpine gcr.io/hosaka-test/test:1.0.0
+docker tag nginx:1.10-alpine gcr.io/hosaka-test/sub/test:1.0.0
+docker tag nginx:1.10-alpine gcr.io/hosaka-test/sub/sub/test:1.0.0
 
 # ACR
-docker tag nginx:1.10-alpine wudtest.azurecr.io/test:1.0.0
-docker tag nginx:1.10-alpine wudtest.azurecr.io/sub/test:1.0.0
-docker tag nginx:1.10-alpine wudtest.azurecr.io/sub/sub/test:1.0.0
+docker tag nginx:1.10-alpine hosakatest.azurecr.io/test:1.0.0
+docker tag nginx:1.10-alpine hosakatest.azurecr.io/sub/test:1.0.0
+docker tag nginx:1.10-alpine hosakatest.azurecr.io/sub/sub/test:1.0.0
 
 docker-compose down --remove-orphans
 

--- a/ui/index.html
+++ b/ui/index.html
@@ -5,7 +5,7 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta name="viewport" content="width=device-width,initial-scale=1.0" />
     <link rel="icon" href="/favicon.ico" />
-    <title>What's up Docker?</title>
+    <title>Hosaka</title>
     <style>
       body {
         /* Prevent page to be horizontally scrollable */
@@ -16,7 +16,7 @@
   <body>
     <noscript>
       <strong
-        >We're sorry but What's up Docker? doesn't work properly without
+        >We're sorry but Hosaka doesn't work properly without
         JavaScript enabled. Please enable it to continue.</strong
       >
     </noscript>

--- a/ui/package.json
+++ b/ui/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "wud-ui",
+  "name": "hosaka-ui",
   "version": "0.1.0",
   "private": true,
   "type": "module",

--- a/ui/src/components/AppFooter.vue
+++ b/ui/src/components/AppFooter.vue
@@ -1,7 +1,7 @@
 <template>
   <v-footer app theme="dark" height="30px" class="pa-0">
     <v-col cols="12" class="text-center text-caption pa-0">
-      {{ new Date().getFullYear() }} — WUD (version {{ version }})
+      {{ new Date().getFullYear() }} — Hosaka (version {{ version }})
     </v-col>
   </v-footer>
 </template>

--- a/ui/vite.config.js
+++ b/ui/vite.config.js
@@ -13,8 +13,8 @@ export default defineConfig({
       registerType: "autoUpdate",
       includeAssets: ["favicon.ico", "img/icons/*"],
       manifest: {
-        name: "WUD",
-        short_name: "WUD",
+        name: "Hosaka",
+        short_name: "Hosaka",
         theme_color: "#00355E",
         background_color: "#00355E",
         icons: [


### PR DESCRIPTION
Renames the project from WUD / What's Up Docker to **Hosaka**. This is a full hard rename of the runtime config contract with no backward-compatibility shims, applied across backend code, build artifacts, observability, and branding.

## What changed
- **Config contract:** env-var prefix `WUD_` -> `HOSAKA_`; container labels `wud.*` -> `hosaka.*` (watch/tag/link/display/digest).
- **Internal identifiers:** event-bus names `wud:*` -> `hosaka:*`; Prometheus metrics `wud_*` -> `hosaka_*`; root logger name `whats-up-docker` -> `hosaka`; LokiJS store default file `wud.json` -> `hosaka.json` and app collection name; trigger default identities (MQTT/Home-Assistant device, Kafka clientId/topic, Discord botusername, IFTTT event); label-map JS identifiers.
- **Build/CI/test:** Dockerfile (`HOSAKA_VERSION`/`HOSAKA_LOG_FORMAT`), entrypoint, `docker-compose.example.yml` (image `ghcr.io/nopoz/hosaka`, service/container name), `publish.yml` build args, package `name`/`repository` fields, e2e features + config, prometheus job.
- **Branding:** README rewritten (upstream badges/donate/doc-site links stripped, links repointed to `nopoz/hosaka`); UI title, PWA manifest name, nav/footer text; backend startup banner.

## Breaking changes - migration required for existing deployments
- Rename env vars `WUD_*` -> `HOSAKA_*`
- Rename container labels `wud.*` -> `hosaka.*`
- `mv wud.json hosaka.json` in the store volume (default store filename changed)
- Repoint the image to `ghcr.io/nopoz/hosaka`
- Update Grafana queries/dashboards for the renamed Prometheus metrics
- Re-pair Home Assistant entities (the MQTT device id changed, so entity IDs change)
- Re-authenticate once: the session-secret seed changed (`wud.<version>` -> `hosaka.<version>`), invalidating existing sessions

## Verification
- Backend unit suite green: 411 passed, 0 failed.
- Local container build + boot test on the renamed image: startup banner `Hosaka is starting`, logger name `hosaka`, store `/store/hosaka.json`, `HOSAKA_*` env parsed into watcher config, `/health` 200, `/api/app` returns `name: hosaka`, `/metrics` exposes `hosaka_*`. Confirmed label hard-rename at runtime: a container labeled `hosaka.watch=true` is watched while one labeled `wud.watch=true` is ignored.

## Deferred (separate follow-ups, intentionally out of scope)
- The `docs/` site tree (still references WUD).
- Logo/icon asset swap (the `wud_logo*.png` / `wud-logo.svg` filenames are kept for now).
- GitHub-side: repo rename, About description, ghcr package name.
