### PR TITLE
docs(readme): explain the watch pipeline in How it works

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,11 +55,49 @@ Hosaka sits in the middle, where most people actually want to be:
 
 ## How it works
 
-Hosaka is built on three concepts:
+Hosaka is a pipeline built from three kinds of components. **Watchers** find the
+containers you care about, **registries** tell Hosaka what newer images exist,
+and **triggers** act on what is found.
 
-- **Watchers** query your Docker hosts to get the containers to watch
-- **Registries** query the Docker registries to find available updates
-- **Triggers** perform actions when updates are available
+- **Watchers** connect to your Docker hosts, local socket or remote over TCP/TLS,
+  and list the running containers. You decide what is watched with a
+  `hosaka.watch` label or a watch-by-default setting, so Hosaka only tracks what
+  you opt in to.
+- **Registries** are the upstream sources Hosaka queries for available tags:
+  Docker Hub, GHCR, ECR, GCR, Quay, and the rest. For each watched container it
+  picks the registry the image came from and asks what tags exist.
+- **Triggers** are the actions that run when an update is available: send a
+  notification, update a Docker container or compose stack, or run an update
+  script such as the built-in Portainer updater.
+
+### The watch cycle
+
+Each watcher runs on a cron schedule and also reacts to Docker events as
+containers start and stop. Every cycle it:
+
+1. Lists the running containers and keeps the ones you have opted in to watch.
+2. Parses each container's image into comparable parts: name, tag, and digest.
+3. Asks the matching registry for the available tags, then narrows them to real
+   candidates. It applies your include/exclude regex and any tag transform, then
+   compares with semver to find versions newer than the one running. For mutable
+   tags like `latest`, it compares the image digest instead of the tag.
+4. When a newer version or a changed digest is found, it builds an update report,
+   classifies the change as major, minor, patch, or prerelease, and records it.
+
+Every report is emitted as an event. Triggers subscribe to those events and
+decide whether to act based on your rules: only on certain update types
+(thresholds), only once per version, notify versus update. Notifications go out
+right away; an update waits for you to click it, or runs on its own if you
+configured it to.
+
+### When an update runs
+
+Updating recreates the container on the new image, which gives it a new container
+ID. Hosaka follows that swap: it confirms the new container is running, forces an
+immediate rescan so the list reflects reality, and carries the update state onto
+the new container instead of leaving a stale or orphaned row. While the update
+runs, the script's output streams to the UI line by line, and the run is not
+marked done until the new container comes back healthy.
 
 ## Features
 


### PR DESCRIPTION
The "How it works" section only listed the three component names without explaining how Hosaka actually works. This rewrites it to walk through the mechanism.

## Changes
- Reframe watchers/registries/triggers as a pipeline, with each bullet describing what the component does rather than restating its name.
- Add a **The watch cycle** subsection: the step-by-step a watcher runs each cycle (list containers, parse image/tag/digest, query the matching registry, filter candidates via include/exclude regex + transform + semver, digest compare for mutable tags, classify the update), then how reports become trigger events gated by thresholds / once / notify-vs-update.
- Add a **When an update runs** subsection covering recreation tracking (new container ID, confirm running, rescan, carry state forward) and the live streamed output.

Grounded in the actual watch loop. Docs-only, no code changes.