### PR TITLE
ci: add hardened CI workflow and harden release publish

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,220 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+# Least privilege by default; each job opts back in to only what it needs.
+permissions: {}
+
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  actionlint:
+    name: actionlint
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
+        with:
+          persist-credentials: false
+      - name: Run actionlint
+        # Pinned release + checksum so a tampered binary can't slip in.
+        env:
+          ACTIONLINT_VERSION: 1.7.7
+          ACTIONLINT_SHA256: 023070a287cd8cccd71515fedc843f1985bf96c436b7effaecce67290e7e0757
+        run: |
+          set -euo pipefail
+          curl -fsSL -o actionlint.tar.gz \
+            "https://github.com/rhysd/actionlint/releases/download/v${ACTIONLINT_VERSION}/actionlint_${ACTIONLINT_VERSION}_linux_amd64.tar.gz"
+          echo "${ACTIONLINT_SHA256}  actionlint.tar.gz" | sha256sum -c -
+          tar -xzf actionlint.tar.gz actionlint
+          ./actionlint -color
+
+  zizmor:
+    name: zizmor
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
+        with:
+          persist-credentials: false
+      - name: Run zizmor
+        # Static analysis of the workflows themselves: template injection,
+        # unpinned actions, credential persistence, over-broad permissions.
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: pipx run zizmor==1.25.2 .github/workflows
+
+  hadolint:
+    name: hadolint
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
+        with:
+          persist-credentials: false
+      - name: Lint Dockerfile
+        uses: hadolint/hadolint-action@2332a7b74a6de0dda2e2221d575162eba76ba5e5  # v3.3.0
+        with:
+          dockerfile: Dockerfile
+          # DL3018: pinning apk versions is impractical on Alpine; base images
+          # are pinned by tag and old apk versions get purged from the repo.
+          # DL3019: the apk block mixes `apk update`/cache-clean with --no-cache;
+          # an info-level style nit, not worth reworking the prod image build here.
+          ignore: DL3018,DL3019
+
+  gitleaks:
+    name: gitleaks
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
+        with:
+          persist-credentials: false
+          fetch-depth: 0
+      - name: Scan for secrets
+        # The repo ships compose examples and a bundled Portainer updater that
+        # reads PORTAINER_API_* env; this guards against committing a real one.
+        uses: gitleaks/gitleaks-action@ff98106e4c7b2bc287b24eaf42907196329070c7  # v2.3.9
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  shellcheck:
+    name: ShellCheck
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
+        with:
+          persist-credentials: false
+      - name: Run shellcheck
+        # First-party scripts that ship in the image. Print every finding for
+        # visibility, but only fail on error severity so pre-existing
+        # info/warning items don't block.
+        run: |
+          shellcheck scripts/portainer_stack_update.sh Docker.entrypoint.sh || true
+          echo "--- gating on error severity ---"
+          shellcheck --severity=error scripts/portainer_stack_update.sh Docker.entrypoint.sh
+
+  app-test:
+    name: app tests (jest)
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
+        with:
+          persist-credentials: false
+      - name: Set up Node 18
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e  # v6.4.0
+        with:
+          node-version: 18
+          cache: npm
+          cache-dependency-path: app/package-lock.json
+      - name: Install deps
+        working-directory: app
+        run: npm ci --no-audit --no-fund
+      - name: Run jest
+        working-directory: app
+        run: npm test
+
+  ui-build:
+    name: ui build (vite)
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
+        with:
+          persist-credentials: false
+      - name: Set up Node 20
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e  # v6.4.0
+        with:
+          node-version: 20
+          cache: npm
+          cache-dependency-path: ui/package-lock.json
+      - name: Install deps
+        working-directory: ui
+        run: npm ci --no-audit --no-fund
+      - name: Build
+        working-directory: ui
+        run: npm run build
+
+  docker-build:
+    name: Build image and scan
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      security-events: write  # upload Trivy SARIF to code scanning
+    steps:
+      - name: Checkout
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
+        with:
+          persist-credentials: false
+      - name: Set up Buildx
+        uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5  # v4.1.0
+      # Build (no push) so a broken Dockerfile fails on the PR, not at release.
+      - name: Build image
+        uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf  # v7.2.0
+        with:
+          context: .
+          push: false
+          load: true
+          tags: hosaka:ci
+          build-args: |
+            HOSAKA_VERSION=ci
+      - name: Scan image with Trivy
+        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25  # v0.36.0
+        with:
+          image-ref: hosaka:ci
+          format: sarif
+          output: trivy-results.sarif
+          ignore-unfixed: true
+        env:
+          # Pin DB sources to avoid rate-limited Docker Hub mirrors.
+          TRIVY_DB_REPOSITORY: ghcr.io/aquasecurity/trivy-db:2
+      - name: Upload Trivy results
+        uses: github/codeql-action/upload-sarif@03e4368ac7daa2bd82b3e85262f3bf87ee112f57  # v3.36.0
+        with:
+          sarif_file: trivy-results.sarif
+          category: trivy-image
+
+  npm-audit:
+    name: npm audit (advisory)
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    strategy:
+      fail-fast: false
+      matrix:
+        package: [app, ui, e2e]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
+        with:
+          persist-credentials: false
+      - name: Set up Node 20
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e  # v6.4.0
+        with:
+          node-version: 20
+      - name: Audit ${{ matrix.package }}
+        working-directory: ${{ matrix.package }}
+        # Advisory only: surfaces high+ advisories without blocking the merge.
+        run: npm audit --audit-level=high || true

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -4,6 +4,9 @@ on:
   release:
     types: [published]
 
+# Least privilege by default; the single job opts in to what it needs.
+permissions: {}
+
 env:
   REGISTRY: ghcr.io
   IMAGE_NAME: ${{ github.repository }}
@@ -13,14 +16,18 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      packages: write
-
+      packages: write          # push to ghcr
+      id-token: write          # OIDC for build provenance
+      attestations: write      # write the attestation
+      security-events: write   # upload Trivy SARIF
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
+        with:
+          persist-credentials: false
 
       - name: Log in to GitHub Container Registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee  # v4.2.0
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
@@ -28,9 +35,10 @@ jobs:
 
       - name: Derive image tags and labels
         id: meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@c299e40c65443455700f0fdfc63efafe5b349051  # v5.10.0
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          # Release tag (e.g. v1.2.3 -> 1.2.3, 1.2, 1), plus latest.
           tags: |
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
@@ -38,15 +46,14 @@ jobs:
             type=raw,value=latest
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
+        uses: docker/setup-qemu-action@06116385d9baf250c9f4dcb4858b16962ea869c3  # v4.1.0
 
       - name: Set up Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5  # v4.1.0
 
       - name: Build and push
-        env:
-          HOSAKA_VERSION: ${{ github.event.release.tag_name }}
-        uses: docker/build-push-action@v6
+        id: build
+        uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf  # v7.2.0
         with:
           context: .
           platforms: linux/amd64,linux/arm64
@@ -54,4 +61,30 @@ jobs:
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           build-args: |
-            HOSAKA_VERSION=${{ env.HOSAKA_VERSION }}
+            HOSAKA_VERSION=${{ github.event.release.tag_name }}
+
+      - name: Attest build provenance
+        # Cryptographically binds the published image to this workflow, commit,
+        # and runner. Verify with:
+        #   gh attestation verify oci://ghcr.io/nopoz/hosaka@<digest> -R nopoz/hosaka
+        uses: actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32  # v4.1.0
+        with:
+          subject-name: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          subject-digest: ${{ steps.build.outputs.digest }}
+          push-to-registry: true
+
+      - name: Scan published image with Trivy
+        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25  # v0.36.0
+        with:
+          image-ref: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}@${{ steps.build.outputs.digest }}
+          format: sarif
+          output: trivy-results.sarif
+          ignore-unfixed: true
+        env:
+          TRIVY_DB_REPOSITORY: ghcr.io/aquasecurity/trivy-db:2
+
+      - name: Upload Trivy results
+        uses: github/codeql-action/upload-sarif@03e4368ac7daa2bd82b3e85262f3bf87ee112f57  # v3.36.0
+        with:
+          sarif_file: trivy-results.sarif
+          category: trivy-release


### PR DESCRIPTION
Adds `.github/workflows/ci.yml` and hardens `.github/workflows/publish.yml`. These land together because the new `zizmor` job scans the whole workflows directory, so `publish.yml` must be SHA-pinned for CI to pass (the planned PR split would have produced a knowingly-red intermediate).

## ci.yml jobs
**Security / hygiene** (ported from the hardened portrieve / pfsense-dnscrypt-proxy setup): actionlint (checksum-verified binary), zizmor (workflow SAST), hadolint (Dockerfile; ignores `DL3018`/`DL3019` Alpine apk-style nits), gitleaks (guards the bundled `PORTAINER_API_*`), shellcheck (first-party `scripts/portainer_stack_update.sh` + `Docker.entrypoint.sh`, gated on error severity).

**Build gates** (tailored to this 3-package JS+Docker monorepo): `app` jest (green, 46/413), `ui` vite build on Node 20, full multi-stage `docker build` (no push) + Trivy image scan with SARIF upload, advisory `npm audit` matrix across app/ui/e2e.

## publish.yml hardening
- SHA-pin every action (was floating `@v3`/`@v4`/`@v5`/`@v6`).
- Top-level `permissions: {}`; job opts into `contents:read`, `packages:write`, `id-token:write`, `attestations:write`, `security-events:write`.
- `persist-credentials: false` on checkout.
- SLSA **build-provenance attestation** bound to the pushed image digest.
- **Trivy scan of the published image by digest** with SARIF upload.
- Preserves multi-arch (amd64/arm64) and the `HOSAKA_VERSION` build-arg.

## Deliberately excluded
`npm run lint` (not yet green) and e2e/cucumber (needs a live stack). `npm audit` is advisory, not a required check.

Validated locally before pushing: actionlint + zizmor clean on both files, hadolint clean with the two ignores, shellcheck error-gate clean.