### PR TITLE
ci: add SBOM attestation and concurrency guard to publish

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -11,6 +11,11 @@ env:
   REGISTRY: ghcr.io
   IMAGE_NAME: ${{ github.repository }}
 
+# Serialize publishes per release ref; never cancel one mid-push.
+concurrency:
+  group: publish-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
+
 jobs:
   build-and-push:
     runs-on: ubuntu-latest
@@ -62,6 +67,12 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
           build-args: |
             HOSAKA_VERSION=${{ github.event.release.tag_name }}
+          # Attach an SBOM attestation to the pushed image (supply-chain
+          # transparency). Provenance is left to the dedicated
+          # attest-build-provenance step below to avoid duplicate provenance
+          # attestations.
+          sbom: true
+          provenance: false
 
       - name: Attest build provenance
         # Cryptographically binds the published image to this workflow, commit,


### PR DESCRIPTION
Final item from the CI/workflow review: supply-chain hardening for the release publish.

## What

- **SBOM attestation** (`sbom: true` on build-push-action): attaches a Software Bill of Materials attestation to the pushed multi-arch image, so consumers can inspect what's inside it.
- **Concurrency guard**: serializes publishes per release ref with `cancel-in-progress: false` (never interrupt an in-flight push).
- **Provenance deliberately left to the existing step** (`provenance: false`): `actions/attest-build-provenance` already emits GH-native SLSA provenance for the image digest; enabling BuildKit provenance too would just duplicate it.

## Notes

- House style preserved (SHA-pinned, `permissions: {}` + least-priv, `persist-credentials: false`).
- Validated: YAML parses, actionlint clean.
- Untestable until a release is actually cut (the ghcr image doesn't exist yet, track 11). The SBOM flag turns the pushed artifact into an OCI index with an attestation manifest; the digest-based attest + Trivy steps remain valid against that index. Worth confirming on the first real publish; trivially revertable if multi-arch attestation misbehaves.