### PR TITLE
feat(watcher): drop sig/sha tags and propagate tag prefix in candidates

### DIFF
--- a/app/watchers/providers/docker/Docker.js
+++ b/app/watchers/providers/docker/Docker.js
@@ -81,6 +81,37 @@ function getTagCandidates(container, tags, logContainer, imageDigestMap = new Ma
         }
     }
 
+    // Always drop Cosign signature tags (e.g. "1.2.3.sig"); they would otherwise
+    // coerce to a real semver and leak in as bogus candidates.
+    filteredTags = filteredTags.filter((tag) => !tag.endsWith('.sig'));
+    logContainer.debug(`[TagFilter] After .sig drop: ${filteredTags.length} tags`);
+
+    const noUserInclude = !container.includeTags;
+
+    // Drop content-addressed "sha..." tags unless the user pinned an include
+    // regex (they coerce to bogus high semvers otherwise).
+    if (noUserInclude) {
+        filteredTags = filteredTags.filter((tag) => !tag.startsWith('sha'));
+        logContainer.debug(`[TagFilter] After sha drop: ${filteredTags.length} tags`);
+    }
+
+    // Tag-prefix propagation: keep only tags sharing the current tag's
+    // non-numeric prefix (so a "v1.2.3" container is not offered a bare
+    // "1.3.0"). Skipped when the user pinned an include regex, or when the
+    // digest map already aliased the candidates (aliases of the same image
+    // legitimately differ in prefix, e.g. local "8" -> alias "8.0.0").
+    if (noUserInclude && !matchingDigest) {
+        const currentTag = container.image.tag.value;
+        const prefixMatch = currentTag.match(/^(.*?)(\d+.*)$/);
+        const currentPrefix = prefixMatch ? prefixMatch[1] : '';
+        if (currentPrefix) {
+            filteredTags = filteredTags.filter((tag) => tag.startsWith(currentPrefix));
+        } else {
+            filteredTags = filteredTags.filter((tag) => /^\d/.test(tag));
+        }
+        logContainer.debug(`[TagFilter] After prefix propagation ('${currentPrefix}'): ${filteredTags.length} tags`);
+    }
+
     if (filteredTags.length === 0) {
         logContainer.warn('No tags found after filtering. Check regex filters.');
     }

--- a/app/watchers/providers/docker/Docker.test.js
+++ b/app/watchers/providers/docker/Docker.test.js
@@ -142,12 +142,69 @@ const getTagCandidatesTestCases = [{
     },
     items: ['1.10.0', '1.2.3'],
     candidates: ['1.10.0'],
+}, {
+    // (b) .sig dropped (no include regex). Without the filter '7.8.9.sig'
+    // coerces to 7.8.9 and would leak in as a candidate.
+    source: sampleSemver,
+    items: ['7.8.9', '7.8.9.sig'],
+    candidates: ['7.8.9'],
+}, {
+    // (b) .sig dropped EVEN WITH an include regex that matches it (always-on).
+    source: {
+        ...sampleSemver,
+        includeTags: '7.8.9',
+    },
+    items: ['7.8.9', '7.8.9.sig'],
+    candidates: ['7.8.9'],
+}, {
+    // (a)+(c) sha-prefixed digest tag dropped (no include regex). Without the
+    // filters 'sha256abcdef' coerces to 256.0.0 and would leak in.
+    source: sampleSemver,
+    items: ['7.8.9', 'sha256abcdef'],
+    candidates: ['7.8.9'],
+}, {
+    // (a) gate off: when an include regex matches a sha tag, the sha-prefix
+    // filter is bypassed and the tag survives (it coerces to a real semver).
+    // Proves the sha drop is gated on the absence of a user include regex.
+    source: {
+        ...sampleSemver,
+        includeTags: 'sha',
+    },
+    items: ['sha256abcdef'],
+    candidates: ['sha256abcdef'],
+}, {
+    // (c) prefix propagation: current 'v1.2.3' keeps only 'v'-prefixed tags,
+    // so a bare '1.3.0' is rejected and 'v1.3.0' accepted.
+    source: {
+        image: {
+            tag: {
+                value: 'v1.2.3',
+                semver: true,
+            },
+        },
+    },
+    items: ['v1.3.0', '1.3.0'],
+    candidates: ['v1.3.0'],
+}, {
+    // coerced-semver preserved (regression guard for the omitted segment-count
+    // filter): current '4.5' still offered 3-segment '7.8.9'.
+    source: sampleCoercedSemver,
+    items: ['7.8.9', '7.8.9.sig'],
+    candidates: ['7.8.9'],
+}, {
+    // digest-alias preserved (regression guard): alias 'v8.0.0' survives even
+    // though prefix propagation would otherwise drop it (current tag '4.5.6'
+    // has no prefix). digest match also skips the greater-semver step.
+    source: sampleSemver,
+    items: ['v8.0.0'],
+    imageDigestMap: new Map([['xxx', { tags: ['v8.0.0'] }]]),
+    candidates: ['v8.0.0'],
 }];
 
 test.each(getTagCandidatesTestCases)(
     'getTagCandidates should behave as expected',
     (item) => {
-        expect(Docker.__get__('getTagCandidates')(item.source, item.items, docker.log)).toEqual(item.candidates);
+        expect(Docker.__get__('getTagCandidates')(item.source, item.items, docker.log, item.imageDigestMap)).toEqual(item.candidates);
     },
 );
 


### PR DESCRIPTION
## What

Ports three upstream tag-noise filters into the fork's `getTagCandidates`:

- **`.sig` drop** (always): Cosign signature tags would otherwise coerce to a real semver and appear as bogus candidates.
- **`sha` drop** (when no include regex): content-addressed `sha...` tags coerce to bogus high versions.
- **Tag-prefix propagation** (when no include regex and not a digest match): a `v1.2.3` container is no longer offered a bare `1.3.0`.

## Intentionally not ported

Upstream's numeric-segment-count match is omitted: it would regress the fork's coerced-semver support (a `4.5`-tagged container would stop being offered a 3-segment `7.8.9`).

## Preserved

- Fork-unique digest-map alias matching (aliases that differ in prefix survive).
- Coerced-semver candidates.

## Verified

Full backend jest suite green (46 suites / 421 tests) and eslint clean on the changed files (no new violations), run in a `node:18-alpine` container.