### PR TITLE
ci: add Dependabot for npm packages and workflow actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,53 @@
+# Dependabot version updates.
+# Keeps the three npm packages and the workflow action pins current so the
+# dependency CVEs that prompted the security-scan remediation don't recur.
+# Non-major updates are grouped into one PR per ecosystem to cut noise; majors
+# still open individually (they are handled as their own modernization tracks).
+version: 2
+updates:
+  # Workflow action pins (SHA-pinned with # vX.Y.Z comments). Dependabot bumps
+  # both the SHA and the version comment, so the pins stay fresh automatically.
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+    groups:
+      github-actions:
+        patterns:
+          - "*"
+
+  # Backend (Node 18 in prod).
+  - package-ecosystem: npm
+    directory: /app
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 5
+    groups:
+      app-non-major:
+        update-types:
+          - minor
+          - patch
+
+  # Frontend SPA.
+  - package-ecosystem: npm
+    directory: /ui
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 5
+    groups:
+      ui-non-major:
+        update-types:
+          - minor
+          - patch
+
+  # End-to-end tests.
+  - package-ecosystem: npm
+    directory: /e2e
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 5
+    groups:
+      e2e-non-major:
+        update-types:
+          - minor
+          - patch


### PR DESCRIPTION
Adds `.github/dependabot.yml` to keep dependencies and action pins current, addressing the recurring dependency-CVE churn surfaced during the security-scan remediation.

## What

- **npm** version updates for all three packages: `app`, `ui`, `e2e` (weekly).
- **github-actions** updates for the workflow pins (weekly) - bumps both the SHA and the `# vX.Y.Z` comment so the pins stay fresh.
- Non-major updates are **grouped** into one PR per ecosystem to cut noise; majors still open individually (handled as their own modernization tracks).

## Notes

- Manifest + lockfile confirmed present for each npm directory.
- Config validated as well-formed YAML.
- First of a short series from the CI/workflow review (Dependabot, CodeQL, nightly scan, publish.yml polish).