### PR TITLE
ci: add CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+# Default owner for everything in this repo.
+* @nopoz


### PR DESCRIPTION
Adds `.github/CODEOWNERS` (`* @nopoz`) so the branch-protection ruleset can require code-owner review.