### PR TITLE
docs: replace example credentials with placeholders

### DIFF
--- a/docs/configuration/registries/acr/README.md
+++ b/docs/configuration/registries/acr/README.md
@@ -23,13 +23,13 @@ services:
     ...
     environment:
       - WUD_REGISTRY_ACR_CLIENTID=7c0195aa-112d-4ac3-be24-6664a13f3d2b
-      - WUD_REGISTRY_ACR_CLIENTSECRET=SBgHNi3zA5K.f9.f9ft~_hpqbS~.pk.t_i
+      - WUD_REGISTRY_ACR_CLIENTSECRET=your-azure-client-secret
 ```
 #### **Docker**
 ```bash
 docker run \
   -e WUD_REGISTRY_ACR_CLIENTID=7c0195aa-112d-4ac3-be24-6664a13f3d2b \
-  -e WUD_REGISTRY_ACR_CLIENTSECRET=SBgHNi3zA5K.f9.f9ft~_hpqbS~.pk.t_i \
+  -e WUD_REGISTRY_ACR_CLIENTSECRET=your-azure-client-secret \
   ...
   getwud/wud
 ```

--- a/docs/configuration/triggers/telegram/README.md
+++ b/docs/configuration/triggers/telegram/README.md
@@ -25,14 +25,14 @@ services:
     image: getwud/wud
     ...
     environment:
-      - WUD_TRIGGER_TELEGRAM_1_BOTTOKEN=0123456789:AApFzFLD0g0NVg8l0bZf55ex3sajC4Aw84Q
+      - WUD_TRIGGER_TELEGRAM_1_BOTTOKEN=your-telegram-bot-token
       - WUD_TRIGGER_TELEGRAM_1_CHATID=9876543210
 ```
 
 #### **Docker**
 ```bash
 docker run \
-  -e WUD_TRIGGER_TELEGRAM_1_BOTTOKEN="0123456789:AApFzFLD0g0NVg8l0bZf55ex3sajC4Aw84Q" \
+  -e WUD_TRIGGER_TELEGRAM_1_BOTTOKEN="your-telegram-bot-token" \
   -e WUD_TRIGGER_TELEGRAM_1_CHATID="9876543210" \
   ...
   getwud/wud


### PR DESCRIPTION
Secret scanning flagged two documentation examples carried over from upstream:

- `docs/configuration/triggers/telegram/README.md` — sample value matched the Telegram bot token pattern
- `docs/configuration/registries/acr/README.md` — sample value matched the Azure AD application secret pattern

Neither is a real credential. Replaced both with obvious placeholders (`your-telegram-bot-token`, `your-azure-client-secret`) so they no longer match the detectors. The corresponding open alerts are being resolved as false positives.

Scope kept surgical: only the example credential values changed; the `WUD_`/`getwud` rebrand of these docs remains separate.