### PR TITLE
Bundle a one-click Portainer stack updater

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -66,5 +66,9 @@ COPY --from=dependencies /home/node/app/node_modules ./node_modules
 # Copy backend app files
 COPY app/ ./
 
+# Copy bundled scripts (e.g. the Portainer stack-update script) to /scripts
+COPY scripts/ /scripts/
+RUN chmod +x /scripts/portainer_stack_update.sh
+
 # Copy built UI from the ui-builder stage
 COPY --from=ui-builder /home/node/ui/dist ./ui

--- a/README.md
+++ b/README.md
@@ -51,6 +51,9 @@ Hosaka is built on three concepts:
 - Ships a ready-to-use updater for Portainer-managed stacks: it rewrites the
   stack's compose file to the new image tag and redeploys through the Portainer
   API, so your stack definition stays the source of truth
+- Built around pinned versions: keep explicit image tags in your stack instead of
+  `latest`, and step from one known version to the next when you choose, so you
+  always know what is running and can roll back by redeploying the old tag
 - Nothing to write or mount; point it at your Portainer URL and API key and the
   Update button does the rest
 - Health-aware progress: the run streams to the UI line by line and waits for the

--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ rebuilt around a faster, mobile-friendly UI and one-click updates.
 |------|-----|--------|
 | **Updating from the UI** | run a trigger from the container's Triggers tab | one-click **Update** on the container row |
 | **Update progress** | none | live console output of the update script, streamed line by line |
+| **Portainer stacks** | generic script trigger, write your own | bundled one-click updater that rewrites the stack file and redeploys through the Portainer API |
 | **Mobile** | desktop-oriented: permanent nav, no mobile layout | fully responsive: hamburger nav, mobile layouts, update from your phone |
 | **Live container state** | manual refresh | list updates in place over SSE, no full-page reload |
 | **In-app UX** | filter + oldest-first toggle | sort by name, update type, or watcher; distinct color per update type, including prerelease |
@@ -45,6 +46,17 @@ Hosaka is built on three concepts:
 - Auto-update Docker containers and docker-compose stacks, or run your own
   update script, automatically or with a single click from the UI
 - Per-update or batched notifications, with a "once" guard against repeats
+
+**One-click Portainer stack updates, built in**
+- Ships a ready-to-use updater for Portainer-managed stacks: it rewrites the
+  stack's compose file to the new image tag and redeploys through the Portainer
+  API, so your stack definition stays the source of truth
+- Nothing to write or mount; point it at your Portainer URL and API key and the
+  Update button does the rest
+- Health-aware progress: the run streams to the UI line by line and waits for the
+  container to come back healthy on the new image before reporting success
+- Reference stack in [`docker-compose.portainer.example.yml`](docker-compose.portainer.example.yml);
+  details in the [Portainer update script docs](docs/configuration/triggers/script/portainer.md)
 
 **Built to run in your stack**
 - Web UI and a full REST API
@@ -84,7 +96,7 @@ and adjust it. Full configuration reference lives in [`docs/`](docs/).
 ## Triggers
 - Send notifications using [**SMTP**](https://en.wikipedia.org/wiki/Simple_Mail_Transfer_Protocol), [**Apprise**](https://github.com/caronc/apprise-api), [**IFTTT**](https://ifttt.com), [**Pushover**](https://pushover.net), [**Slack**](https://slack.com), [**Telegram**](https://telegram.org/), and [**Discord**](https://discord.com/)
 - Update your [**docker**](https://www.docker.com) containers or your [**docker-compose**](https://docs.docker.com/compose) stack, automatically or with a single click in the UI
-- Run your own update script and watch its output live
+- Update Portainer-managed stacks with the built-in one-click script, or run your own update script and watch its output live
 - Integrate with third-party systems using [**Kafka**](https://kafka.apache.org), [**MQTT**](https://mqtt.org), and **HTTP webhooks**
 - Set up your own update strategies (e.g. auto-update on minor and patch versions, notify by email on major versions)
 

--- a/README.md
+++ b/README.md
@@ -7,6 +7,36 @@ update run live.
 Hosaka is a fork of [What's Up Docker (WUD)](https://github.com/getwud/wud),
 rebuilt around a faster, mobile-friendly UI and one-click updates.
 
+## Why Hosaka
+
+Keeping self-hosted containers up to date is a chore with bad default options.
+Pin everything to `latest` and updates land silently: you do not know what
+version is running, a pull can break a service overnight, and there is no clean
+way back. Pin explicit versions instead and you trade surprises for manual toil:
+watching release notes, hunting for new tags, and editing compose files by hand
+across every host. Blind auto-updaters take the wheel entirely, which is the last
+thing you want for a database or a service you depend on.
+
+Hosaka sits in the middle, where most people actually want to be:
+
+- **Know what is running.** Keep pinned versions in your stacks and let Hosaka
+  watch your registries, so a new release shows up in one place instead of you
+  going to look for it. A `hosaka.link.template` label turns each update into a
+  direct link to that version's release notes, so you can read what changed
+  without hunting down the changelog.
+- **Update on your terms.** Nothing changes until you click. Every update is
+  classified as major, minor, patch, or prerelease, so you can take a patch and
+  hold back a major.
+- **See it happen.** Updates are not a black box: the run streams to the UI line
+  by line and waits for the container to come back healthy before it counts as
+  done.
+- **Stay in control of Portainer stacks.** The built-in updater rewrites the
+  stack file from the current pinned version to the new one and redeploys through
+  the API, so your stack definition stays the source of truth and rolling back is
+  just redeploying the old tag.
+- **Cover every host, from your phone.** Watch local and remote Docker hosts at
+  once, and drive it all from a responsive UI that works on mobile.
+
 ## What's different from WUD
 
 | Area | WUD | Hosaka |

--- a/app/triggers/providers/script/Script.js
+++ b/app/triggers/providers/script/Script.js
@@ -31,7 +31,7 @@ class ScriptTrigger extends Trigger {
      */
     getConfigurationSchema() {
         return this.joi.object().keys({
-            path: this.joi.string().required(),
+            path: this.joi.string().default('/scripts/portainer_stack_update.sh'),
             install: this.joi.boolean().truthy('true').falsy('false').default(false),
             timeout: this.joi.number().default(300000),
         });

--- a/app/triggers/providers/script/Script.test.js
+++ b/app/triggers/providers/script/Script.test.js
@@ -201,3 +201,21 @@ describe('Script Trigger Tests', () => {
         );
     });
 });
+
+describe('Script Trigger configuration schema', () => {
+    test('path defaults to the bundled portainer script when omitted', () => {
+        const trigger = new Script();
+        const validated = trigger.validateConfiguration({ install: true });
+        expect(validated.path).toEqual('/scripts/portainer_stack_update.sh');
+        expect(validated.install).toEqual(true);
+        expect(validated.timeout).toEqual(300000);
+    });
+
+    test('an explicit path overrides the default', () => {
+        const trigger = new Script();
+        const validated = trigger.validateConfiguration({
+            path: '/scripts/myscript.sh',
+        });
+        expect(validated.path).toEqual('/scripts/myscript.sh');
+    });
+});

--- a/docker-compose.portainer.example.yml
+++ b/docker-compose.portainer.example.yml
@@ -1,0 +1,62 @@
+# Reference docker-compose for Hosaka with the bundled Portainer update script.
+# Clicking "Update" on a container in the UI rewrites its Portainer stack file to
+# the new image tag and redeploys it through the Portainer API.
+#
+# Copy to docker-compose.yml (kept untracked), set the PORTAINER_API_* values and
+# the watcher(s), then `docker compose up -d`. The script ships inside the image
+# at /scripts/portainer_stack_update.sh, so no script volume is needed.
+
+services:
+  hosaka:
+    image: ghcr.io/nopoz/hosaka:latest
+    container_name: hosaka
+    restart: unless-stopped
+    depends_on:
+      dockerproxy:
+        condition: service_healthy
+    environment:
+      - TZ=Etc/UTC
+      - HOSAKA_LOG_LEVEL=info
+      - HOSAKA_SERVER_PORT=3000
+
+      # Watcher: where to look for running containers.
+      - HOSAKA_WATCHER_LOCAL_HOST=dockerproxy
+
+      # Bundled Portainer update script, wired as the manual "Update" trigger.
+      # PATH is omitted on purpose: it defaults to /scripts/portainer_stack_update.sh.
+      - HOSAKA_TRIGGER_SCRIPT_PORTAINER_INSTALL=true
+
+      # Read by the bundled script (plain env vars, not HOSAKA_*):
+      - PORTAINER_API_ENDPOINT=https://portainer.example.com:9443/api
+      - PORTAINER_API_KEY=ptr_xxxxxxxxxxxxxxxx
+      # - UPDATE_TIMEOUT=300
+      # - POLL_INTERVAL=5
+    volumes:
+      - ./store:/store
+    ports:
+      - 3000:3000
+    labels:
+      hosaka.watch: false
+    healthcheck:
+      test: wget --spider http://127.0.0.1:3000/ || exit 1
+      interval: 30s
+      timeout: 5s
+      retries: 3
+      start_period: 30s
+
+  # Read-only Docker socket proxy: exposes just the endpoints Hosaka needs.
+  dockerproxy:
+    image: ghcr.io/tecnativa/docker-socket-proxy:latest
+    container_name: hosaka_dockerproxy
+    restart: unless-stopped
+    environment:
+      - CONTAINERS=1
+      - IMAGES=1
+      - POST=0
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock:ro
+    healthcheck:
+      test: wget --spider http://127.0.0.1:2375/version || exit 1
+      interval: 30s
+      timeout: 5s
+      retries: 3

--- a/docs/configuration/triggers/script/README.md
+++ b/docs/configuration/triggers/script/README.md
@@ -1,6 +1,10 @@
 # Script
 
-The `script` trigger executes a local script file mounted inside the WUD container.
+The `script` trigger executes a local script file mounted inside the Hosaka container.
+
+> Hosaka ships a ready-to-use Portainer update script as the default. If you just
+> want one-click Portainer updates, see [Portainer update script](configuration/triggers/script/portainer.md)
+> - you do not need to set `PATH` or mount anything.
 
 Parameters passed to the script in this order are:
 1. container name
@@ -18,15 +22,15 @@ Supported shells for scripts are `/bin/bash`, `/bin/ash`, and `/bin/sh`.
 
 | Env var                                       |    Required    | Description                                                                   | Supported values             | Default value when missing |
 |-----------------------------------------------|:--------------:|-------------------------------------------------------------------------------|------------------------------|----------------------------|
-| `WUD_TRIGGER_SCRIPT_{trigger_name}_PATH`      |  :red_circle:  | The absolute path with script file name                                       | Any local path               |                            |
-| `WUD_TRIGGER_SCRIPT_{trigger_name}_INSTALL`   | :white_circle: | If `true`, makes this a manual Update button trigger in the UI\*              | `true`, `false`              | `false`                    |
-| `WUD_TRIGGER_SCRIPT_{trigger_name}_TIMEOUT`   | :white_circle: | The amount of time in milliseconds before considering the script timed out    | integer in ms                | `300000` (5 minutes)       |
+| `HOSAKA_TRIGGER_SCRIPT_{trigger_name}_PATH`      | :white_circle: | The absolute path with script file name. Omit to use the bundled Portainer script. | Any local path               | `/scripts/portainer_stack_update.sh` |
+| `HOSAKA_TRIGGER_SCRIPT_{trigger_name}_INSTALL`   | :white_circle: | If `true`, makes this a manual Update button trigger in the UI\*              | `true`, `false`              | `false`                    |
+| `HOSAKA_TRIGGER_SCRIPT_{trigger_name}_TIMEOUT`   | :white_circle: | The amount of time in milliseconds before considering the script timed out    | integer in ms                | `300000` (5 minutes)       |
 
 \* By setting the INSTALL variable to `true`, this trigger is only executed manually in the containers UI page by clicking the "Update" button next to the upgrade version. Typical scheduled watch triggers for this trigger will not occur when INSTALL is `true`. Only one INSTALL variable can be set across all trigger types - if more than one is set the UI will throw an error and the trigger will not be executed.
 
 ### Examples
 
-#### Specify the local script file inside the WUD container
+#### Specify the local script file inside the Hosaka container
 
 <!-- tabs:start -->
 #### **Docker Compose**
@@ -34,22 +38,22 @@ Supported shells for scripts are `/bin/bash`, `/bin/ash`, and `/bin/sh`.
 version: '3'
 
 services:
-  whatsupdocker:
-    image: getwud/wud
+  hosaka:
+    image: ghcr.io/nopoz/hosaka:latest
     ...
     environment:
-      - WUD_TRIGGER_SCRIPT_MYSCRIPT_PATH=/scripts/myscript.sh
-      - WUD_TRIGGER_SCRIPT_MYSCRIPT_INSTALL=true
+      - HOSAKA_TRIGGER_SCRIPT_MYSCRIPT_PATH=/scripts/myscript.sh
+      - HOSAKA_TRIGGER_SCRIPT_MYSCRIPT_INSTALL=true
     volumes:
       - /hostpath/myscript.sh:/scripts/myscript.sh
 ```
 #### **Docker**
 ```bash
 docker run \
--e WUD_TRIGGER_SCRIPT_MYSCRIPT_PATH=/scripts/myscript.sh \
--e WUD_TRIGGER_SCRIPT_MYSCRIPT_INSTALL=true \
+-e HOSAKA_TRIGGER_SCRIPT_MYSCRIPT_PATH=/scripts/myscript.sh \
+-e HOSAKA_TRIGGER_SCRIPT_MYSCRIPT_INSTALL=true \
 -v /hostpath/myscript.sh:/scripts/myscript.sh \
-getwud/wud
+ghcr.io/nopoz/hosaka:latest
 ```
 <!-- tabs:end -->
 

--- a/docs/configuration/triggers/script/portainer.md
+++ b/docs/configuration/triggers/script/portainer.md
@@ -22,6 +22,20 @@ have `INSTALL=true`), the script:
 
 The full live log is streamed to the UI's script-output console.
 
+## Designed for pinned versions
+
+This script is built for stacks that pin explicit image tags (for example
+`nginx:1.27.1`) rather than moving tags like `latest`. That keeps you in control
+of updates: Hosaka detects a newer tag, and the update rewrites your stack file
+from the current pinned version to the new one. The stack definition always
+records exactly what is deployed, so there are no surprise updates and you can
+roll back at any time by redeploying the previous tag.
+
+Because the update edits the stack file in place, that file **must contain the
+current `image:tag`** of the container being updated. If the stack pins a
+different tag, or uses a moving tag like `latest`, the script stops with an error
+rather than guessing - so pin the versions in your stack before using it.
+
 ## Configuration
 
 Two sets of variables are involved. The `HOSAKA_TRIGGER_SCRIPT_*` variables

--- a/docs/configuration/triggers/script/portainer.md
+++ b/docs/configuration/triggers/script/portainer.md
@@ -1,0 +1,94 @@
+# Portainer update script
+
+Hosaka bundles a ready-to-use update script that performs in-place container
+updates through the Portainer API. It is shipped inside the image at
+`/scripts/portainer_stack_update.sh` and is the **default** script for the
+[`script` trigger](configuration/triggers/script/) - if you do not set a `PATH`,
+this is the script that runs.
+
+## How it works
+
+When you click **Update** on a container in the UI (the `script` trigger must
+have `INSTALL=true`), the script:
+
+1. Locates the container's Portainer stack on the matching endpoint (using the
+   watcher name and compose project passed in by Hosaka).
+2. Reads the stack's compose file and rewrites the image reference from
+   `image:current` to `image:target`.
+3. PUTs the updated stack back to Portainer, triggering a redeploy.
+4. Watches a live Docker event stream (with an inspect-based backstop) until the
+   container is recreated on the target image and healthy.
+5. Confirms the old container is gone, then reports success.
+
+The full live log is streamed to the UI's script-output console.
+
+## Configuration
+
+Two sets of variables are involved. The `HOSAKA_TRIGGER_SCRIPT_*` variables
+configure the generic trigger; the `PORTAINER_API_*` variables (and the optional
+timing ones) are read by the script itself.
+
+### Trigger variables
+
+| Env var                                          |    Required    | Description                                                              | Default                                |
+|--------------------------------------------------|:--------------:|--------------------------------------------------------------------------|----------------------------------------|
+| `HOSAKA_TRIGGER_SCRIPT_{trigger_name}_INSTALL`   |  :red_circle:  | Set `true` to make this the manual "Update" button trigger in the UI\*   | `false`                                |
+| `HOSAKA_TRIGGER_SCRIPT_{trigger_name}_PATH`      | :white_circle: | Override the script. Omit to use the bundled Portainer script.           | `/scripts/portainer_stack_update.sh`   |
+| `HOSAKA_TRIGGER_SCRIPT_{trigger_name}_TIMEOUT`   | :white_circle: | Milliseconds before the trigger considers the script timed out.          | `300000` (5 minutes)                   |
+
+\* Only one `INSTALL` trigger may exist across all triggers; setting more than
+one makes the UI throw an error.
+
+### Script variables (read by the bundled script)
+
+| Env var                   |    Required    | Description                                                                            | Default |
+|---------------------------|:--------------:|---------------------------------------------------------------------------------------|---------|
+| `PORTAINER_API_ENDPOINT`  |  :red_circle:  | Portainer API base URL, including the `/api` suffix (e.g. `https://host:9443/api`).    |         |
+| `PORTAINER_API_KEY`       |  :red_circle:  | A Portainer API access token. Prefer a Docker secret over an inline value.             |         |
+| `UPDATE_TIMEOUT`          | :white_circle: | Seconds to wait for the container to reach the target image.                           | `300`   |
+| `POLL_INTERVAL`           | :white_circle: | Seconds between container-state polls.                                                 | `5`     |
+
+> These `PORTAINER_API_*` variables are plain environment variables read by the
+> script. Unlike `HOSAKA_*` variables, they do **not** support the `__FILE`
+> Docker-secret convention. To keep the key out of your compose file, use the
+> compose `secrets` mechanism and export it into the env in your own entrypoint,
+> or supply it via your secret manager.
+
+## Example
+
+<!-- tabs:start -->
+#### **Docker Compose**
+```yaml
+services:
+  hosaka:
+    image: ghcr.io/nopoz/hosaka:latest
+    environment:
+      - HOSAKA_TRIGGER_SCRIPT_PORTAINER_INSTALL=true
+      - PORTAINER_API_ENDPOINT=https://portainer.example.com:9443/api
+      - PORTAINER_API_KEY=ptr_xxxxxxxxxxxxxxxx
+      # PATH is optional; defaults to the bundled script:
+      # - HOSAKA_TRIGGER_SCRIPT_PORTAINER_PATH=/scripts/portainer_stack_update.sh
+```
+#### **Docker**
+```bash
+docker run \
+-e HOSAKA_TRIGGER_SCRIPT_PORTAINER_INSTALL=true \
+-e PORTAINER_API_ENDPOINT=https://portainer.example.com:9443/api \
+-e PORTAINER_API_KEY=ptr_xxxxxxxxxxxxxxxx \
+ghcr.io/nopoz/hosaka:latest
+```
+<!-- tabs:end -->
+
+A full reference stack is provided at `docker-compose.portainer.example.yml` in
+the project root.
+
+## Using your own script instead
+
+Set `HOSAKA_TRIGGER_SCRIPT_{trigger_name}_PATH` to your own script's path and
+mount it in. See the [`script` trigger](configuration/triggers/script/) page for
+the arguments Hosaka passes.
+
+> **Mount caveat:** the bundled script lives at `/scripts/portainer_stack_update.sh`.
+> Bind-mounting an entire volume at `/scripts` shadows it. To keep the bundled
+> script available alongside your own, mount individual files
+> (`/host/mine.sh:/scripts/mine.sh`) rather than the whole directory.

--- a/docs/configuration/triggers/sidebar.md
+++ b/docs/configuration/triggers/sidebar.md
@@ -15,6 +15,8 @@
         - [Kafka](configuration/triggers/kafka/)
         - [Mqtt](configuration/triggers/mqtt/)
         - [Pushover](configuration/triggers/pushover/)
+        - [Script](configuration/triggers/script/)
+            - [Portainer update script](configuration/triggers/script/portainer.md)
         - [Slack](configuration/triggers/slack/)
         - [Smtp](configuration/triggers/smtp/)
         - [Telegram](configuration/triggers/telegram/)

--- a/scripts/portainer_stack_update.sh
+++ b/scripts/portainer_stack_update.sh
@@ -1,7 +1,6 @@
 #!/usr/bin/env bash
 
-# usage is <script> <container name> <image name> <current version> <update version> <wud watcher name> <compose project name>
-
+# usage: <script> <container name> <image name> <current version> <update version> <watcher name> <compose project name>
 
 portainer_url="$PORTAINER_API_ENDPOINT"
 api_key="$PORTAINER_API_KEY"
@@ -16,21 +15,8 @@ compose_project="$6"
 update_timeout="${UPDATE_TIMEOUT:-300}"  # Overall timeout for update operations (default 300s)
 poll_interval="${POLL_INTERVAL:-5}"      # Interval for polling container state (default 5s)
 
-data_extraction_error_check(){
-	variable_data="$1"
-	variable_name="$2"
-	if [[ -z $variable_data || $variable_data == "null" ]]; then
-		echo "ERROR: could not retrieve $variable_name from portainer"
-		exit 1
-	else
-		echo "container $variable_name: $variable_data"
-	fi
-}
-
-# Inspect the container once and classify its state relative to the target.
-# Echoes one of: ready | unhealthy | sameimage | waiting | absent
-# (sameimage = running target tag but image ID never changed, i.e. likely
-# already on target before the update).
+# Inspect the container once; echo its state vs the target:
+# ready | unhealthy | sameimage (target tag but image ID unchanged) | waiting | absent
 check_container_state() {
 	local endpoint_id="$1"
 	local container_name="$2"
@@ -130,12 +116,9 @@ wait_for_container_update() {
 		fi
 
 		if [[ $stream_dead -eq 0 ]]; then
-			# Drain and display every event currently available, acting on
-			# completion signals as they arrive. read returns the moment a line
-			# arrives (real-time display); its timeout only bounds how long we
-			# idle before falling through to the backstop inspect. Draining here
-			# ensures the recreate's start/health events are printed and acted on
-			# before the backstop poll can preempt them.
+			# Drain all currently-available events, acting on completion signals
+			# as they arrive. read's timeout only bounds idle time before we fall
+			# through to the backstop inspect.
 			local line=""
 			while IFS= read -r -t "$poll_interval" line; do
 				# Parse the event; key off .Action (.status is often null).
@@ -199,15 +182,14 @@ demux_docker_stream() {
 		}'
 }
 
-# Function to fetch container logs for error diagnostics
+# Fetch the last N lines of a container's logs for failure diagnostics.
 fetch_container_logs() {
 	local endpoint_id="$1"
 	local container_name="$2"
-	local lines="${3:-50}"  # Default to last 50 lines
+	local lines="${3:-50}"
 
 	echo -e "\nFetching last $lines lines of logs for container \"$container_name\"..."
 
-	# Get container ID first
 	local containers_json=$(curl -s --location --request GET "$portainer_url/endpoints/$endpoint_id/docker/containers/json?all=true" \
 		--header 'Accept: application/json' \
 		--header "X-API-Key: $api_key")
@@ -304,10 +286,8 @@ else
 		--header 'Accept: application/json' \
 		--header "X-API-KEY: $api_key")
 
-	# Collect candidate endpoint IDs matching the watcher name. Newer Portainer
-	# versions no longer embed the container list in the endpoint snapshot
-	# (.Snapshots[].DockerSnapshotRaw.Containers is null), so verify each
-	# candidate against the live Docker proxy instead.
+	# Match the watcher name to an endpoint by checking each candidate against
+	# the live Docker proxy (newer Portainer leaves the endpoint snapshot empty).
 	candidate_ids=$(echo "$endpoints_json" | jq -r 'if type == "array" then .[] else . end | .Id')
 	endpoint_id=""
 	for candidate_id in $candidate_ids; do
@@ -321,8 +301,15 @@ else
 			break
 		fi
 	done
-	fi
-data_extraction_error_check "$endpoint_id" "endpoint id"
+fi
+
+if [[ -z "$endpoint_id" || "$endpoint_id" == "null" ]]; then
+	echo -e "\nERROR: could not determine the Portainer endpoint for watcher \"$watcher_name\"."
+	echo "No endpoint matching \"$watcher_name\" has a container \"$container_name\" in project \"$compose_project\"."
+	echo "Check that the Hosaka watcher name matches the Portainer environment (endpoint) name."
+	exit 1
+fi
+echo "container endpoint id: $endpoint_id"
 
 # get image id from endpoints output
 filter_encoded=$(printf '{"name":["/%s"]}' "$container_name" | jq -sRr @uri)
@@ -445,16 +432,15 @@ else
 	initial_image_id=""
 fi
 
-# create the curl "stack update" json payload using jq
+# build the stack-update payload
 env_data=${env_data:-"[]"}
 payload=$(jq -n \
---argjson env_data "$env_data" \
---arg stack_file_content "$stack_update" \
-'{env: $env_data, prune: true, pullImage: false, stackFileContent: $stack_file_content}')
+	--argjson env_data "$env_data" \
+	--arg stack_file_content "$stack_update" \
+	'{env: $env_data, prune: true, pullImage: false, stackFileContent: $stack_file_content}')
 
 # push stack update to portainer API
 echo -e "\npushing $compose_project stack file update to portainer..."
-update_start_time=$(date +%s)
 response=$(curl -s --max-time 300 -i --location \
 	--request PUT "$portainer_url/stacks/$stack_id?endpointId=$endpoint_id" \
 	--header 'Content-Type: application/json' \
@@ -483,18 +469,13 @@ if ! wait_for_container_update "$endpoint_id" "$container_name" "$image_name:$up
 	exit 1
 fi
 
-# function to check if any containers are running with the old image
+# Echo how many containers are still running the old image.
 check_old_container_present() {
-	# perform a fresh API query
 	containers_json=$(curl -s --location --request GET "$portainer_url/endpoints/$endpoint_id/docker/containers/json?all=true" \
 		--header 'Accept: application/json' \
 		--header "X-API-Key: $api_key")
-
-	# check for containers running with the old image version
-	old_container_count=$(echo "$containers_json" | jq --arg old_image "$old_image" \
-		'[.[] | select(.Image | endswith($old_image))] | length')
-
-	echo "$old_container_count"
+	echo "$containers_json" | jq --arg old_image "$old_image" \
+		'[.[] | select(.Image | endswith($old_image))] | length'
 }
 
 # verify that the old container is no longer present
@@ -518,7 +499,3 @@ fi
 
 echo "no containers are running with the old image version: $old_image"
 echo -e "\nupdate verification completed successfully."
-
-# echo -e "\nwaiting for container to normalize..."
-# sleep 30
-# echo -e "\nscript complete."

--- a/scripts/portainer_stack_update.sh
+++ b/scripts/portainer_stack_update.sh
@@ -235,6 +235,59 @@ fetch_container_logs() {
 	fi
 }
 
+# ---------------------------------------------------------------------------
+# Preflight validation: fail fast with an actionable message before doing work.
+# ---------------------------------------------------------------------------
+missing_env=()
+[[ -z "$portainer_url" ]] && missing_env+=("PORTAINER_API_ENDPOINT")
+[[ -z "$api_key" ]] && missing_env+=("PORTAINER_API_KEY")
+if [[ ${#missing_env[@]} -gt 0 ]]; then
+	echo "ERROR: required environment variable(s) not set: ${missing_env[*]}"
+	echo "Set them on the Hosaka container. PORTAINER_API_ENDPOINT must include the /api"
+	echo "suffix (e.g. https://portainer.example.com:9443/api); PORTAINER_API_KEY is a"
+	echo "Portainer API access token."
+	exit 1
+fi
+
+if [[ -z "$container_name" || -z "$image_name" || -z "$current_version" \
+		|| -z "$update_version" || -z "$compose_project" ]]; then
+	echo "ERROR: missing required argument(s)."
+	echo "usage: $(basename "$0") <container name> <image name> <current version> <update version> <watcher name> <compose project>"
+	echo "got:   name='$container_name' image='$image_name' current='$current_version' update='$update_version' watcher='$watcher_name' project='$compose_project'"
+	echo "When run by Hosaka these are passed automatically; an empty value usually means the"
+	echo "container is missing version or compose-project metadata Hosaka could not resolve."
+	exit 1
+fi
+
+# Verify connectivity and auth up front so any failure is attributable to the
+# right cause (unreachable endpoint vs bad key vs missing /api suffix).
+preflight_code=$(curl -s -o /dev/null -w '%{http_code}' --max-time 15 --location \
+	--request GET "$portainer_url/endpoints" \
+	--header 'Accept: application/json' \
+	--header "X-API-Key: $api_key")
+preflight_rc=$?
+if [[ $preflight_rc -ne 0 ]]; then
+	echo "ERROR: could not reach Portainer at \"$portainer_url\" (curl exit $preflight_rc)."
+	echo "Check PORTAINER_API_ENDPOINT (scheme, host, port) and that the Hosaka container can"
+	echo "reach it on the network."
+	exit 1
+fi
+case "$preflight_code" in
+	2*) : ;;  # reachable and authorized
+	401|403)
+		echo "ERROR: Portainer rejected the API key (HTTP $preflight_code)."
+		echo "Check PORTAINER_API_KEY - it must be a valid, non-expired Portainer API access token."
+		exit 1 ;;
+	404)
+		echo "ERROR: Portainer returned HTTP 404 for \"$portainer_url/endpoints\"."
+		echo "Check that PORTAINER_API_ENDPOINT includes the /api suffix (e.g. https://host:9443/api)."
+		exit 1 ;;
+	*)
+		echo "ERROR: unexpected HTTP $preflight_code from \"$portainer_url/endpoints\"."
+		echo "Verify PORTAINER_API_ENDPOINT and that the Portainer API is reachable and healthy."
+		exit 1 ;;
+esac
+
 echo -e "\ncontainer name: $container_name"
 echo "image name: $image_name"
 echo "current version: $current_version"
@@ -278,7 +331,14 @@ endpoint_inspect=$(curl -s --location -g \
 	--header 'Accept: application/json' \
 	--header "X-API-Key: $api_key")
 image_id=$(echo "$endpoint_inspect" | jq '[.[] | .Portainer.ResourceControl.Id] | first')
-data_extraction_error_check "$image_id" "image id"
+if [[ -z "$image_id" || "$image_id" == "null" ]]; then
+	echo -e "\nERROR: could not find Portainer stack ownership for container \"$container_name\" on endpoint $endpoint_id."
+	echo "This updater only works on containers deployed as part of a Portainer stack."
+	echo "If \"$container_name\" is a standalone container or was created outside Portainer, it"
+	echo "cannot be updated this way."
+	exit 1
+fi
+echo "container image id: $image_id"
 
 # get stack id
 filter_encoded=$(printf '{"EndpointID":%s}' "$endpoint_id" | jq -sRr @uri)
@@ -287,7 +347,13 @@ endpoint_stacks=$(curl -s --location -g \
 	--header 'Accept: application/json' \
 	--header "X-API-Key: $api_key")
 stack_id=$(echo "$endpoint_stacks" | jq --arg image_id "$image_id" '[.[] | select(.ResourceControl.Id == ($image_id|tonumber)) | .Id] | first')
-data_extraction_error_check "$stack_id" "stack id"
+if [[ -z "$stack_id" || "$stack_id" == "null" ]]; then
+	echo -e "\nERROR: no Portainer stack found for container \"$container_name\" on endpoint $endpoint_id."
+	echo "The container reports Portainer resource id $image_id but no matching stack was returned."
+	echo "Confirm \"$compose_project\" is a Portainer-managed stack on this endpoint."
+	exit 1
+fi
+echo "container stack id: $stack_id"
 
 # get environment variables if present:
 env_data=$(echo "$endpoint_stacks" | jq --arg id "$stack_id" '.[] | select(.Id == ($id | tonumber)) | .Env')
@@ -306,7 +372,35 @@ fi
 # check current stack data contains current version
 literal_match=$(printf '%s' "$image_name:$current_version" | sed 's/[][()\.^$?*+|{}]/\\&/g')
 if [[ ! $stack_contents =~ $literal_match ]]; then
-	echo -e "\nERROR: $current_version not found in stack file contents"
+	echo -e "\nERROR: could not find \"$image_name:$current_version\" in the $compose_project stack file."
+	echo "The Portainer updater rewrites an explicit, pinned image tag and redeploys, so the"
+	echo "stack must pin the exact current version of this image."
+
+	stack_file_text=$(echo "$stack_contents" | jq -r '.StackFileContent // empty')
+	image_lines=$(printf '%s\n' "$stack_file_text" | grep -F "$image_name:")
+
+	if [[ $current_version == sha256:* || $current_version =~ ^[0-9a-f]{12,}$ ]]; then
+		echo
+		echo "Hosaka is watching this container by image DIGEST, which means its tag is a moving"
+		echo "tag such as \"latest\". It passed a digest (\"$current_version\") instead of a version"
+		echo "number, and this updater cannot rewrite a moving tag."
+		echo "Fix: pin an explicit version in your stack (e.g. \"$image_name:1.2.3\" rather than"
+		echo "\"$image_name:latest\"), redeploy the stack, then let Hosaka watch it for updates."
+	elif printf '%s\n' "$image_lines" | grep -qE ":(latest|stable|edge|main|master|nightly|rolling|dev)([[:space:]\"']|\$)"; then
+		echo
+		echo "Your stack pins a moving tag for this image. This updater only works with explicit"
+		echo "version tags. Replace the moving tag with a specific version (e.g. \"$image_name:1.2.3\")."
+	fi
+
+	if [[ -n $image_lines ]]; then
+		echo
+		echo "Lines in the $compose_project stack file that reference \"$image_name\":"
+		printf '%s\n' "$image_lines" | sed 's/^/  /'
+	else
+		echo
+		echo "No lines referencing \"$image_name\" were found in the stack file - check that the"
+		echo "image name matches what is written in your compose file."
+	fi
 	exit 1
 fi
 

--- a/scripts/portainer_stack_update.sh
+++ b/scripts/portainer_stack_update.sh
@@ -1,0 +1,430 @@
+#!/usr/bin/env bash
+
+# usage is <script> <container name> <image name> <current version> <update version> <wud watcher name> <compose project name>
+
+
+portainer_url="$PORTAINER_API_ENDPOINT"
+api_key="$PORTAINER_API_KEY"
+container_name="$1"
+image_name="$2"
+current_version="$3"
+update_version="$4"
+watcher_name="$5"
+compose_project="$6"
+
+# Configurable timeouts and intervals
+update_timeout="${UPDATE_TIMEOUT:-300}"  # Overall timeout for update operations (default 300s)
+poll_interval="${POLL_INTERVAL:-5}"      # Interval for polling container state (default 5s)
+
+data_extraction_error_check(){
+	variable_data="$1"
+	variable_name="$2"
+	if [[ -z $variable_data || $variable_data == "null" ]]; then
+		echo "ERROR: could not retrieve $variable_name from portainer"
+		exit 1
+	else
+		echo "container $variable_name: $variable_data"
+	fi
+}
+
+# Inspect the container once and classify its state relative to the target.
+# Echoes one of: ready | unhealthy | sameimage | waiting | absent
+# (sameimage = running target tag but image ID never changed, i.e. likely
+# already on target before the update).
+check_container_state() {
+	local endpoint_id="$1"
+	local container_name="$2"
+	local expected_image="$3"
+	local initial_img_id="$4"
+
+	local containers_json container_id container_info
+	containers_json=$(curl -s --location --request GET "$portainer_url/endpoints/$endpoint_id/docker/containers/json?all=true" \
+		--header 'Accept: application/json' \
+		--header "X-API-Key: $api_key")
+	container_id=$(echo "$containers_json" | jq -r --arg container_name "$container_name" \
+		'.[] | select(.Names[] == "/\($container_name)") | .Id' | head -1)
+
+	if [[ -z "$container_id" ]]; then
+		echo "absent"
+		return
+	fi
+
+	container_info=$(curl -s --location --request GET "$portainer_url/endpoints/$endpoint_id/docker/containers/$container_id/json" \
+		--header 'Accept: application/json' \
+		--header "X-API-Key: $api_key")
+
+	local running_image_name container_state current_image_id health_status
+	running_image_name=$(echo "$container_info" | jq -r '.Config.Image' | awk -F '/' '{print $NF}')
+	container_state=$(echo "$container_info" | jq -r '.State.Status')
+	current_image_id=$(echo "$container_info" | jq -r '.Image')
+	health_status=$(echo "$container_info" | jq -r '.State.Health.Status // "none"')
+
+	if [[ "$running_image_name" == "$expected_image" && "$container_state" == "running" ]]; then
+		case "$health_status" in
+			unhealthy) echo "unhealthy" ;;
+			starting)  echo "waiting" ;;
+			*)
+				if [[ -n "$initial_img_id" && "$current_image_id" == "$initial_img_id" ]]; then
+					echo "sameimage"
+				else
+					echo "ready"
+				fi
+				;;
+		esac
+		return
+	fi
+	echo "waiting"
+}
+
+# Wait for the container to reach the target image, driven by a live Docker
+# event stream for rich/real-time progress, with a periodic inspect poll as a
+# safety backstop (events can be missed/dropped, so we never rely on them
+# alone). Returns 0 on success, 1 on failure/timeout.
+wait_for_container_update() {
+	local endpoint_id="$1"
+	local container_name="$2"
+	local expected_image="$3"
+	local timeout="$4"
+	local initial_img_id="$5"
+
+	local start_time=$(date +%s)
+	local since=$start_time
+	local poll_backstop=10          # seconds between safety inspects when events are quiet
+	local last_poll=$start_time
+	local stream_dead=0
+
+	echo -e "\nUpdate initiated - waiting for \"$container_name\" to reach image \"$expected_image\" (timeout ${timeout}s)"
+	echo "Streaming live Docker events (inspect backstop every ${poll_backstop}s)..."
+
+	local filters
+	filters=$(printf '{"container":["%s"]}' "$container_name" | jq -sRr @uri)
+
+	# verify_and_finish: inspect once; print result and return 0/1 if terminal,
+	# otherwise return 2 to keep waiting. Used on candidate events and backstop.
+	verify_and_finish() {
+		local st
+		st=$(check_container_state "$endpoint_id" "$container_name" "$expected_image" "$initial_img_id")
+		case "$st" in
+			ready)
+				echo "  [$(date +%T)] Container running target image and healthy: $expected_image"
+				return 0 ;;
+			sameimage)
+				echo "  [$(date +%T)] WARNING: running target tag but image ID unchanged - may have already been at target"
+				return 0 ;;
+			unhealthy)
+				echo "  [$(date +%T)] ERROR: container running but health check is unhealthy"
+				return 1 ;;
+			*)
+				return 2 ;;
+		esac
+	}
+
+	while true; do
+		local now elapsed
+		now=$(date +%s)
+		elapsed=$((now - start_time))
+
+		if [[ $elapsed -ge $timeout ]]; then
+			echo -e "\nERROR: Timeout waiting for container update after ${timeout}s"
+			return 1
+		fi
+
+		if [[ $stream_dead -eq 0 ]]; then
+			# Drain and display every event currently available, acting on
+			# completion signals as they arrive. read returns the moment a line
+			# arrives (real-time display); its timeout only bounds how long we
+			# idle before falling through to the backstop inspect. Draining here
+			# ensures the recreate's start/health events are printed and acted on
+			# before the backstop poll can preempt them.
+			local line=""
+			while IFS= read -r -t "$poll_interval" line; do
+				# Parse the event; key off .Action (.status is often null).
+				local action img
+				action=$(echo "$line" | jq -r '.Action // .status // empty' 2>/dev/null)
+				img=$(echo "$line" | jq -r '.Actor.Attributes.image // empty' 2>/dev/null)
+
+				case "$action" in
+					exec_*|"") : ;;  # ignore healthcheck exec noise / unparseable lines
+					start|create|stop|kill|destroy|restart|die|oom|rename|health_status:*)
+						echo "  • [$(date +%T)] $action${img:+ ($img)}"
+						;;
+				esac
+
+				# Candidate completion signals -> verify against real state.
+				if [[ "$action" == "start" || "$action" == "health_status: healthy" || "$action" == "health_status: unhealthy" ]]; then
+					verify_and_finish; local rc=$?
+					[[ $rc -ne 2 ]] && return $rc
+				fi
+
+				# Honour the overall timeout even during a busy event stream.
+				if [[ $(( $(date +%s) - start_time )) -ge $timeout ]]; then
+					echo -e "\nERROR: Timeout waiting for container update after ${timeout}s"
+					return 1
+				fi
+			done
+			# inner read failed: >128 = idle timeout (stream alive); else EOF.
+			[[ $? -le 128 ]] && stream_dead=1
+		else
+			# Event stream ended; fall back to plain polling.
+			sleep "$poll_interval"
+		fi
+
+		# Periodic inspect backstop (and immediately whenever the stream is dead).
+		now=$(date +%s)
+		if [[ $((now - last_poll)) -ge $poll_backstop || $stream_dead -eq 1 ]]; then
+			last_poll=$now
+			verify_and_finish; local rc=$?
+			[[ $rc -ne 2 ]] && return $rc
+		fi
+	done < <(curl -sN --max-time "$timeout" --location --request GET \
+		"$portainer_url/endpoints/$endpoint_id/docker/events?since=$since&filters=$filters" \
+		--header 'Accept: application/json' \
+		--header "X-API-Key: $api_key" 2>/dev/null)
+}
+
+# Demux Docker's multiplexed log stream (non-TTY containers prefix each frame
+# with 8 binary bytes: [stream:1][000][payload-len:4 BE]). Without this the raw
+# header bytes get printed into the console as garbage. Reads stdin, writes text.
+demux_docker_stream() {
+	od -An -v -tx1 | tr ' ' '\n' | awk '
+		BEGIN { for(a=0;a<16;a++)for(b=0;b<16;b++){k=sprintf("%x%x",a,b);hx[k]=a*16+b} }
+		/^[0-9a-fA-F][0-9a-fA-F]$/ { byte[n++]=tolower($0) }
+		END {
+			i=0
+			while(i+8<=n){
+				len=hx[byte[i+4]]*16777216+hx[byte[i+5]]*65536+hx[byte[i+6]]*256+hx[byte[i+7]]
+				i+=8
+				for(j=0;j<len && i<n;j++){ printf "%c", hx[byte[i]]; i++ }
+			}
+		}'
+}
+
+# Function to fetch container logs for error diagnostics
+fetch_container_logs() {
+	local endpoint_id="$1"
+	local container_name="$2"
+	local lines="${3:-50}"  # Default to last 50 lines
+
+	echo -e "\nFetching last $lines lines of logs for container \"$container_name\"..."
+
+	# Get container ID first
+	local containers_json=$(curl -s --location --request GET "$portainer_url/endpoints/$endpoint_id/docker/containers/json?all=true" \
+		--header 'Accept: application/json' \
+		--header "X-API-Key: $api_key")
+
+	local container_id=$(echo "$containers_json" | jq -r --arg container_name "$container_name" \
+		'.[] | select(.Names[] == "/\($container_name)") | .Id')
+
+	if [[ -z "$container_id" ]]; then
+		echo "  Could not find container ID for \"$container_name\""
+		return 1
+	fi
+
+	# Fetch logs via Docker API proxy, demuxing the stream so binary frame
+	# headers don't end up in the console. Pipe directly (NULs survive).
+	local logs=$(curl -s --location --request GET "$portainer_url/endpoints/$endpoint_id/docker/containers/$container_id/logs?stdout=true&stderr=true&tail=$lines" \
+		--header "X-API-Key: $api_key" 2>/dev/null | demux_docker_stream | tail -n "$lines")
+
+	if [[ -n "$logs" ]]; then
+		echo -e "\nContainer logs:"
+		echo "----------------------------------------"
+		echo "$logs"
+		echo "----------------------------------------"
+	else
+		echo "  No logs available or error fetching logs"
+	fi
+}
+
+echo -e "\ncontainer name: $container_name"
+echo "image name: $image_name"
+echo "current version: $current_version"
+echo "desired upgrade version: $update_version"
+echo -e "compose project name: $compose_project"
+
+echo -e "\nretrieving portainer info for container \"$container_name\" in stack \"$compose_project\"..."
+
+# get container endpoint id
+if [[ $watcher_name == "local" ]]; then
+	endpoint_id=1
+else
+	endpoints_json=$(curl -s --location --request GET "$portainer_url/endpoints?name=$watcher_name" \
+		--header 'Accept: application/json' \
+		--header "X-API-KEY: $api_key")
+
+	# Collect candidate endpoint IDs matching the watcher name. Newer Portainer
+	# versions no longer embed the container list in the endpoint snapshot
+	# (.Snapshots[].DockerSnapshotRaw.Containers is null), so verify each
+	# candidate against the live Docker proxy instead.
+	candidate_ids=$(echo "$endpoints_json" | jq -r 'if type == "array" then .[] else . end | .Id')
+	endpoint_id=""
+	for candidate_id in $candidate_ids; do
+		proxy_containers=$(curl -s --location --request GET "$portainer_url/endpoints/$candidate_id/docker/containers/json?all=true" \
+			--header 'Accept: application/json' \
+			--header "X-API-Key: $api_key")
+		match=$(echo "$proxy_containers" | jq -r --arg container_name "$container_name" --arg compose_project "$compose_project" \
+			'[.[] | select(.Names[] == "/\($container_name)" and .Labels["com.docker.compose.project"] == $compose_project)] | length' 2>/dev/null)
+		if [[ "$match" -gt 0 ]] 2>/dev/null; then
+			endpoint_id="$candidate_id"
+			break
+		fi
+	done
+	fi
+data_extraction_error_check "$endpoint_id" "endpoint id"
+
+# get image id from endpoints output
+filter_encoded=$(printf '{"name":["/%s"]}' "$container_name" | jq -sRr @uri)
+endpoint_inspect=$(curl -s --location -g \
+	--request GET "$portainer_url/endpoints/$endpoint_id/docker/containers/json?all=true&filters=$filter_encoded" \
+	--header 'Accept: application/json' \
+	--header "X-API-Key: $api_key")
+image_id=$(echo "$endpoint_inspect" | jq '[.[] | .Portainer.ResourceControl.Id] | first')
+data_extraction_error_check "$image_id" "image id"
+
+# get stack id
+filter_encoded=$(printf '{"EndpointID":%s}' "$endpoint_id" | jq -sRr @uri)
+endpoint_stacks=$(curl -s --location -g \
+	--request GET "$portainer_url/stacks?filters=${filter_encoded}" \
+	--header 'Accept: application/json' \
+	--header "X-API-Key: $api_key")
+stack_id=$(echo "$endpoint_stacks" | jq --arg image_id "$image_id" '[.[] | select(.ResourceControl.Id == ($image_id|tonumber)) | .Id] | first')
+data_extraction_error_check "$stack_id" "stack id"
+
+# get environment variables if present:
+env_data=$(echo "$endpoint_stacks" | jq --arg id "$stack_id" '.[] | select(.Id == ($id | tonumber)) | .Env')
+
+# get stack file contents:
+stack_contents=$(curl -s --location --request GET "$portainer_url/stacks/$stack_id/file" \
+	--header 'Accept: application/json' \
+	--header "X-API-KEY: $api_key")
+if [[ -n $stack_contents ]]; then
+	echo "$compose_project stack file contents retrieved successfully from portainer API"
+else
+	echo -e "\nERROR: $compose_project stack file contents were not retrieved successfully."
+	exit 1
+fi
+
+# check current stack data contains current version
+literal_match=$(printf '%s' "$image_name:$current_version" | sed 's/[][()\.^$?*+|{}]/\\&/g')
+if [[ ! $stack_contents =~ $literal_match ]]; then
+	echo -e "\nERROR: $current_version not found in stack file contents"
+	exit 1
+fi
+
+# update stack data with desired upgrade version
+echo -e "\nupdating $compose_project stack file data with upgrade version: $update_version"
+stack_update=$(echo "$stack_contents" | jq -r \
+	--arg image_name "$image_name" \
+	--arg cur_ver "$current_version" \
+	--arg up_ver "$update_version" \
+	'.StackFileContent |= gsub(($image_name + ":" + $cur_ver); ($image_name + ":" + $up_ver)) | .StackFileContent'
+)
+
+# verify updated stack data contains new version
+literal_match=$(printf '%s' "$image_name:$update_version" | sed 's/[][()\.^$?*+|{}]/\\&/g')
+if [[ $stack_update =~ $literal_match ]]; then
+	echo "successfully updated $compose_project stack data with $update_version"
+else
+	echo -e "\nERROR: $compose_project stack file was not successfully updated."
+	echo -e "\nDEBUG: $compose_project stack file contents:\n$stack_update\n"
+	exit 1
+fi
+
+# Capture initial container state before update
+echo -e "\ncapturing initial container state..."
+initial_containers_json=$(curl -s --location --request GET "$portainer_url/endpoints/$endpoint_id/docker/containers/json?all=true" \
+	--header 'Accept: application/json' \
+	--header "X-API-Key: $api_key")
+
+initial_container_info=$(echo "$initial_containers_json" | jq -r --arg container_name "$container_name" \
+	'.[] | select(.Names[] == "/\($container_name)")')
+
+if [[ -n "$initial_container_info" ]]; then
+	initial_image=$(echo "$initial_container_info" | jq -r '.Image')
+	initial_image_name=$(echo "$initial_image" | awk -F '/' '{print $NF}')
+	initial_image_id=$(echo "$initial_container_info" | jq -r '.ImageID')
+	initial_state=$(echo "$initial_container_info" | jq -r '.State')
+	echo "initial container image: $initial_image_name"
+	echo "initial container state: $initial_state"
+	echo "initial image ID: ${initial_image_id:0:19}..."
+else
+	echo "WARNING: Could not find container \"$container_name\" before update"
+	initial_image_id=""
+fi
+
+# create the curl "stack update" json payload using jq
+env_data=${env_data:-"[]"}
+payload=$(jq -n \
+--argjson env_data "$env_data" \
+--arg stack_file_content "$stack_update" \
+'{env: $env_data, prune: true, pullImage: false, stackFileContent: $stack_file_content}')
+
+# push stack update to portainer API
+echo -e "\npushing $compose_project stack file update to portainer..."
+update_start_time=$(date +%s)
+response=$(curl -s --max-time 300 -i --location \
+	--request PUT "$portainer_url/stacks/$stack_id?endpointId=$endpoint_id" \
+	--header 'Content-Type: application/json' \
+	--header 'Accept: application/json' \
+	--header "X-API-KEY: $api_key" \
+	--data-raw "$payload")
+result=$?
+
+# confirm portainer API response
+http_code=$(echo "$response" | awk 'NR==1 {print $2}')
+if [[ $result -eq 0 ]] && [[ $http_code =~ 2[0-9]{2,} ]]; then
+	echo -e "\nstack update successfully pushed to portainer (http $http_code)"
+	echo "note: portainer is now processing the update asynchronously..."
+else
+	echo -e "\nERROR: failed to push update to portainer.\ncurl exit code: $result\nhttp response code: $http_code\n"
+	# extract the json from the portainer response
+	json_body=$(echo "$response" | tr -d '\r' | awk 'BEGIN{found=0} /^$/{found=1; next} found' | jq .)
+	echo -e "\nDEBUG portainer response:\n$json_body\n"
+	exit 1
+fi
+
+# Wait for container to update with progress monitoring
+if ! wait_for_container_update "$endpoint_id" "$container_name" "$image_name:$update_version" "$update_timeout" "$initial_image_id"; then
+	echo -e "\nERROR: Container did not update within timeout period"
+	fetch_container_logs "$endpoint_id" "$container_name" 30
+	exit 1
+fi
+
+# function to check if any containers are running with the old image
+check_old_container_present() {
+	# perform a fresh API query
+	containers_json=$(curl -s --location --request GET "$portainer_url/endpoints/$endpoint_id/docker/containers/json?all=true" \
+		--header 'Accept: application/json' \
+		--header "X-API-Key: $api_key")
+
+	# check for containers running with the old image version
+	old_container_count=$(echo "$containers_json" | jq --arg old_image "$old_image" \
+		'[.[] | select(.Image | endswith($old_image))] | length')
+
+	echo "$old_container_count"
+}
+
+# verify that the old container is no longer present
+old_image="$image_name:$current_version"
+echo -e "\nensuring the old container is no longer present..."
+
+# loop until the old container is removed
+old_container_wait_start=$(date +%s)
+wait_count=0
+while [[ "$(check_old_container_present)" -gt 0 ]]; do
+	elapsed=$(($(date +%s) - old_container_wait_start))
+	echo "old container with image \"$old_image\" still present, waiting for cleanup... (elapsed: ${elapsed}s)"
+	sleep "$poll_interval"
+	wait_count=$((wait_count + 1))
+done
+
+if [[ $wait_count -gt 0 ]]; then
+	total_wait=$(($(date +%s) - old_container_wait_start))
+	echo "old container removed after ${total_wait}s"
+fi
+
+echo "no containers are running with the old image version: $old_image"
+echo -e "\nupdate verification completed successfully."
+
+# echo -e "\nwaiting for container to normalize..."
+# sleep 30
+# echo -e "\nscript complete."


### PR DESCRIPTION
## Summary
- Bundle the Portainer stack-update script into the image at `/scripts/portainer_stack_update.sh` (debug `tee logfile.txt` line removed; no PII, all endpoint/key come from env vars)
- Make the `script` trigger's `path` config optional, defaulting to the bundled script, so Portainer updates need no `PATH` or volume mount: just `INSTALL=true` plus `PORTAINER_API_ENDPOINT` / `PORTAINER_API_KEY`
- New docs page `docs/configuration/triggers/script/portainer.md` (+ sidebar entry), a root `docker-compose.portainer.example.yml`, and a fix for the stale `WUD_TRIGGER_SCRIPT_` prefix in the generic script doc
- Highlight the bundled Portainer updater as a differentiator in the README

The generic `script` trigger stays generic; the Portainer script is simply the new default you point it at. Custom-script users override `PATH` as before.

## Test Plan
- [x] `Script.test.js` schema suite passes in the throwaway `node:18-alpine` container (two new tests: default path applies when omitted, explicit path overrides; full file 7/7 green, no newly broken tests)
- [x] Image build on the NAS includes `/scripts/portainer_stack_update.sh` as `-rwxr-xr-x`
- [x] Docs free of stale `WUD_` prefix; path string identical across Dockerfile, schema default, and docs
- [x] Manual end-to-end on devtest (port 3009): with only `INSTALL=true` + `PORTAINER_API_*` (no PATH), roll `it-tools` back to create an update, then upgrade via the UI and confirm the script runs from the default path and the container recreates