### PR TITLE
fix(security): address CodeQL code-scanning findings

### DIFF
--- a/app/api/auth.js
+++ b/app/api/auth.js
@@ -7,7 +7,7 @@ const getmac = require('getmac').default;
 const store = require('../store');
 const registry = require('../registry');
 const log = require('../log');
-const { getVersion } = require('../configuration');
+const { getVersion, getServerConfiguration } = require('../configuration');
 
 const router = express.Router();
 
@@ -127,6 +127,16 @@ function logout(req, res) {
  * @returns {*}
  */
 function init(app) {
+    // Mark the session cookie as Secure when Hosaka serves TLS directly, or when
+    // explicitly opted in for a TLS-terminating reverse proxy (HOSAKA_SERVER_COOKIE_SECURE).
+    // In the proxy case, trust the proxy so X-Forwarded-Proto is honoured, otherwise
+    // a Secure cookie would never be set over the plain-HTTP hop to the proxy.
+    const serverConfiguration = getServerConfiguration();
+    const secureCookie = serverConfiguration.tls.enabled || serverConfiguration.cookie.secure;
+    if (serverConfiguration.cookie.secure && !serverConfiguration.tls.enabled) {
+        app.set('trust proxy', 1);
+    }
+
     // Init express session
     app.use(session({
         store: new LokiStore({
@@ -138,6 +148,7 @@ function init(app) {
         saveUninitialized: false,
         cookie: {
             httpOnly: true,
+            secure: secureCookie,
             maxAge: getCookieMaxAge(7),
         },
     }));

--- a/app/api/container.js
+++ b/app/api/container.js
@@ -518,7 +518,7 @@ async function refreshContainer(req, res) {
         const containerReport = await watcherInstance.watchContainer(liveContainer);
         return res.status(200).json(containerReport.container);
     } catch (error) {
-        console.error(`Error refreshing container ${name}:`, error);
+        console.error('Error refreshing container %s:', name, error);
         return res.status(500).json({ error: `Error refreshing container: ${error.message}` });
     }
 }

--- a/app/authentications/providers/oidc/Oidc.js
+++ b/app/authentications/providers/oidc/Oidc.js
@@ -129,7 +129,7 @@ class Oidc extends Authentication {
             req.login(user, (err) => {
                 if (err) {
                     this.log.warn(`Error when logging the user [${err.message}]`);
-                    res.status(401).send(err.message);
+                    res.status(401).json({ error: err.message });
                 } else {
                     this.log.debug('User authenticated => redirect to app');
                     res.redirect(`${getPublicUrl(req)}`);
@@ -137,7 +137,7 @@ class Oidc extends Authentication {
             });
         } catch (err) {
             this.log.warn(`Error when logging the user [${err.message}]`);
-            res.status(401).send(err.message);
+            res.status(401).json({ error: err.message });
         }
     }
 

--- a/app/configuration/index.js
+++ b/app/configuration/index.js
@@ -113,6 +113,9 @@ function getServerConfiguration() {
             origin: joi.string().default('*'),
             methods: joi.string().default('GET,HEAD,PUT,PATCH,POST,DELETE'),
         }).default({}),
+        cookie: joi.object({
+            secure: joi.boolean().default(false),
+        }).default({}),
         feature: joi.object({
             delete: joi.boolean().default(true),
         }).default({

--- a/app/configuration/index.test.js
+++ b/app/configuration/index.test.js
@@ -81,6 +81,7 @@ test('getStoreConfiguration should return configured store', () => {
 test('getServerConfiguration should return configured api (new vars)', () => {
     configuration.hosakaEnvVars.HOSAKA_SERVER_PORT = '4000';
     expect(configuration.getServerConfiguration()).toStrictEqual({
+        cookie: {},
         cors: {},
         enabled: true,
         feature: {

--- a/app/registries/providers/hub/Hub.js
+++ b/app/registries/providers/hub/Hub.js
@@ -100,7 +100,7 @@ class Hub extends Custom {
     // eslint-disable-next-line class-methods-use-this
     getImageFullName(image, tagOrDigest) {
         let fullName = super.getImageFullName(image, tagOrDigest);
-        fullName = fullName.replace(/registry-1.docker.io\//, '');
+        fullName = fullName.replace(/registry-1\.docker\.io\//, '');
         fullName = fullName.replace(/library\//, '');
         return fullName;
     }


### PR DESCRIPTION
Resolves the actionable CodeQL alerts.

## Fixed
- **xss-through-exception (`Oidc.js`)** — auth errors returned as JSON instead of `res.send(err.message)`, so an exception message can't be reflected as `text/html`. Two call sites.
- **clear-text-cookie (`auth.js`)** — session cookie now marked `Secure` when Hosaka serves TLS directly (`tls.enabled`), or when opted in via the new `HOSAKA_SERVER_COOKIE_SECURE` flag for a TLS-terminating reverse proxy (sets `trust proxy` so `X-Forwarded-Proto` is honoured). **Defaults off** — plain-HTTP deploys are unchanged.
- **incomplete-hostname-regexp (`Hub.js`)** — escaped the dots in the `registry-1.docker.io` strip regex.
- **tainted-format-string (`container.js`)** — user-supplied container name kept out of the `console.error` format string on the refresh error path.

## Verification
Full backend suite green (46 suites / 442 tests) in a clean `node:18-alpine` container; the `getServerConfiguration` test updated for the new `cookie` key. No new lint errors in the changed files.