### PR TITLE
build(deps): bump dockerode 4 -> 5 (app)

### DIFF
--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -17,7 +17,7 @@
         "capitalize": "2.0.4",
         "connect-loki": "1.2.0",
         "cors": "2.8.6",
-        "dockerode": "4.0.12",
+        "dockerode": "5.0.0",
         "express": "4.22.2",
         "express-healthcheck": "0.1.0",
         "express-session": "1.19.0",
@@ -6132,9 +6132,9 @@
       }
     },
     "node_modules/dockerode": {
-      "version": "4.0.12",
-      "resolved": "https://registry.npmjs.org/dockerode/-/dockerode-4.0.12.tgz",
-      "integrity": "sha512-/bCZd6KlGcjZO8Buqmi/vXuqEGVEZ0PNjx/biBNqJD3MhK9DmdiAuKxqfNhflgDESDIiBz3qF+0e55+CpnrUcw==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/dockerode/-/dockerode-5.0.0.tgz",
+      "integrity": "sha512-C52mvJ+7lcyhWNfrzVfFsbTrBfy/ezE9FGEYLpu17FUeBcCkxERk9nN7uDl/478ynDiQ4U+5DbQC2vENHkVEtQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "@balena/dockerignore": "^1.0.2",
@@ -6142,25 +6142,10 @@
         "@grpc/proto-loader": "^0.7.13",
         "docker-modem": "^5.0.7",
         "protobufjs": "^7.3.2",
-        "tar-fs": "^2.1.4",
-        "uuid": "^10.0.0"
+        "tar-fs": "^2.1.4"
       },
       "engines": {
-        "node": ">= 8.0"
-      }
-    },
-    "node_modules/dockerode/node_modules/uuid": {
-      "version": "10.0.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-10.0.0.tgz",
-      "integrity": "sha512-8XkAphELsDnEGrDxUOHB3RGvXz6TeuYSGEZBOjtTtPm2lwhGBjLgOzLHB63IUWfBpNucQjND6d3AOudO+H3RWQ==",
-      "deprecated": "uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).",
-      "funding": [
-        "https://github.com/sponsors/broofa",
-        "https://github.com/sponsors/ctavan"
-      ],
-      "license": "MIT",
-      "bin": {
-        "uuid": "dist/bin/uuid"
+        "node": ">= 14.17"
       }
     },
     "node_modules/doctrine": {

--- a/app/package.json
+++ b/app/package.json
@@ -21,7 +21,7 @@
     "capitalize": "2.0.4",
     "connect-loki": "1.2.0",
     "cors": "2.8.6",
-    "dockerode": "4.0.12",
+    "dockerode": "5.0.0",
     "express": "4.22.2",
     "express-healthcheck": "0.1.0",
     "express-session": "1.19.0",


### PR DESCRIPTION
Bumps `dockerode` 4.0.12 -> 5.0.0 in `app/`.

## Why low-risk
v5.0.0 is effectively a drop-in major: the only breaking change is dropping dockerode's internal `uuid` dependency and raising the engines floor to `node >= 14.17` (Node 18 backend unaffected). None of the methods this codebase uses changed signature:

- `new Dockerode(options)` (`Docker.js`, `Script.js`)
- `getEvents(options, cb)`
- `getContainer(id).inspect()`
- `listContainers(options)`
- `getImage(name).inspect()`

Lockfile net `-21/+6` (removes the internal uuid subtree).

## Verification
- Full jest suite green in a clean `node:18-alpine` container: **46 suites / 413 tests pass**.
- Live against a real Docker daemon on the devtest stack: watch loop lists containers across all watchers, the event stream attaches ("Listening to docker events"), registry lookups + digest resolution run, and the API serves container state. No new errors.