### PR TITLE
build(deps): bump nodemailer 6 -> 8 (app)

### DIFF
--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -32,7 +32,7 @@
         "nocache": "4.0.0",
         "node-cron": "4.2.1",
         "node-telegram-bot-api": "0.67.0",
-        "nodemailer": "6.10.1",
+        "nodemailer": "8.0.10",
         "openid-client": "4.9.1",
         "parse-docker-image-name": "3.0.0",
         "pass": "0.2.0",
@@ -9422,9 +9422,9 @@
       }
     },
     "node_modules/nodemailer": {
-      "version": "6.10.1",
-      "resolved": "https://registry.npmjs.org/nodemailer/-/nodemailer-6.10.1.tgz",
-      "integrity": "sha512-Z+iLaBGVaSjbIzQ4pX6XV41HrooLsQ10ZWPUehGmuantvzWoDVBnmsdUcOIDM1t+yPor5pDhVlDESgOMEGxhHA==",
+      "version": "8.0.10",
+      "resolved": "https://registry.npmjs.org/nodemailer/-/nodemailer-8.0.10.tgz",
+      "integrity": "sha512-BLFuSth7QtHOkBzyqTehWWyub0NTRDuK2Q2SQfnGLsrJnzyU+Yeh4WpV1eZGuARFj1xQJHIdnTuJZLP+b9R1GQ==",
       "license": "MIT-0",
       "engines": {
         "node": ">=6.0.0"

--- a/app/package.json
+++ b/app/package.json
@@ -36,7 +36,7 @@
     "nocache": "4.0.0",
     "node-cron": "4.2.1",
     "node-telegram-bot-api": "0.67.0",
-    "nodemailer": "6.10.1",
+    "nodemailer": "8.0.10",
     "openid-client": "4.9.1",
     "parse-docker-image-name": "3.0.0",
     "pass": "0.2.0",


### PR DESCRIPTION
Risky-majors track, third dependency (after uuid #24, node-cron #25).

## What

Bumps `app` `nodemailer` from `6.10.1` to `8.0.10` (+ lockfile).

## Surface

Used only by the SMTP trigger (`app/triggers/providers/smtp/Smtp.js`):

- `nodemailer.createTransport({ host, port, auth, secure, tls: { rejectUnauthorized } })`
- `transporter.sendMail({ from, to, subject, text })`

This is nodemailer's core API, stable across many majors. No test references nodemailer.

## Why it's safe

v7/v8 raised the Node floor and reworked internals, but the used surface is unchanged. Verified empirically in a clean `node:18-alpine` container:

- v8 stays CommonJS, `require('nodemailer')` works.
- `engines.node` is `>=6.0.0` (Node 18 satisfies).
- `createTransport` + `sendMail` work (via `jsonTransport`, returns a `messageId`).

## Verification

Clean container, `npm ci` from the updated lockfile: full suite green, **46 suites / 413 tests**.