### PR TITLE
docs: rewrite README to highlight fork features

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,27 +9,21 @@ rebuilt around a faster, mobile-friendly UI and one-click updates.
 
 ## What's different from WUD
 
-- **One-click updates with live output.** Update a container straight from the
-  UI and watch the update script run in a console window, line by line, so you
-  see exactly what happened (and any errors) without leaving the page.
-- **Works on mobile.** The UI is fully responsive, so you can check and update
-  your containers from a phone, not just a desktop.
-- **Modern, maintained dependencies.** The UI runs on Vue 3 / Vuetify 3 / Vite
-  (off the EOL Vue 2 stack), and the backend has dropped deprecated libraries in
-  favor of current ones.
-- **A more polished UI.** Fewer clicks, clearer navigation, container sorting,
-  distinct colors per update type, and live container state that updates in
-  place without a full-page reload.
+| Area | WUD | Hosaka |
+|------|-----|--------|
+| **Updating from the UI** | run a trigger from the container's Triggers tab | one-click **Update** on the container row |
+| **Update progress** | none | live console output of the update script, streamed line by line |
+| **Mobile** | desktop-oriented: permanent nav, no mobile layout | fully responsive: hamburger nav, mobile layouts, update from your phone |
+| **Live container state** | manual refresh | list updates in place over SSE, no full-page reload |
+| **In-app UX** | filter + oldest-first toggle | sort by name, update type, or watcher; distinct color per update type, including prerelease |
 
 ## How it works
 
 Hosaka is built on three concepts:
 
-> `WATCHERS` query your Docker hosts to get the containers to watch
-
-> `REGISTRIES` query the Docker registries to find available updates
-
-> `TRIGGERS` perform actions when updates are available
+- **Watchers** query your Docker hosts to get the containers to watch
+- **Registries** query the Docker registries to find available updates
+- **Triggers** perform actions when updates are available
 
 ## Features
 
@@ -58,41 +52,55 @@ Hosaka is built on three concepts:
 - Basic auth or OpenID Connect (OIDC) for SSO
 - Docker secrets via `__FILE` env vars, single image, sensible defaults
 
+## Get started
+
+Create a `docker-compose.yml`:
+
+```yaml
+services:
+  hosaka:
+    image: ghcr.io/nopoz/hosaka:latest
+    container_name: hosaka
+    restart: unless-stopped
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
+      - ./store:/store
+    ports:
+      - 3000:3000
+```
+
+Then bring it up and open the UI:
+
+```bash
+docker compose up -d
+```
+
+The UI is now at [http://localhost:3000](http://localhost:3000).
+
+For a hardened setup (read-only Docker socket proxy, plus watcher, registry, and
+trigger config), copy [`docker-compose.example.yml`](docker-compose.example.yml)
+and adjust it. Full configuration reference lives in [`docs/`](docs/).
+
 ## Triggers
-> Send notifications using **Smtp**, [**Apprise**](https://github.com/caronc/apprise-api), [**Ifttt**](https://ifttt.com), [**Pushover**](https://pushover.net), [**Slack**](https://slack.com), [**Telegram**](https://telegram.org/), [**Discord**](https://discord.com/)...
-
-> Update your [**docker**](https://www.docker.com) containers or your [**docker-compose**](https://docs.docker.com/compose) stack, automatically or with a single click in the UI.
-
-> Run your own update script and watch its output live.
-
-> Integrate with third-party systems using [**Kafka**](https://kafka.apache.org), [**Mqtt**](https://mqtt.org), **Http Webhooks**...
-
-> Setup your own update strategies \
-> (e.g. automatically update containers when minor or patch versions are available & notify by email when major versions are available)
+- Send notifications using [**SMTP**](https://en.wikipedia.org/wiki/Simple_Mail_Transfer_Protocol), [**Apprise**](https://github.com/caronc/apprise-api), [**IFTTT**](https://ifttt.com), [**Pushover**](https://pushover.net), [**Slack**](https://slack.com), [**Telegram**](https://telegram.org/), and [**Discord**](https://discord.com/)
+- Update your [**docker**](https://www.docker.com) containers or your [**docker-compose**](https://docs.docker.com/compose) stack, automatically or with a single click in the UI
+- Run your own update script and watch its output live
+- Integrate with third-party systems using [**Kafka**](https://kafka.apache.org), [**MQTT**](https://mqtt.org), and **HTTP webhooks**
+- Set up your own update strategies (e.g. auto-update on minor and patch versions, notify by email on major versions)
 
 ## Registries
 
-> [**AWS Elastic Container Registry**](https://aws.amazon.com/ecr)
-
-> [**Azure Container Registry**](https://azure.microsoft.com/services/container-registry)
-
-> [**Docker Hub**](http://hub.docker.com)
-
-> [**Forgejo Container Registry**](https://forgejo.org/)
-
-> [**Gitea Container Registry**](https://gitea.com/)
-
-> [**Github Container Registry**](https://docs.github.com/en/packages/working-with-a-github-packages-registry/working-with-the-docker-registry)
-
-> [**Gitlab Container Registry**](https://docs.gitlab.com/ee/user/packages/container_registry/)
-
-> [**Google Container Registry**](https://cloud.google.com/container-registry)
-
-> [**LinuxServer Container Registry (lscr.io)**](https://fleet.linuxserver.io/)
-
-> [**Redhat Quay**](https://quay.io/)
-
-> [**Self-hosted Docker Registry**](https://docs.docker.com/registry/)
+- [**AWS Elastic Container Registry**](https://aws.amazon.com/ecr)
+- [**Azure Container Registry**](https://azure.microsoft.com/services/container-registry)
+- [**Docker Hub**](http://hub.docker.com)
+- [**Forgejo Container Registry**](https://forgejo.org/)
+- [**Gitea Container Registry**](https://gitea.com/)
+- [**GitHub Container Registry**](https://docs.github.com/en/packages/working-with-a-github-packages-registry/working-with-the-docker-registry)
+- [**GitLab Container Registry**](https://docs.gitlab.com/ee/user/packages/container_registry/)
+- [**Google Container Registry**](https://cloud.google.com/container-registry)
+- [**LinuxServer Container Registry (lscr.io)**](https://fleet.linuxserver.io/)
+- [**Red Hat Quay**](https://quay.io/)
+- [**Self-hosted Docker Registry**](https://docs.docker.com/registry/)
 
 ## Authentication
 - [Openid Connect](https://openid.net/connect/)
@@ -100,19 +108,13 @@ Hosaka is built on three concepts:
 
 ## Integrations
 
-> [**Authelia**](https://www.authelia.com/)
-
-> [**Authentik**](https://goauthentik.io/)
-
-> [**Auth0**](https://auth0.com/)
-
-> [**Grafana**](https://grafana.com/)
-
-> [**Home-Assistant**](https://www.home-assistant.io/)
-
-> [**Keycloak**](https://www.keycloak.org/)
-
-> [**Prometheus**](https://prometheus.io/)
+- [**Authelia**](https://www.authelia.com/)
+- [**Authentik**](https://goauthentik.io/)
+- [**Auth0**](https://auth0.com/)
+- [**Grafana**](https://grafana.com/)
+- [**Home-Assistant**](https://www.home-assistant.io/)
+- [**Keycloak**](https://www.keycloak.org/)
+- [**Prometheus**](https://prometheus.io/)
 
 ## Contact & Support
 - Create a [GitHub issue](https://github.com/nopoz/hosaka/issues) for bug reports, feature requests, or questions

--- a/README.md
+++ b/README.md
@@ -116,13 +116,42 @@ and adjust it. Full configuration reference lives in [`docs/`](docs/).
 - [**Keycloak**](https://www.keycloak.org/)
 - [**Prometheus**](https://prometheus.io/)
 
+## Security
+
+Hosaka talks to your Docker host and can update running services, so treat it as
+a privileged tool.
+
+- **Lock down access.** Hosaka allows anonymous access by default. Enable
+  [Basic auth](https://developer.mozilla.org/en-US/docs/Web/HTTP/Authentication)
+  or [OIDC](https://openid.net/connect/) before exposing it, and put it behind a
+  reverse proxy with TLS rather than publishing the port to the internet. Anyone
+  who can reach the UI or API can trigger updates that change your live
+  containers.
+- **Limit Docker access.** The Docker socket is effectively root on the host.
+  Prefer the read-only socket proxy shown in `docker-compose.example.yml` over
+  mounting `/var/run/docker.sock` directly, so Hosaka only gets the endpoints it
+  needs.
+- **Keep secrets out of plain config.** Registry credentials and trigger tokens
+  can be loaded from files with the `__FILE` env var suffix (Docker secrets)
+  instead of being written in your compose file.
+
+## More of my projects
+
+Other open-source tools I maintain that you might find useful:
+
+- [**Portrieve**](https://github.com/nopoz/portrieve) - back up, restore, and
+  migrate Portainer stacks as plain Docker Compose files.
+- [**pfSense DNSCrypt Proxy**](https://github.com/nopoz/pfsense-dnscrypt-proxy) -
+  a pfSense package for DNSCrypt Proxy: encrypted DNS with full GUI support.
+
 ## Contact & Support
 - Create a [GitHub issue](https://github.com/nopoz/hosaka/issues) for bug reports, feature requests, or questions
 - Add a star on [GitHub](https://github.com/nopoz/hosaka) to support the project!
 
 ## Credits
 Hosaka builds on [What's Up Docker](https://github.com/getwud/wud) by the WUD
-authors and contributors. Thanks for the foundation.
+authors and contributors. Huge thanks to them for the solid foundation this fork
+is built on.
 
 ## License
 This project is licensed under the [MIT license](https://github.com/nopoz/hosaka/blob/main/LICENSE).

--- a/README.md
+++ b/README.md
@@ -1,8 +1,29 @@
 # Hosaka
 
-Gets you notified when new versions of your Docker containers are available and lets you react the way you want.
+Hosaka watches your Docker hosts for new container image versions, then lets you
+react: get notified, or update the container with a single click and watch the
+update run live.
 
-### Hosaka is built on 3 concepts:
+Hosaka is a fork of [What's Up Docker (WUD)](https://github.com/getwud/wud),
+rebuilt around a faster, mobile-friendly UI and one-click updates.
+
+## What's different from WUD
+
+- **One-click updates with live output.** Update a container straight from the
+  UI and watch the update script run in a console window, line by line, so you
+  see exactly what happened (and any errors) without leaving the page.
+- **Works on mobile.** The UI is fully responsive, so you can check and update
+  your containers from a phone, not just a desktop.
+- **Modern, maintained dependencies.** The UI runs on Vue 3 / Vuetify 3 / Vite
+  (off the EOL Vue 2 stack), and the backend has dropped deprecated libraries in
+  favor of current ones.
+- **A more polished UI.** Fewer clicks, clearer navigation, container sorting,
+  distinct colors per update type, and live container state that updates in
+  place without a full-page reload.
+
+## How it works
+
+Hosaka is built on three concepts:
 
 > `WATCHERS` query your Docker hosts to get the containers to watch
 
@@ -10,17 +31,46 @@ Gets you notified when new versions of your Docker containers are available and 
 
 > `TRIGGERS` perform actions when updates are available
 
-## Many supported triggers
+## Features
+
+**Smart update detection**
+- Watch multiple Docker hosts at once, local socket or remote over TCP/TLS
+- Semver-aware: every update is classified as major, minor, patch, or prerelease
+- Digest watching catches new images behind mutable tags like `latest`
+- Per-tag include/exclude regex and tag transforms to handle any versioning scheme
+- Scheduled (cron) scans plus instant detection from Docker events
+
+**Per-container control, no central config**
+- Drive everything with `hosaka.*` Docker labels: opt in/out, set tag filters,
+  custom display name and icon, or a link to the release notes
+- Update thresholds so you only act on, say, minor and patch bumps
+
+**Notify or update, your call**
+- Notify through SMTP, Slack, Discord, Telegram, Apprise, IFTTT, Pushover,
+  Kafka, MQTT, or HTTP webhooks, with templated titles and bodies
+- Auto-update Docker containers and docker-compose stacks, or run your own
+  update script, automatically or with a single click from the UI
+- Per-update or batched notifications, with a "once" guard against repeats
+
+**Built to run in your stack**
+- Web UI and a full REST API
+- Prometheus metrics and a `/health` endpoint, ready for Grafana
+- Basic auth or OpenID Connect (OIDC) for SSO
+- Docker secrets via `__FILE` env vars, single image, sensible defaults
+
+## Triggers
 > Send notifications using **Smtp**, [**Apprise**](https://github.com/caronc/apprise-api), [**Ifttt**](https://ifttt.com), [**Pushover**](https://pushover.net), [**Slack**](https://slack.com), [**Telegram**](https://telegram.org/), [**Discord**](https://discord.com/)...
 
-> Automatically update your [**docker**](https://www.docker.com) containers or your [**docker-compose**](https://docs.docker.com/compose) stack.
+> Update your [**docker**](https://www.docker.com) containers or your [**docker-compose**](https://docs.docker.com/compose) stack, automatically or with a single click in the UI.
+
+> Run your own update script and watch its output live.
 
 > Integrate with third-party systems using [**Kafka**](https://kafka.apache.org), [**Mqtt**](https://mqtt.org), **Http Webhooks**...
 
 > Setup your own update strategies \
 > (e.g. automatically update containers when minor or patch versions are available & notify by email when major versions are available)
 
-## Many supported registries
+## Registries
 
 > [**AWS Elastic Container Registry**](https://aws.amazon.com/ecr)
 
@@ -44,17 +94,17 @@ Gets you notified when new versions of your Docker containers are available and 
 
 > [**Self-hosted Docker Registry**](https://docs.docker.com/registry/)
 
-## REST API & Web UI
-
-## Flexible authentication strategies
+## Authentication
 - [Openid Connect](https://openid.net/connect/)
 - [Basic authentication](https://developer.mozilla.org/en-US/docs/Web/HTTP/Authentication)
 
-## Good integration with
+## Integrations
 
 > [**Authelia**](https://www.authelia.com/)
 
 > [**Authentik**](https://goauthentik.io/)
+
+> [**Auth0**](https://auth0.com/)
 
 > [**Grafana**](https://grafana.com/)
 
@@ -64,11 +114,13 @@ Gets you notified when new versions of your Docker containers are available and 
 
 > [**Prometheus**](https://prometheus.io/)
 
-> ...
-
 ## Contact & Support
 - Create a [GitHub issue](https://github.com/nopoz/hosaka/issues) for bug reports, feature requests, or questions
 - Add a star on [GitHub](https://github.com/nopoz/hosaka) to support the project!
+
+## Credits
+Hosaka builds on [What's Up Docker](https://github.com/getwud/wud) by the WUD
+authors and contributors. Thanks for the foundation.
 
 ## License
 This project is licensed under the [MIT license](https://github.com/nopoz/hosaka/blob/main/LICENSE).


### PR DESCRIPTION
Rewrites the README, which was mostly carried over from the upstream WUD README, to focus on what this fork offers.

## Changes
- New lead and a **What's different from WUD** comparison table. Every row was verified against current upstream `getwud/wud` `main`:
  - One-click Update on the container row (WUD only runs triggers from the Triggers tab)
  - Live console output of the update script (WUD has none)
  - Responsive mobile UI (WUD is desktop-oriented)
  - Live container state over SSE (WUD requires manual refresh)
  - Multi-key sort + distinct color per update type incl. prerelease (WUD has a single oldest-first toggle and three colors)
- Added a **Features** section summarizing capabilities from the docs.
- Added a **Get started** docker compose quickstart, pointing to `docker-compose.example.yml` and `docs/` for the full setup.
- Added a **Security** section (anonymous-by-default warning, read-only socket proxy, secrets via `__FILE`).
- Added a **More of my projects** section linking Portrieve and pfSense DNSCrypt Proxy.
- Converted the inherited `>` blockquote lists to normal bullet lists; removed a bare header and a stray `...` placeholder; added Auth0 to integrations; warmed up the credits note.