### PR TITLE
ci: add CodeQL analysis for JavaScript/TypeScript

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,48 @@
+name: CodeQL
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+  schedule:
+    # Weekly run so newly-published queries flag latent issues between PRs.
+    - cron: "0 6 * * 1"
+  workflow_dispatch:
+
+# Least privilege by default; the analyze job opts back in to what it needs.
+permissions: {}
+
+concurrency:
+  group: codeql-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  analyze:
+    name: CodeQL analyze
+    runs-on: ubuntu-latest
+    permissions:
+      actions: read          # read workflow run metadata
+      contents: read
+      security-events: write  # upload CodeQL results to code scanning
+    strategy:
+      fail-fast: false
+      matrix:
+        # Single combined identifier covers both the app/ backend and ui/ SPA.
+        language: [javascript-typescript]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6.0.3
+        with:
+          persist-credentials: false
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@8aad20d150bbac5944a9f9d289da16a4b0d87c1e  # v4.36.2
+        with:
+          languages: ${{ matrix.language }}
+          # JS/TS is interpreted; no compilation step needed.
+          build-mode: none
+
+      - name: Perform CodeQL analysis
+        uses: github/codeql-action/analyze@8aad20d150bbac5944a9f9d289da16a4b0d87c1e  # v4.36.2
+        with:
+          category: "/language:${{ matrix.language }}"


### PR DESCRIPTION
Adds source-level SAST for the codebase, the biggest gap surfaced by the CI/workflow review (Trivy only scans the built image for known-CVE dependencies; nothing analyzed app/ui source for injection/taint bugs).

## What

- New `.github/workflows/codeql.yml` analyzing `javascript-typescript` (covers both the `app/` backend and `ui/` SPA), `build-mode: none`.
- Triggers: PRs, push to `main`, weekly schedule, and manual dispatch.
- House style: top-level `permissions: {}`, per-job least-privilege (`actions: read`, `contents: read`, `security-events: write`), `persist-credentials: false`, `concurrency` with cancel-in-progress.
- Action pins (checkout v6.0.3; codeql-action v4.36.2) match the versions used elsewhere in CI after the actions-group bump.

## Notes

- Implemented as a version-controlled advanced workflow rather than default setup, to match the repo's SHA-pinned house style.
- Results upload to code scanning (already enabled; repo is public).
- Follow-up (separate, not in this PR): add CodeQL as a required status check in the branch ruleset once a clean baseline run lands.