### PR TITLE
chore(license): add fork copyright line and fix package attribution

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,7 @@
 MIT License
 
 Copyright (c) [2019] [Manfred Martin]
+Copyright (c) 2026 nopoz
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/app/package.json
+++ b/app/package.json
@@ -9,7 +9,7 @@
     "lint": "eslint '**/*.js'",
     "test": "jest --coverage"
   },
-  "author": "fmartinou",
+  "author": "nopoz",
   "repository": "nopoz/hosaka",
   "license": "MIT",
   "dependencies": {

--- a/e2e/package.json
+++ b/e2e/package.json
@@ -7,7 +7,7 @@
     "lint": "eslint '**/*.js'",
     "cucumber": "cucumber-js **/*.feature"
   },
-  "author": "fmartinou",
+  "author": "nopoz",
   "repository": "nopoz/hosaka",
   "license": "MIT",
   "dependencies": {

--- a/ui/package.json
+++ b/ui/package.json
@@ -2,6 +2,8 @@
   "name": "hosaka-ui",
   "version": "0.1.0",
   "private": true,
+  "author": "nopoz",
+  "license": "MIT",
   "type": "module",
   "scripts": {
     "serve": "vite",


### PR DESCRIPTION
Keeps MIT. Adds a second copyright line for the fork below the upstream notice (upstream MIT line kept verbatim) and fixes stale package metadata.

## Changes
- `LICENSE` — add fork copyright line under the upstream MIT notice; upstream line unchanged.
- `app/package.json` / `e2e/package.json` — `author` was the upstream author; updated to the fork owner.
- `ui/package.json` — add the missing `author` and `license` fields.

## Scope
Attribution hygiene only. The CLA / relicense tooling is intentionally deferred until there is an actual outside contribution or a concrete monetization need.

## Verification
All three `package.json` files parse as valid JSON.