### PR TITLE
build(eslint): fix parserOptions so optional chaining parses

### DIFF
--- a/app/.eslintrc
+++ b/app/.eslintrc
@@ -1,5 +1,9 @@
 {
     "extends": "airbnb-base",
+    "parserOptions": {
+        "ecmaVersion": 2022,
+        "sourceType": "script"
+    },
     "plugins": ["jest"],
     "rules": {
         "indent": ["error", 4],


### PR DESCRIPTION
## What

Adds `parserOptions` to `app/.eslintrc`:

```json
"parserOptions": { "ecmaVersion": 2022, "sourceType": "script" }
```

## Why

The config extended `airbnb-base` without overriding its inherited `ecmaVersion` (2018), so ESLint could not parse optional chaining (ES2020). Any file using `?.` reported only a fatal `Unexpected token .` parse error, and a parse error suppresses every other rule result for that file. Real violations were hidden behind the parser failure, so `eslint` output could not be trusted.

`sourceType: script` reflects that the backend is CommonJS (`require`/`module.exports`).

## Verification

Run in a clean `node:18-alpine` container (host lacks dev deps):

- Before: multiple fatal `Unexpected token .` parse errors.
- After: **0 parse errors**; ESLint now reports actual rule results across the tree.

This change only makes the linter run correctly. It does not make `npm run lint` pass, the now-unmasked style violations are intentionally left for a separate cleanup.