### PR TITLE
build(deps): bump node-cron 3 -> 4 (app)

### DIFF
--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -30,7 +30,7 @@
         "lokijs": "1.5.12",
         "mqtt": "5.15.1",
         "nocache": "4.0.0",
-        "node-cron": "3.0.3",
+        "node-cron": "4.2.1",
         "node-telegram-bot-api": "0.67.0",
         "nodemailer": "6.10.1",
         "openid-client": "4.9.1",
@@ -9335,24 +9335,12 @@
       }
     },
     "node_modules/node-cron": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/node-cron/-/node-cron-3.0.3.tgz",
-      "integrity": "sha512-dOal67//nohNgYWb+nWmg5dkFdIwDm8EpeGYMekPMrngV3637lqnX0lbUcCtgibHTz6SEz7DAIjKvKDFYCnO1A==",
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/node-cron/-/node-cron-4.2.1.tgz",
+      "integrity": "sha512-lgimEHPE/QDgFlywTd8yTR61ptugX3Qer29efeyWw2rv259HtGBNn1vZVmp8lB9uo9wC0t/AT4iGqXxia+CJFg==",
       "license": "ISC",
-      "dependencies": {
-        "uuid": "8.3.2"
-      },
       "engines": {
         "node": ">=6.0.0"
-      }
-    },
-    "node_modules/node-cron/node_modules/uuid": {
-      "version": "8.3.2",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
-      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
-      "license": "MIT",
-      "bin": {
-        "uuid": "dist/bin/uuid"
       }
     },
     "node_modules/node-int64": {

--- a/app/package.json
+++ b/app/package.json
@@ -34,7 +34,7 @@
     "lokijs": "1.5.12",
     "mqtt": "5.15.1",
     "nocache": "4.0.0",
-    "node-cron": "3.0.3",
+    "node-cron": "4.2.1",
     "node-telegram-bot-api": "0.67.0",
     "nodemailer": "6.10.1",
     "openid-client": "4.9.1",


### PR DESCRIPTION
Risky-majors track, second dependency (after uuid #24).

## What

Bumps `app` `node-cron` from `3.0.3` to `4.2.1` (+ lockfile).

## Surface

The watch loop uses node-cron in exactly two places (`app/watchers/providers/docker/Docker.js`):

- `this.watchCron = cron.schedule(this.configuration.cron, () => this.watchFromCron())`
- `this.watchCron.stop()`

Cron-expression validation is done by `joi-cron-expression`, not node-cron, so the validation path is unaffected. No test references node-cron.

## Why it's safe

v4 is a TypeScript rewrite, but the used surface is drop-in. Verified empirically in a clean `node:18-alpine` container:

- CommonJS `require('node-cron')` works (ships a `require` entry).
- `schedule(expr, fn)` returns a task exposing `start`/`stop`/`destroy`.
- Tasks **auto-start** (the watcher never calls `start()`) - confirmed a `* * * * * *` task fired on cadence without an explicit start.
- `stop()` is synchronous and halts firing.

## Verification

Clean container, `npm ci` from the updated lockfile: full suite green, **46 suites / 413 tests**.