### PR TITLE
feat(trigger): per-container trigger routing labels

### DIFF
--- a/app/model/container.js
+++ b/app/model/container.js
@@ -17,6 +17,8 @@ const schema = joi.object({
     excludeTags: joi.string(),
     transformTags: joi.string(),
     linkTemplate: joi.string(),
+    triggerInclude: joi.string(),
+    triggerExclude: joi.string(),
     link: joi.string(),
     image: joi.object({
         id: joi.string().min(1).required(),

--- a/app/triggers/providers/Trigger.js
+++ b/app/triggers/providers/Trigger.js
@@ -43,6 +43,8 @@ class Trigger extends Component {
             try {
                 if (!this.isThresholdReached(containerReport.container)) {
                     logContainer.debug('Threshold not reached => do not trigger');
+                } else if (!this.mustTrigger(containerReport.container)) {
+                    logContainer.debug('Trigger routing excludes this container => do not trigger');
                 } else {
                     logContainer.debug('Run trigger');
                     await this.trigger(containerReport.container);
@@ -68,7 +70,8 @@ class Trigger extends Component {
             const containerReportsFiltered = containerReports
                 .filter((containerReport) => containerReport.changed || !this.configuration.once)
                 .filter((containerReport) => containerReport.container.updateAvailable)
-                .filter((containerReport) => this.isThresholdReached(containerReport.container));
+                .filter((containerReport) => this.isThresholdReached(containerReport.container))
+                .filter((containerReport) => this.mustTrigger(containerReport.container));
             const containersFiltered = containerReportsFiltered
                 .map((containerReport) => containerReport.container);
             if (containersFiltered.length > 0) {
@@ -82,21 +85,28 @@ class Trigger extends Component {
     }
 
     /**
-     * Return true if update reaches trigger threshold.
+     * Return true if update reaches the given threshold (defaults to the
+     * trigger's configured threshold).
      * @param containerResult
+     * @param threshold
      * @returns {boolean}
      */
-    isThresholdReached(containerResult) {
+    isThresholdReached(containerResult, threshold = this.configuration.threshold) {
         let thresholdPassing = true;
         if (
-            this.configuration.threshold.toLowerCase() !== 'all'
+            threshold.toLowerCase() !== 'all'
             && containerResult.updateKind
             && containerResult.updateKind.kind === 'tag'
             && containerResult.updateKind.semverDiff
             && containerResult.updateKind.semverDiff !== 'unknown'
         ) {
-            const threshold = this.configuration.threshold.toLowerCase();
-            switch (threshold) {
+            switch (threshold.toLowerCase()) {
+            case 'major-only':
+                thresholdPassing = containerResult.updateKind.semverDiff === 'major';
+                break;
+            case 'minor-only':
+                thresholdPassing = containerResult.updateKind.semverDiff === 'minor';
+                break;
             case 'minor':
                 thresholdPassing = containerResult.updateKind.semverDiff !== 'major';
                 break;
@@ -109,6 +119,96 @@ class Trigger extends Component {
             }
         }
         return thresholdPassing;
+    }
+
+    /**
+     * Parse an "id" or "id:threshold" trigger string.
+     * @param includeOrExcludeTriggerString
+     * @returns {{id: string, threshold: string}}
+     */
+    static parseIncludeOrExcludeTriggerString(includeOrExcludeTriggerString) {
+        const split = includeOrExcludeTriggerString.split(/\s*:\s*/);
+        const parsed = { id: split[0], threshold: 'all' };
+        if (split.length === 2) {
+            switch (split[1]) {
+            case 'major-only':
+                parsed.threshold = 'major-only';
+                break;
+            case 'minor-only':
+                parsed.threshold = 'minor-only';
+                break;
+            case 'major':
+                parsed.threshold = 'major';
+                break;
+            case 'minor':
+                parsed.threshold = 'minor';
+                break;
+            case 'patch':
+                parsed.threshold = 'patch';
+                break;
+            default:
+                parsed.threshold = 'all';
+            }
+        }
+        return parsed;
+    }
+
+    /**
+     * Return true if this trigger id is in the comma-separated list AND the
+     * update reaches the per-entry threshold.
+     * @param containerResult
+     * @param triggerList
+     * @returns {boolean}
+     */
+    isTriggerIncludedOrExcluded(containerResult, triggerList) {
+        const triggers = triggerList
+            .split(/\s*,\s*/)
+            .map((t) => Trigger.parseIncludeOrExcludeTriggerString(t));
+        const matched = triggers
+            .find((t) => t.id.toLowerCase() === this.getId().toLowerCase());
+        if (!matched) {
+            return false;
+        }
+        return this.isThresholdReached(containerResult, matched.threshold.toLowerCase());
+    }
+
+    /**
+     * Return true when the container does not restrict includes, or this
+     * trigger is in the include list.
+     * @param containerResult
+     * @param triggerInclude
+     * @returns {boolean}
+     */
+    isTriggerIncluded(containerResult, triggerInclude) {
+        if (!triggerInclude) {
+            return true;
+        }
+        return this.isTriggerIncludedOrExcluded(containerResult, triggerInclude);
+    }
+
+    /**
+     * Return true when this trigger is in the exclude list (and threshold met).
+     * @param containerResult
+     * @param triggerExclude
+     * @returns {boolean}
+     */
+    isTriggerExcluded(containerResult, triggerExclude) {
+        if (!triggerExclude) {
+            return false;
+        }
+        return this.isTriggerIncludedOrExcluded(containerResult, triggerExclude);
+    }
+
+    /**
+     * Return true if this trigger must fire for the container per its routing
+     * labels.
+     * @param containerResult
+     * @returns {boolean}
+     */
+    mustTrigger(containerResult) {
+        const { triggerInclude, triggerExclude } = containerResult;
+        return this.isTriggerIncluded(containerResult, triggerInclude)
+            && !this.isTriggerExcluded(containerResult, triggerExclude);
     }
 
     /**
@@ -141,7 +241,7 @@ class Trigger extends Component {
             threshold: this.joi
                 .string()
                 .insensitive()
-                .valid('all', 'major', 'minor', 'patch')
+                .valid('all', 'major', 'minor', 'patch', 'major-only', 'minor-only')
                 .default('all'),
             mode: this.joi
                 .string()

--- a/app/triggers/providers/Trigger.test.js
+++ b/app/triggers/providers/Trigger.test.js
@@ -377,3 +377,81 @@ test('renderBatchBody should replace placeholders when called', async () => {
         },
     }])).toEqual('- Container container-name running with tag 1.0.0 can be updated to tag 2.0.0\nhttp://test\n');
 });
+
+test('parseIncludeOrExcludeTriggerString parses id and threshold', () => {
+    expect(Trigger.parseIncludeOrExcludeTriggerString('trigger.smtp.main'))
+        .toEqual({ id: 'trigger.smtp.main', threshold: 'all' });
+    expect(Trigger.parseIncludeOrExcludeTriggerString('trigger.smtp.main:minor'))
+        .toEqual({ id: 'trigger.smtp.main', threshold: 'minor' });
+    expect(Trigger.parseIncludeOrExcludeTriggerString('trigger.smtp.main:major-only'))
+        .toEqual({ id: 'trigger.smtp.main', threshold: 'major-only' });
+    expect(Trigger.parseIncludeOrExcludeTriggerString('trigger.smtp.main:bogus'))
+        .toEqual({ id: 'trigger.smtp.main', threshold: 'all' });
+});
+
+const isThresholdReachedOverrideTestCases = [
+    { threshold: 'major-only', semverDiff: 'major', expected: true },
+    { threshold: 'major-only', semverDiff: 'minor', expected: false },
+    { threshold: 'minor-only', semverDiff: 'minor', expected: true },
+    { threshold: 'minor-only', semverDiff: 'major', expected: false },
+    { threshold: 'minor', semverDiff: 'major', expected: false },
+    { threshold: 'minor', semverDiff: 'minor', expected: true },
+    { threshold: 'minor', semverDiff: 'patch', expected: true },
+    { threshold: 'patch', semverDiff: 'minor', expected: false },
+    { threshold: 'patch', semverDiff: 'patch', expected: true },
+    { threshold: 'all', semverDiff: 'major', expected: true },
+];
+
+test.each(isThresholdReachedOverrideTestCases)(
+    'isThresholdReached($threshold, $semverDiff) === $expected',
+    ({ threshold, semverDiff, expected }) => {
+        const container = { updateKind: { kind: 'tag', semverDiff } };
+        expect(trigger.isThresholdReached(container, threshold)).toEqual(expected);
+    },
+);
+
+const mustTriggerTestCases = [
+    // no labels => fires
+    { triggerInclude: undefined, triggerExclude: undefined, expected: true },
+    // include matches this trigger id => fires
+    { triggerInclude: 'trigger.mock.mock', triggerExclude: undefined, expected: true },
+    // include does not match => does not fire
+    { triggerInclude: 'trigger.other.x', triggerExclude: undefined, expected: false },
+    // exclude matches this trigger id => does not fire
+    { triggerInclude: undefined, triggerExclude: 'trigger.mock.mock', expected: false },
+    // include with cumulative ':minor' and a patch update => fires (minor covers patch)
+    {
+        triggerInclude: 'trigger.mock.mock:minor', triggerExclude: undefined, semverDiff: 'patch', expected: true,
+    },
+    // include with ':patch' and a major update => does not fire (threshold not reached)
+    {
+        triggerInclude: 'trigger.mock.mock:patch', triggerExclude: undefined, semverDiff: 'major', expected: false,
+    },
+    // include with exact ':minor-only' and a patch update => does not fire
+    {
+        triggerInclude: 'trigger.mock.mock:minor-only', triggerExclude: undefined, semverDiff: 'patch', expected: false,
+    },
+    // exclude with ':major-only' and a minor update => still fires (exclude threshold not reached)
+    {
+        triggerInclude: undefined, triggerExclude: 'trigger.mock.mock:major-only', semverDiff: 'minor', expected: true,
+    },
+    // case-insensitive id match
+    { triggerInclude: 'TRIGGER.MOCK.MOCK', triggerExclude: undefined, expected: true },
+];
+
+test.each(mustTriggerTestCases)(
+    'mustTrigger include=$triggerInclude exclude=$triggerExclude => $expected',
+    ({
+        triggerInclude, triggerExclude, semverDiff, expected,
+    }) => {
+        trigger.kind = 'trigger';
+        trigger.type = 'mock';
+        trigger.name = 'mock';
+        const container = {
+            triggerInclude,
+            triggerExclude,
+            updateKind: { kind: 'tag', semverDiff: semverDiff || 'major' },
+        };
+        expect(trigger.mustTrigger(container)).toEqual(expected);
+    },
+);

--- a/app/watchers/providers/docker/Docker.js
+++ b/app/watchers/providers/docker/Docker.js
@@ -15,6 +15,8 @@ const {
     hosakaLinkTemplate,
     hosakaDisplayName,
     hosakaDisplayIcon,
+    hosakaTriggerInclude,
+    hosakaTriggerExclude,
 } = require('./label');
 const storeContainer = require('../../../store/container');
 const log = require('../../../log');
@@ -179,7 +181,7 @@ function getRegistry(registryName) {
  * @param {Object} newLive - the freshly built live container (mutated in place)
  */
 function carryUpdateState(oldRow, newLive) {
-    const metadataFields = ['includeTags', 'excludeTags', 'transformTags', 'linkTemplate'];
+    const metadataFields = ['includeTags', 'excludeTags', 'transformTags', 'linkTemplate', 'triggerInclude', 'triggerExclude'];
     metadataFields.forEach((field) => {
         if ((newLive[field] === undefined || newLive[field] === null)
             && oldRow[field] !== undefined && oldRow[field] !== null) {
@@ -673,6 +675,8 @@ async watchContainer(container, skipRegistryCheck = false) {
                 container.Labels[hosakaLinkTemplate],
                 container.Labels[hosakaDisplayName],
                 container.Labels[hosakaDisplayIcon],
+                container.Labels[hosakaTriggerInclude],
+                container.Labels[hosakaTriggerExclude],
             ));
         let containersWithImage = await Promise.all(containerPromises);
 
@@ -810,6 +814,8 @@ async watchContainer(container, skipRegistryCheck = false) {
         linkTemplate,
         displayName,
         displayIcon,
+        triggerInclude,
+        triggerExclude,
     ) {
         const containerId = container.Id;
 
@@ -896,6 +902,8 @@ async watchContainer(container, skipRegistryCheck = false) {
             linkTemplate,
             displayName,
             displayIcon,
+            triggerInclude,
+            triggerExclude,
             compose_project: projectLabel,
             image: {
                 id: imageId,

--- a/app/watchers/providers/docker/Docker.test.js
+++ b/app/watchers/providers/docker/Docker.test.js
@@ -514,6 +514,44 @@ test('addImageDetailsToContainer should support transforms', async () => {
     });
 });
 
+test('addImageDetailsToContainer should map trigger include/exclude labels', async () => {
+    storeContainer.getContainer = () => (undefined);
+    docker.dockerApi = {
+        getContainer: () => ({
+            inspect: () => ({ State: { Status: 'running' } }),
+        }),
+        getImage: () => ({
+            inspect: () => ({
+                Id: 'image-123456789',
+                Architecture: 'arch',
+                Os: 'os',
+            }),
+        }),
+    };
+    const container = {
+        Id: 'container-123456789',
+        Image: 'organization/image:version',
+        Names: ['/test'],
+        Labels: {},
+    };
+
+    const containerWithImage = await docker.addImageDetailsToContainer(
+        container,
+        undefined, // includeTags
+        undefined, // excludeTags
+        undefined, // transformTags
+        undefined, // linkTemplate
+        undefined, // displayName
+        undefined, // displayIcon
+        'trigger.smtp.main', // triggerInclude
+        'trigger.discord.x:minor', // triggerExclude
+    );
+    expect(containerWithImage).toMatchObject({
+        triggerInclude: 'trigger.smtp.main',
+        triggerExclude: 'trigger.discord.x:minor',
+    });
+});
+
 test('watchContainer should return container report when found', async () => {
     storeContainer.getContainer = () => (undefined);
     storeContainer.insertContainer = (container) => (container);

--- a/app/watchers/providers/docker/label.js
+++ b/app/watchers/providers/docker/label.js
@@ -43,4 +43,14 @@ module.exports = {
      */
     hosakaDisplayIcon: 'hosaka.display.icon',
 
+    /**
+     * Optional comma-separated list of triggers to include.
+     */
+    hosakaTriggerInclude: 'hosaka.trigger.include',
+
+    /**
+     * Optional comma-separated list of triggers to exclude.
+     */
+    hosakaTriggerExclude: 'hosaka.trigger.exclude',
+
 };


### PR DESCRIPTION
## What

Adds per-container trigger-routing labels, porting upstream's feature under the fork's namespace:

- `hosaka.trigger.include` — comma-separated trigger ids; if set, only listed triggers fire for the container.
- `hosaka.trigger.exclude` — comma-separated trigger ids to suppress.
- Each entry accepts an optional `:threshold` override (`major-only`, `minor-only`, `major`, `minor`, `patch`, `all`). Thresholds are cumulative (`minor` covers patch); the `-only` variants match exactly.

## How

- The Docker watcher reads the labels onto `triggerInclude`/`triggerExclude` container fields, persisted via the model schema and carried across container recreations.
- `Trigger.js` gains `mustTrigger` (include/exclude membership + per-trigger threshold via `isThresholdReached`), gated into both simple and batch dispatch after the existing config-threshold check. `isThresholdReached` takes an optional threshold and gains `major-only`/`minor-only` levels (config schema extended to match).

## Backward compatible

A container with no routing labels has `mustTrigger` return true, so all existing dispatch behavior is unchanged.

## Verified

Full backend jest suite green (46 suites / 442 tests) and eslint clean (no new violations) on the changed files, run in a `node:18-alpine` container.