### PR TITLE
docs(config): correct env var and label contract to HOSAKA_/hosaka.

### DIFF
--- a/docs/api/store.md
+++ b/docs/api/store.md
@@ -10,7 +10,7 @@ curl http://wud:3000/api/store
 {
    "configuration":{
       "path":".store",
-      "file":"wud.json"
+      "file":"hosaka.json"
    }
 }
 ```

--- a/docs/configuration/README.md
+++ b/docs/configuration/README.md
@@ -28,39 +28,39 @@ services:
     image: vaultwarden/server:1.22.1-alpine
     container_name: bitwarden
     labels:
-      - 'wud.tag.include=^\d+\.\d+\.\d+-alpine$$'
-      - 'wud.link.template=https://github.com/dani-garcia/vaultwarden/releases/tag/$${major}.$${minor}.$${patch}'
+      - 'hosaka.tag.include=^\d+\.\d+\.\d+-alpine$$'
+      - 'hosaka.link.template=https://github.com/dani-garcia/vaultwarden/releases/tag/$${major}.$${minor}.$${patch}'
 
   # Valid semver following by an build number (linux server style)
   duplicati:
     image: linuxserver/duplicati:v2.0.6.3-2.0.6.3_beta_2021-06-17-ls104
     container_name: duplicati
     labels:
-      - 'wud.tag.include=^v\d+\.\d+\.\d+\.\d+-\d+\.\d+\.\d+\.\d+.*$$'
+      - 'hosaka.tag.include=^v\d+\.\d+\.\d+\.\d+-\d+\.\d+\.\d+\.\d+.*$$'
 
   # Valid calver
   homeassistant:
     image: homeassistant/home-assistant:2021.7.1
     container_name: homeassistant
     labels:
-      - 'wud.tag.include=^\d+\.\d+\.\d+$$'
-      - 'wud.link.template=https://github.com/home-assistant/core/releases/tag/$${major}.$${minor}.$${patch}'
+      - 'hosaka.tag.include=^\d+\.\d+\.\d+$$'
+      - 'hosaka.link.template=https://github.com/home-assistant/core/releases/tag/$${major}.$${minor}.$${patch}'
 
   # Valid semver with a leading v
   pihole:
     image: pihole/pihole:v5.8.1
     container_name: pihole
     labels:
-      - 'wud.tag.include=^v\d+\.\d+\.\d+$$'
-      - 'wud.link.template=https://github.com/pi-hole/FTL/releases/tag/v$${major}.$${minor}.$${patch}'
+      - 'hosaka.tag.include=^v\d+\.\d+\.\d+$$'
+      - 'hosaka.link.template=https://github.com/pi-hole/FTL/releases/tag/v$${major}.$${minor}.$${patch}'
 
   # Mutable tag (latest) with digest tracking
   pyload:
     image: writl/pyload:latest
     container_name: pyload
     labels:
-      - 'wud.tag.include=latest'
-      - 'wud.watch.digest=true'
+      - 'hosaka.tag.include=latest'
+      - 'hosaka.watch.digest=true'
 
   # Wud self tracking :)
   whatsupdocker:
@@ -76,8 +76,8 @@ services:
       retries: 3
       start_period: 10s       
     labels:
-      - 'wud.tag.include=^\d+\.\d+\.\d+$$'
-      - 'wud.link.template=https://github.com/getwud/wud/releases/tag/$${major}.$${minor}.$${patch}'
+      - 'hosaka.tag.include=^\d+\.\d+\.\d+$$'
+      - 'hosaka.link.template=https://github.com/getwud/wud/releases/tag/$${major}.$${minor}.$${patch}'
 ```
 
 ## Secret management
@@ -85,13 +85,13 @@ services:
 
 For example, instead of providing the Basic auth details as
 ```
-WUD_AUTH_BASIC_JOHN_HASH=$$apr1$$aefKbZEa$$ZSA5Y3zv9vDQOxr283NGx/
+HOSAKA_AUTH_BASIC_JOHN_HASH=$$apr1$$aefKbZEa$$ZSA5Y3zv9vDQOxr283NGx/
 ```
 
 You can create an external file with the appropriate permissions (let's say `/tmp/john_hash`) containing the secret value (`$$apr1$$aefKbZEa$$ZSA5Y3zv9vDQOxr283NGx/`).
 Then you need to reference this file by using the following env var
 ```
-WUD_AUTH_BASIC_JOHN_HASH__FILE=/tmp/john_hash
+HOSAKA_AUTH_BASIC_JOHN_HASH__FILE=/tmp/john_hash
 ```
 
 ?> This feature can be used for any WUD env var (no restrictions).

--- a/docs/configuration/authentications/README.md
+++ b/docs/configuration/authentications/README.md
@@ -2,7 +2,7 @@
   
 WUD allows `Anonymous` access by default.
 
-You can enable 1 or multiple authentication strategies using `WUD_AUTH_*` env vars.
+You can enable 1 or multiple authentication strategies using `HOSAKA_AUTH_*` env vars.
 
 !> Please pay attention that all API routes & all UI views will be authenticated.
 

--- a/docs/configuration/authentications/basic/README.md
+++ b/docs/configuration/authentications/basic/README.md
@@ -6,19 +6,19 @@ The `basic` authentication lets you protect WUD access using the [Http Basic aut
 
 | Env var                           | Required       | Description              | Supported values                                                                           | Default value when missing |
 | --------------------------------- |:--------------:| ------------------------ | ------------------------------------------------------------------------------------------ | -------------------------- | 
-| `WUD_AUTH_BASIC_{auth_name}_USER` | :red_circle:   | Username                 |                                                                                            |                            |
-| `WUD_AUTH_BASIC_{auth_name}_HASH` | :red_circle:   | Htpasswd compliant hash  | [See htpasswd documentation](https://httpd.apache.org/docs/current/programs/htpasswd.html) |                            |
+| `HOSAKA_AUTH_BASIC_{auth_name}_USER` | :red_circle:   | Username                 |                                                                                            |                            |
+| `HOSAKA_AUTH_BASIC_{auth_name}_HASH` | :red_circle:   | Htpasswd compliant hash  | [See htpasswd documentation](https://httpd.apache.org/docs/current/programs/htpasswd.html) |                            |
 
 !> Hash will likely contain `$` signs; don't forget to protect them! \
 \
 [double `$$` in Docker Compose files](https://docs.docker.com/compose/compose-file/compose-file-v3/#variable-substitution) \
-`WUD_AUTH_BASIC_JOHN_HASH: $$apr1$$aefKbZEa$$ZSA5Y3zv9vDQOxr283NGx/` \
+`HOSAKA_AUTH_BASIC_JOHN_HASH: $$apr1$$aefKbZEa$$ZSA5Y3zv9vDQOxr283NGx/` \
 \
 or use single quotes in Bash commands \
-`WUD_AUTH_BASIC_JOHN_HASH='$apr1$aefKbZEa$ZSA5Y3zv9vDQOxr283NGx/'` \
+`HOSAKA_AUTH_BASIC_JOHN_HASH='$apr1$aefKbZEa$ZSA5Y3zv9vDQOxr283NGx/'` \
 \
 or escape them in Bash commands \
-`WUD_AUTH_BASIC_JOHN_HASH="\$apr1\$aefKbZEa$ZSA5Y3zv9vDQOxr283NGx/"`
+`HOSAKA_AUTH_BASIC_JOHN_HASH="\$apr1\$aefKbZEa$ZSA5Y3zv9vDQOxr283NGx/"`
 
 ### Examples
 
@@ -32,22 +32,22 @@ services:
     image: getwud/wud
     ...
     environment:
-      - WUD_AUTH_BASIC_JOHN_USER=john
-      - WUD_AUTH_BASIC_JOHN_HASH=$$apr1$$8zDVtSAY$$62WBh9DspNbUKMZXYRsjS/
-      - WUD_AUTH_BASIC_JANE_USER=jane
-      - WUD_AUTH_BASIC_JANE_HASH=$$apr1$$5iyu65pm$$m/6I35fjUT7.1CMnS2w9d1
-      - WUD_AUTH_BASIC_BOB_USER=bob
-      - WUD_AUTH_BASIC_BOB_HASH=$apr1$$aefKbZEa$$ZSA5Y3zv9vDQOxr283NGx/
+      - HOSAKA_AUTH_BASIC_JOHN_USER=john
+      - HOSAKA_AUTH_BASIC_JOHN_HASH=$$apr1$$8zDVtSAY$$62WBh9DspNbUKMZXYRsjS/
+      - HOSAKA_AUTH_BASIC_JANE_USER=jane
+      - HOSAKA_AUTH_BASIC_JANE_HASH=$$apr1$$5iyu65pm$$m/6I35fjUT7.1CMnS2w9d1
+      - HOSAKA_AUTH_BASIC_BOB_USER=bob
+      - HOSAKA_AUTH_BASIC_BOB_HASH=$apr1$$aefKbZEa$$ZSA5Y3zv9vDQOxr283NGx/
 ```
 #### **Docker**
 ```bash
 docker run \
-  -e WUD_AUTH_BASIC_JOHN_USER="john" \
-  -e WUD_AUTH_BASIC_JOHN_HASH='$apr1$8zDVtSAY$62WBh9DspNbUKMZXYRsjS/' \
-  -e WUD_AUTH_BASIC_JANE_USER="jane" \
-  -e WUD_AUTH_BASIC_JANE_HASH='$apr1$5iyu65pm$m/6I35fjUT7.1CMnS2w9d1' \
-  -e WUD_AUTH_BASIC_JANE_USER="bob" \
-  -e WUD_AUTH_BASIC_JANE_HASH='$apr1$aefKbZEa$ZSA5Y3zv9vDQOxr283NGx/' \    
+  -e HOSAKA_AUTH_BASIC_JOHN_USER="john" \
+  -e HOSAKA_AUTH_BASIC_JOHN_HASH='$apr1$8zDVtSAY$62WBh9DspNbUKMZXYRsjS/' \
+  -e HOSAKA_AUTH_BASIC_JANE_USER="jane" \
+  -e HOSAKA_AUTH_BASIC_JANE_HASH='$apr1$5iyu65pm$m/6I35fjUT7.1CMnS2w9d1' \
+  -e HOSAKA_AUTH_BASIC_JANE_USER="bob" \
+  -e HOSAKA_AUTH_BASIC_JANE_HASH='$apr1$aefKbZEa$ZSA5Y3zv9vDQOxr283NGx/' \    
   ...
   getwud/wud
 ```

--- a/docs/configuration/authentications/oidc/README.md
+++ b/docs/configuration/authentications/oidc/README.md
@@ -7,16 +7,16 @@ The `oidc` authentication lets you protect WUD access using the [Openid Connect 
 
 | Env var                                  | Required       | Description                                                            | Supported values | Default value when missing |
 |------------------------------------------|:--------------:|------------------------------------------------------------------------|------------------|----------------------------|
-| `WUD_AUTH_OIDC_{auth_name}_CLIENTID`     | :red_circle:   | Client ID                                                              |                  |                            |
-| `WUD_AUTH_OIDC_{auth_name}_CLIENTSECRET` | :red_circle:   | Client Secret                                                          |                  |                            |
-| `WUD_AUTH_OIDC_{auth_name}_DISCOVERY`    | :red_circle:   | Oidc discovery URL                                                     |                  |                            |
-| `WUD_AUTH_OIDC_{auth_name}_REDIRECT`     | :white_circle: | Skip internal login page & automatically redirect to the OIDC provider | `true`, `false`  | `false`                    |
-| `WUD_AUTH_OIDC_{auth_name}_TIMEOUT`      | :white_circle: | Timeout (in ms) when calling the OIDC provider                         | Minimum is 500   | `5000`                     |
+| `HOSAKA_AUTH_OIDC_{auth_name}_CLIENTID`     | :red_circle:   | Client ID                                                              |                  |                            |
+| `HOSAKA_AUTH_OIDC_{auth_name}_CLIENTSECRET` | :red_circle:   | Client Secret                                                          |                  |                            |
+| `HOSAKA_AUTH_OIDC_{auth_name}_DISCOVERY`    | :red_circle:   | Oidc discovery URL                                                     |                  |                            |
+| `HOSAKA_AUTH_OIDC_{auth_name}_REDIRECT`     | :white_circle: | Skip internal login page & automatically redirect to the OIDC provider | `true`, `false`  | `false`                    |
+| `HOSAKA_AUTH_OIDC_{auth_name}_TIMEOUT`      | :white_circle: | Timeout (in ms) when calling the OIDC provider                         | Minimum is 500   | `5000`                     |
 
 ?> The callback URL (to configure in the IDP is built as `${wud_public_url}/auth/oidc/${auth_name}/cb`
 
 !> WUD tries its best to determine the public address to forge redirections on its own. \
-If it fails (irregular reverse proxy configuration...), you can enforce the value using the env var `WUD_PUBLIC_URL` 
+If it fails (irregular reverse proxy configuration...), you can enforce the value using the env var `HOSAKA_PUBLIC_URL` 
 
 ### How to integrate with&nbsp;[Authelia](https://www.authelia.com)
 ![logo](authelia.png)
@@ -70,16 +70,16 @@ services:
     image: getwud/wud
     ...
     environment:
-      - WUD_AUTH_OIDC_AUTHELIA_CLIENTID=my-wud-client-id
-      - WUD_AUTH_OIDC_AUTHELIA_CLIENTSECRET=this-is-a-very-secure-secret
-      - WUD_AUTH_OIDC_AUTHELIA_DISCOVERY=https://<your_authelia_public_domain>/.well-known/openid-configuration
+      - HOSAKA_AUTH_OIDC_AUTHELIA_CLIENTID=my-wud-client-id
+      - HOSAKA_AUTH_OIDC_AUTHELIA_CLIENTSECRET=this-is-a-very-secure-secret
+      - HOSAKA_AUTH_OIDC_AUTHELIA_DISCOVERY=https://<your_authelia_public_domain>/.well-known/openid-configuration
 ```
 #### **Docker**
 ```bash
 docker run \
-  -e WUD_AUTH_OIDC_AUTHELIA_CLIENTID="my-wud-client-id" \
-  -e WUD_AUTH_OIDC_AUTHELIA_CLIENTSECRET="this-is-a-very-secure-secret" \
-  -e WUD_AUTH_OIDC_AUTHELIA_DISCOVERY="https://<your_authelia_public_domain>/.well-known/openid-configuration" \
+  -e HOSAKA_AUTH_OIDC_AUTHELIA_CLIENTID="my-wud-client-id" \
+  -e HOSAKA_AUTH_OIDC_AUTHELIA_CLIENTSECRET="this-is-a-very-secure-secret" \
+  -e HOSAKA_AUTH_OIDC_AUTHELIA_DISCOVERY="https://<your_authelia_public_domain>/.well-known/openid-configuration" \
   ...
   getwud/wud
 ```
@@ -106,16 +106,16 @@ services:
     image: getwud/wud
     ...
     environment:
-      - WUD_AUTH_OIDC_AUTH0_CLIENTID=<paste the Client ID from auth0 application settings>
-      - WUD_AUTH_OIDC_AUTH0_CLIENTSECRET=<paste the Client Secret from auth0 application settings>
-      - WUD_AUTH_OIDC_AUTH0_DISCOVERY=https://<paste the domain from auth0 application settings>/.well-known/openid-configuration
+      - HOSAKA_AUTH_OIDC_AUTH0_CLIENTID=<paste the Client ID from auth0 application settings>
+      - HOSAKA_AUTH_OIDC_AUTH0_CLIENTSECRET=<paste the Client Secret from auth0 application settings>
+      - HOSAKA_AUTH_OIDC_AUTH0_DISCOVERY=https://<paste the domain from auth0 application settings>/.well-known/openid-configuration
 ```
 #### **Docker**
 ```bash
 docker run \
-  -e WUD_AUTH_OIDC_AUTH0_CLIENTID="<paste the Client ID from auth0 application settings>" \
-  -e WUD_AUTH_OIDC_AUTH0_CLIENTSECRET="<paste the Client Secret from auth0 application settings>" \
-  -e WUD_AUTH_OIDC_AUTH0_DISCOVERY="https://<paste the domain from auth0 application settings>/.well-known/openid-configuration" \
+  -e HOSAKA_AUTH_OIDC_AUTH0_CLIENTID="<paste the Client ID from auth0 application settings>" \
+  -e HOSAKA_AUTH_OIDC_AUTH0_CLIENTSECRET="<paste the Client Secret from auth0 application settings>" \
+  -e HOSAKA_AUTH_OIDC_AUTH0_DISCOVERY="https://<paste the domain from auth0 application settings>/.well-known/openid-configuration" \
   ...
   getwud/wud
 ```
@@ -153,18 +153,18 @@ services:
     image: getwud/wud
     ...
     environment:
-      - WUD_AUTH_OIDC_AUTHENTIK_CLIENTID=<paste the Client ID from authentik wud_oidc provider>
-      - WUD_AUTH_OIDC_AUTHENTIK_CLIENTSECRET=<paste the Client Secret from authentik wud_oidc provider>
-      - WUD_AUTH_OIDC_AUTHENTIK_DISCOVERY=<authentik_url>/application/o/<authentik_application_name>/.well-known/openid-configuration
-      - WUD_AUTH_OIDC_AUTHENTIK_REDIRECT=true # optional (to skip internal login page)
+      - HOSAKA_AUTH_OIDC_AUTHENTIK_CLIENTID=<paste the Client ID from authentik wud_oidc provider>
+      - HOSAKA_AUTH_OIDC_AUTHENTIK_CLIENTSECRET=<paste the Client Secret from authentik wud_oidc provider>
+      - HOSAKA_AUTH_OIDC_AUTHENTIK_DISCOVERY=<authentik_url>/application/o/<authentik_application_name>/.well-known/openid-configuration
+      - HOSAKA_AUTH_OIDC_AUTHENTIK_REDIRECT=true # optional (to skip internal login page)
 ```
 #### **Docker**
 ```bash
 docker run \
-  -e WUD_AUTH_OIDC_AUTHENTIK_CLIENTID="<paste the Client ID from authentik wud_oidc provider>" \
-  -e WUD_AUTH_OIDC_AUTHENTIK_CLIENTSECRET="<paste the Client Secret from authentik wud_oidc provider>" \
-  -e WUD_AUTH_OIDC_AUTHENTIK_DISCOVERY="<authentik_url>/application/o/<authentik_application_name>/.well-known/openid-configuration" \
-  -e WUD_AUTH_OIDC_AUTHENTIK_REDIRECT=true # optional (to skip internal login page) \  
+  -e HOSAKA_AUTH_OIDC_AUTHENTIK_CLIENTID="<paste the Client ID from authentik wud_oidc provider>" \
+  -e HOSAKA_AUTH_OIDC_AUTHENTIK_CLIENTSECRET="<paste the Client Secret from authentik wud_oidc provider>" \
+  -e HOSAKA_AUTH_OIDC_AUTHENTIK_DISCOVERY="<authentik_url>/application/o/<authentik_application_name>/.well-known/openid-configuration" \
+  -e HOSAKA_AUTH_OIDC_AUTHENTIK_REDIRECT=true # optional (to skip internal login page) \  
   ...
   getwud/wud
 ```

--- a/docs/configuration/logs/README.md
+++ b/docs/configuration/logs/README.md
@@ -1,13 +1,13 @@
 # Logs
 
-You can adjust the log level with env var WUD_LOG_LEVEL.
+You can adjust the log level with env var HOSAKA_LOG_LEVEL.
 
 ### Variables
 
 | Env var          | Required       | Description | Supported values            | Default value when missing  |
 | ---------------- |:--------------:| ----------- | --------------------------- | --------------------------- | 
-| `WUD_LOG_LEVEL`  | :white_circle: | Log level   | error info debug trace      | `info`                      |
-| `WUD_LOG_FORMAT` | :white_circle: | Log format  | text json                   | `text`                      |
+| `HOSAKA_LOG_LEVEL`  | :white_circle: | Log level   | error info debug trace      | `info`                      |
+| `HOSAKA_LOG_FORMAT` | :white_circle: | Log format  | text json                   | `text`                      |
 
 ### Examples
 
@@ -23,11 +23,11 @@ services:
     image: getwud/wud
     ...
     environment:
-      - WUD_LOG_LEVEL=debug
+      - HOSAKA_LOG_LEVEL=debug
 ```
 #### **Docker**
 ```bash
-docker run -e WUD_LOG_LEVEL=debug ... getwud/wud
+docker run -e HOSAKA_LOG_LEVEL=debug ... getwud/wud
 ```
 <!-- tabs:end -->
 
@@ -36,7 +36,7 @@ docker run -e WUD_LOG_LEVEL=debug ... getwud/wud
 <!-- tabs:start -->
 #### **Docker**
 ```bash
-docker run -e WUD_LOG_FORMAT=json ... getwud/wud
+docker run -e HOSAKA_LOG_FORMAT=json ... getwud/wud
 ```
 
 #### **Docker Compose**
@@ -48,6 +48,6 @@ services:
     image: getwud/wud
     ...
     environment:
-      - WUD_LOG_FORMAT=json
+      - HOSAKA_LOG_FORMAT=json
 ```
 <!-- tabs:end -->

--- a/docs/configuration/registries/acr/README.md
+++ b/docs/configuration/registries/acr/README.md
@@ -7,8 +7,8 @@ The `acr`registry lets you configure [ACR](https://azure.microsoft.com/services/
 
 | Env var                         | Required     | Description                 | Supported values                                                                                                                  | Default value when missing |
 | ------------------------------- |:------------:| ----------------- | ------------------------------------------------------------------------------------------------------------------------------------------- | -------------------------- | 
-| `WUD_REGISTRY_ACR_CLIENTID`     | :red_circle: | Service Principal Client ID | See [Service Principal Auth](https://docs.microsoft.com/en-us/azure/container-registry/container-registry-auth-service-principal) |                            |
-| `WUD_REGISTRY_ACR_CLIENTSECRET` | :red_circle: | Service Principal Secret    | See [Service Principal Auth](https://docs.microsoft.com/en-us/azure/container-registry/container-registry-auth-service-principal) |                            |
+| `HOSAKA_REGISTRY_ACR_CLIENTID`     | :red_circle: | Service Principal Client ID | See [Service Principal Auth](https://docs.microsoft.com/en-us/azure/container-registry/container-registry-auth-service-principal) |                            |
+| `HOSAKA_REGISTRY_ACR_CLIENTSECRET` | :red_circle: | Service Principal Secret    | See [Service Principal Auth](https://docs.microsoft.com/en-us/azure/container-registry/container-registry-auth-service-principal) |                            |
 
 ### Examples
 
@@ -22,14 +22,14 @@ services:
     image: getwud/wud
     ...
     environment:
-      - WUD_REGISTRY_ACR_CLIENTID=7c0195aa-112d-4ac3-be24-6664a13f3d2b
-      - WUD_REGISTRY_ACR_CLIENTSECRET=your-azure-client-secret
+      - HOSAKA_REGISTRY_ACR_CLIENTID=7c0195aa-112d-4ac3-be24-6664a13f3d2b
+      - HOSAKA_REGISTRY_ACR_CLIENTSECRET=your-azure-client-secret
 ```
 #### **Docker**
 ```bash
 docker run \
-  -e WUD_REGISTRY_ACR_CLIENTID=7c0195aa-112d-4ac3-be24-6664a13f3d2b \
-  -e WUD_REGISTRY_ACR_CLIENTSECRET=your-azure-client-secret \
+  -e HOSAKA_REGISTRY_ACR_CLIENTID=7c0195aa-112d-4ac3-be24-6664a13f3d2b \
+  -e HOSAKA_REGISTRY_ACR_CLIENTSECRET=your-azure-client-secret \
   ...
   getwud/wud
 ```

--- a/docs/configuration/registries/custom/README.md
+++ b/docs/configuration/registries/custom/README.md
@@ -7,10 +7,10 @@ The `custom` registry lets you configure a self-hosted [Docker Registry](https:/
 
 | Env var                        | Required       | Description                                                     | Supported values                                     | Default value when missing |
 | ------------------------------ |:--------------:| --------------------------------------------------------------- | ---------------------------------------------------- | -------------------------- | 
-| `WUD_REGISTRY_CUSTOM_URL`      | :red_circle:   | Registry URL (e.g. http://localhost:5000)                       |                                                      |                            |
-| `WUD_REGISTRY_CUSTOM_LOGIN`    | :white_circle: | Login (when htpasswd auth is enabled on the registry)           | WUD_REGISTRY_CUSTOM_PASSWORD must be defined         |                            |
-| `WUD_REGISTRY_CUSTOM_PASSWORD` | :white_circle: | Password (when htpasswd auth is enabled on the registry)        | WUD_REGISTRY_CUSTOM_LOGIN must be defined            |                            |
-| `WUD_REGISTRY_CUSTOM_AUTH`     | :white_circle: | Htpasswd string (when htpasswd auth is enabled on the registry) | WUD_REGISTRY_CUSTOM_LOGIN/TOKEN  must not be defined |                            |
+| `HOSAKA_REGISTRY_CUSTOM_URL`      | :red_circle:   | Registry URL (e.g. http://localhost:5000)                       |                                                      |                            |
+| `HOSAKA_REGISTRY_CUSTOM_LOGIN`    | :white_circle: | Login (when htpasswd auth is enabled on the registry)           | HOSAKA_REGISTRY_CUSTOM_PASSWORD must be defined         |                            |
+| `HOSAKA_REGISTRY_CUSTOM_PASSWORD` | :white_circle: | Password (when htpasswd auth is enabled on the registry)        | HOSAKA_REGISTRY_CUSTOM_LOGIN must be defined            |                            |
+| `HOSAKA_REGISTRY_CUSTOM_AUTH`     | :white_circle: | Htpasswd string (when htpasswd auth is enabled on the registry) | HOSAKA_REGISTRY_CUSTOM_LOGIN/TOKEN  must not be defined |                            |
 ### Examples
 
 #### Configure for anonymous access
@@ -24,12 +24,12 @@ services:
     image: getwud/wud
     ...
     environment:
-      - WUD_REGISTRY_CUSTOM_URL=http://localhost:5000
+      - HOSAKA_REGISTRY_CUSTOM_URL=http://localhost:5000
 ```
 #### **Docker**
 ```bash
 docker run \
-  -e "WUD_REGISTRY_CUSTOM_URL=http://localhost:5000" \
+  -e "HOSAKA_REGISTRY_CUSTOM_URL=http://localhost:5000" \
   ...
   getwud/wud
 ```
@@ -46,16 +46,16 @@ services:
     image: getwud/wud
     ...
     environment:
-      - WUD_REGISTRY_CUSTOM_URL=http://localhost:5000
-      - WUD_REGISTRY_CUSTOM_LOGIN=john
-      - WUD_REGISTRY_CUSTOM_PASSWORD=doe
+      - HOSAKA_REGISTRY_CUSTOM_URL=http://localhost:5000
+      - HOSAKA_REGISTRY_CUSTOM_LOGIN=john
+      - HOSAKA_REGISTRY_CUSTOM_PASSWORD=doe
 ```
 #### **Docker**
 ```bash
 docker run \
-  -e "WUD_REGISTRY_CUSTOM_URL=http://localhost:5000" \
-  -e "WUD_REGISTRY_CUSTOM_LOGIN=john" \
-  -e "WUD_REGISTRY_CUSTOM_PASSWORD=doe" \
+  -e "HOSAKA_REGISTRY_CUSTOM_URL=http://localhost:5000" \
+  -e "HOSAKA_REGISTRY_CUSTOM_LOGIN=john" \
+  -e "HOSAKA_REGISTRY_CUSTOM_PASSWORD=doe" \
   ...
   getwud/wud
 ```

--- a/docs/configuration/registries/ecr/README.md
+++ b/docs/configuration/registries/ecr/README.md
@@ -7,9 +7,9 @@ The `ecr` registry lets you configure [ECR](https://aws.amazon.com/ecr/) integra
 
 | Env var                            | Required     | Description                   | Supported values                                                                                  | Default value when missing |
 | ---------------------------------- |:------------:| ----------------------------- | ------------------------------------------------------------------------------------------------- | -------------------------- | 
-| `WUD_REGISTRY_ECR_REGION`          | :red_circle: | A valid AWS Region Code       | [AWS Region list](https://docs.aws.amazon.com/general/latest/gr/rande.html#regional-endpoints)    |                            |
-| `WUD_REGISTRY_ECR_ACCESSKEYID`     | :red_circle: | A valid AWS Access Key Id     | [Standard AWS Credentials](https://docs.aws.amazon.com/general/latest/gr/aws-sec-cred-types.html) |                            |
-| `WUD_REGISTRY_ECR_SECRETACCESSKEY` | :red_circle: | A valid AWS Secret Access Key | [Standard AWS Credentials](https://docs.aws.amazon.com/general/latest/gr/aws-sec-cred-types.html) |                            |
+| `HOSAKA_REGISTRY_ECR_REGION`          | :red_circle: | A valid AWS Region Code       | [AWS Region list](https://docs.aws.amazon.com/general/latest/gr/rande.html#regional-endpoints)    |                            |
+| `HOSAKA_REGISTRY_ECR_ACCESSKEYID`     | :red_circle: | A valid AWS Access Key Id     | [Standard AWS Credentials](https://docs.aws.amazon.com/general/latest/gr/aws-sec-cred-types.html) |                            |
+| `HOSAKA_REGISTRY_ECR_SECRETACCESSKEY` | :red_circle: | A valid AWS Secret Access Key | [Standard AWS Credentials](https://docs.aws.amazon.com/general/latest/gr/aws-sec-cred-types.html) |                            |
 
 !> The AmazonEC2ContainerRegistryReadOnly Policy (or higher) must be attached to the AWS IAM User.
 
@@ -24,16 +24,16 @@ services:
     image: getwud/wud
     ...
     environment:
-      - WUD_REGISTRY_ECR_ACCESSKEYID=xxx
-      - WUD_REGISTRY_ECR_SECRETACCESSKEY=xxx
-      - WUD_REGISTRY_ECR_REGION=eu-west-1 
+      - HOSAKA_REGISTRY_ECR_ACCESSKEYID=xxx
+      - HOSAKA_REGISTRY_ECR_SECRETACCESSKEY=xxx
+      - HOSAKA_REGISTRY_ECR_REGION=eu-west-1 
 ```
 #### **Docker**
 ```bash
 docker run \
-  -e WUD_REGISTRY_ECR_ACCESSKEYID="xxx" \
-  -e WUD_REGISTRY_ECR_SECRETACCESSKEY="xxx" \
-  -e WUD_REGISTRY_ECR_REGION="eu-west-1" \
+  -e HOSAKA_REGISTRY_ECR_ACCESSKEYID="xxx" \
+  -e HOSAKA_REGISTRY_ECR_SECRETACCESSKEY="xxx" \
+  -e HOSAKA_REGISTRY_ECR_REGION="eu-west-1" \
   ...
   getwud/wud
 ```

--- a/docs/configuration/registries/forgejo/README.md
+++ b/docs/configuration/registries/forgejo/README.md
@@ -7,10 +7,10 @@ The `forgejo` registry lets you configure a self-hosted [Forgejo](https://forgej
 
 | Env var                         |    Required    | Description                                                     | Supported values                                      | Default value when missing |
 |---------------------------------|:--------------:|-----------------------------------------------------------------|-------------------------------------------------------|----------------------------| 
-| `WUD_REGISTRY_FORGEJO_URL`      |  :red_circle:  | Registry URL (e.g. https://forgejo.acme.com)                      |                                                       |                            |
-| `WUD_REGISTRY_FORGEJO_LOGIN`    | :red_circle:   | Gitea username                                                  | WUD_REGISTRY_FORGEJO_PASSWORD must be defined         |                            |
-| `WUD_REGISTRY_FORGEJO_PASSWORD` |  :red_circle:  | Gitea password                                                  | WUD_REGISTRY_FORGEJO_LOGIN must be defined            |                            |
-| `WUD_REGISTRY_FORGEJO_AUTH`     | :white_circle: | Htpasswd string (when htpasswd auth is enabled on the registry) | WUD_REGISTRY_FORGEJO_LOGIN/TOKEN  must not be defined |                            |
+| `HOSAKA_REGISTRY_FORGEJO_URL`      |  :red_circle:  | Registry URL (e.g. https://forgejo.acme.com)                      |                                                       |                            |
+| `HOSAKA_REGISTRY_FORGEJO_LOGIN`    | :red_circle:   | Gitea username                                                  | HOSAKA_REGISTRY_FORGEJO_PASSWORD must be defined         |                            |
+| `HOSAKA_REGISTRY_FORGEJO_PASSWORD` |  :red_circle:  | Gitea password                                                  | HOSAKA_REGISTRY_FORGEJO_LOGIN must be defined            |                            |
+| `HOSAKA_REGISTRY_FORGEJO_AUTH`     | :white_circle: | Htpasswd string (when htpasswd auth is enabled on the registry) | HOSAKA_REGISTRY_FORGEJO_LOGIN/TOKEN  must not be defined |                            |
 ### Examples
 
 #### Configure
@@ -24,16 +24,16 @@ services:
     image: getwud/wud
     ...
     environment:
-      - WUD_REGISTRY_FORGEJO_URL=https://forgejo.acme.com
-      - WUD_REGISTRY_FORGEJO_LOGIN=john
-      - WUD_REGISTRY_FORGEJO_PASSWORD=doe
+      - HOSAKA_REGISTRY_FORGEJO_URL=https://forgejo.acme.com
+      - HOSAKA_REGISTRY_FORGEJO_LOGIN=john
+      - HOSAKA_REGISTRY_FORGEJO_PASSWORD=doe
 ```
 #### **Docker**
 ```bash
 docker run \
-  -e "WUD_REGISTRY_FORGEJO_URL=https://forgejo.acme.com" \
-  -e "WUD_REGISTRY_FORGEJO_LOGIN=john" \
-  -e "WUD_REGISTRY_FORGEJO_PASSWORD=doe" \
+  -e "HOSAKA_REGISTRY_FORGEJO_URL=https://forgejo.acme.com" \
+  -e "HOSAKA_REGISTRY_FORGEJO_LOGIN=john" \
+  -e "HOSAKA_REGISTRY_FORGEJO_PASSWORD=doe" \
   ...
   getwud/wud
 ```

--- a/docs/configuration/registries/gcr/README.md
+++ b/docs/configuration/registries/gcr/README.md
@@ -7,8 +7,8 @@ The `gcr` registry lets you configure [GCR](https://cloud.google.com/container-r
 
 | Env var                        |    Required    | Description                                                       | Supported values                                                                                                     | Default value when missing |
 | ------------------------------ |:--------------:|-------------------------------------------------------------------| -------------------------------------------------------------------------------------------------------------------- | -------------------------- | 
-| `WUD_REGISTRY_GCR_CLIENTEMAIL` | :white_circle: | Service Account Client Email (required for private images access) | See [Service Account credentials](https://cloud.google.com/container-registry/docs/advanced-authentication#json-key) |                            |
-| `WUD_REGISTRY_GCR_PRIVATEKEY`  | :white_circle: | Service Account Private Key (required for private images access)  | See [Service Account credentials](https://cloud.google.com/container-registry/docs/advanced-authentication#json-key) |                            |
+| `HOSAKA_REGISTRY_GCR_CLIENTEMAIL` | :white_circle: | Service Account Client Email (required for private images access) | See [Service Account credentials](https://cloud.google.com/container-registry/docs/advanced-authentication#json-key) |                            |
+| `HOSAKA_REGISTRY_GCR_PRIVATEKEY`  | :white_circle: | Service Account Private Key (required for private images access)  | See [Service Account credentials](https://cloud.google.com/container-registry/docs/advanced-authentication#json-key) |                            |
 
 ### Examples
 
@@ -23,12 +23,12 @@ services:
     image: getwud/wud
     ...
     environment:
-      - WUD_REGISTRY_GCR=
+      - HOSAKA_REGISTRY_GCR=
 ```
 #### **Docker**
 ```bash
 docker run \
-  -e WUD_REGISTRY_GCR="" \
+  -e HOSAKA_REGISTRY_GCR="" \
   ...
   getwud/wud
 ```
@@ -45,14 +45,14 @@ services:
     image: getwud/wud
     ...
     environment:
-      - WUD_REGISTRY_GCR_CLIENTEMAIL=johndoe@mysuperproject.iam.gserviceaccount.com
-      - WUD_REGISTRY_GCR_PRIVATEKEY=-----BEGIN PRIVATE KEY-----xxxxxxxxxxx\n-----END PRIVATE KEY-----\n 
+      - HOSAKA_REGISTRY_GCR_CLIENTEMAIL=johndoe@mysuperproject.iam.gserviceaccount.com
+      - HOSAKA_REGISTRY_GCR_PRIVATEKEY=-----BEGIN PRIVATE KEY-----xxxxxxxxxxx\n-----END PRIVATE KEY-----\n 
 ```
 #### **Docker**
 ```bash
 docker run \
-  -e WUD_REGISTRY_GCR_CLIENTEMAIL="johndoe@mysuperproject.iam.gserviceaccount.com" \
-  -e WUD_REGISTRY_GCR_PRIVATEKEY="-----BEGIN PRIVATE KEY-----xxxxxxxxxxx\n-----END PRIVATE KEY-----\n" \
+  -e HOSAKA_REGISTRY_GCR_CLIENTEMAIL="johndoe@mysuperproject.iam.gserviceaccount.com" \
+  -e HOSAKA_REGISTRY_GCR_PRIVATEKEY="-----BEGIN PRIVATE KEY-----xxxxxxxxxxx\n-----END PRIVATE KEY-----\n" \
   ...
   getwud/wud
 ```

--- a/docs/configuration/registries/ghcr/README.md
+++ b/docs/configuration/registries/ghcr/README.md
@@ -7,8 +7,8 @@ The `ghcr` registry lets you configure [GHCR](https://docs.github.com/en/package
 
 | Env var                      | Required       | Description     | Supported values                         | Default value when missing |
 | ---------------------------- |:--------------:| --------------- | ---------------------------------------- | -------------------------- | 
-| `WUD_REGISTRY_GHCR_USERNAME` | :white_circle: | Github username |                                          |                            |
-| `WUD_REGISTRY_GHCR_TOKEN`    | :white_circle: | Github token    | Github password or Github Personal Token |                            |
+| `HOSAKA_REGISTRY_GHCR_USERNAME` | :white_circle: | Github username |                                          |                            |
+| `HOSAKA_REGISTRY_GHCR_TOKEN`    | :white_circle: | Github token    | Github password or Github Personal Token |                            |
 
 ### Examples
 
@@ -24,12 +24,12 @@ services:
     image: getwud/wud
     ...
     environment:
-      - WUD_REGISTRY_GHCR=
+      - HOSAKA_REGISTRY_GHCR=
 ```
 #### **Docker**
 ```bash
 docker run \
-  -e WUD_REGISTRY_GHCR= \
+  -e HOSAKA_REGISTRY_GHCR= \
   ...
   getwud/wud
 ```
@@ -47,14 +47,14 @@ services:
     image: getwud/wud
     ...
     environment:
-      - WUD_REGISTRY_GHCR_USERNAME=john@doe
-      - WUD_REGISTRY_GHCR_TOKEN=xxxxx 
+      - HOSAKA_REGISTRY_GHCR_USERNAME=john@doe
+      - HOSAKA_REGISTRY_GHCR_TOKEN=xxxxx 
 ```
 #### **Docker**
 ```bash
 docker run \
-  -e WUD_REGISTRY_GHCR_USERNAME="john@doe" \
-  -e WUD_REGISTRY_GHCR_TOKEN="xxxxx" \
+  -e HOSAKA_REGISTRY_GHCR_USERNAME="john@doe" \
+  -e HOSAKA_REGISTRY_GHCR_TOKEN="xxxxx" \
   ...
   getwud/wud
 ```
@@ -68,5 +68,5 @@ docker run \
 Choose an expiration time & appropriate scopes (`read:packages` is only needed for wud) and generate.
 ![image](ghcr_01.png)
 
-#### Copy the token & use it as the WUD_REGISTRY_GHCR_TOKEN value
+#### Copy the token & use it as the HOSAKA_REGISTRY_GHCR_TOKEN value
 ![image](ghcr_02.png)

--- a/docs/configuration/registries/gitea/README.md
+++ b/docs/configuration/registries/gitea/README.md
@@ -7,10 +7,10 @@ The `gitea` registry lets you configure a self-hosted [Gitea](https://gitea.com)
 
 | Env var                       |    Required    | Description                                                     | Supported values                                    | Default value when missing |
 |-------------------------------|:--------------:|-----------------------------------------------------------------|-----------------------------------------------------|----------------------------| 
-| `WUD_REGISTRY_GITEA_URL`      |  :red_circle:  | Registry URL (e.g. https://gitea.acme.com)                      |                                                     |                            |
-| `WUD_REGISTRY_GITEA_LOGIN`    | :red_circle:   | Gitea username                                                  | WUD_REGISTRY_GITEA_PASSWORD must be defined         |                            |
-| `WUD_REGISTRY_GITEA_PASSWORD` |  :red_circle:  | Gitea password                                                  | WUD_REGISTRY_GITEA_LOGIN must be defined            |                            |
-| `WUD_REGISTRY_GITEA_AUTH`     | :white_circle: | Htpasswd string (when htpasswd auth is enabled on the registry) | WUD_REGISTRY_GITEA_LOGIN/TOKEN  must not be defined |                            |
+| `HOSAKA_REGISTRY_GITEA_URL`      |  :red_circle:  | Registry URL (e.g. https://gitea.acme.com)                      |                                                     |                            |
+| `HOSAKA_REGISTRY_GITEA_LOGIN`    | :red_circle:   | Gitea username                                                  | HOSAKA_REGISTRY_GITEA_PASSWORD must be defined         |                            |
+| `HOSAKA_REGISTRY_GITEA_PASSWORD` |  :red_circle:  | Gitea password                                                  | HOSAKA_REGISTRY_GITEA_LOGIN must be defined            |                            |
+| `HOSAKA_REGISTRY_GITEA_AUTH`     | :white_circle: | Htpasswd string (when htpasswd auth is enabled on the registry) | HOSAKA_REGISTRY_GITEA_LOGIN/TOKEN  must not be defined |                            |
 ### Examples
 
 #### Configure
@@ -24,16 +24,16 @@ services:
     image: getwud/wud
     ...
     environment:
-      - WUD_REGISTRY_GITEA_URL=https://gitea.acme.com
-      - WUD_REGISTRY_GITEA_LOGIN=john
-      - WUD_REGISTRY_GITEA_PASSWORD=doe
+      - HOSAKA_REGISTRY_GITEA_URL=https://gitea.acme.com
+      - HOSAKA_REGISTRY_GITEA_LOGIN=john
+      - HOSAKA_REGISTRY_GITEA_PASSWORD=doe
 ```
 #### **Docker**
 ```bash
 docker run \
-  -e "WUD_REGISTRY_GITEA_URL=https://gitea.acme.com/" \
-  -e "WUD_REGISTRY_GITEA_LOGIN=john" \
-  -e "WUD_REGISTRY_GITEA_PASSWORD=doe" \
+  -e "HOSAKA_REGISTRY_GITEA_URL=https://gitea.acme.com/" \
+  -e "HOSAKA_REGISTRY_GITEA_LOGIN=john" \
+  -e "HOSAKA_REGISTRY_GITEA_PASSWORD=doe" \
   ...
   getwud/wud
 ```

--- a/docs/configuration/registries/gitlab/README.md
+++ b/docs/configuration/registries/gitlab/README.md
@@ -7,9 +7,9 @@ The `gitlab` registry lets you configure [GITLAB](https://docs.gitlab.com/ee/use
 
 | Env var                       |   Required   | Description                    | Supported values                         | Default value when missing  |
 |-------------------------------|:------------:|--------------------------------| ---------------------------------------- |-----------------------------| 
-| `WUD_REGISTRY_GITLAB_URL`     | :red_circle: | Gitlab Registry base url       |                                          | https://registry.gitlab.com |
-| `WUD_REGISTRY_GITLAB_AUTHURL` | :red_circle: | Gitlab Authentication base url |                                          | https://gitlab.com          |
-| `WUD_REGISTRY_GITLAB_TOKEN`   | :red_circle: | Gitlab Personal Access Token   |                                          |                             |
+| `HOSAKA_REGISTRY_GITLAB_URL`     | :red_circle: | Gitlab Registry base url       |                                          | https://registry.gitlab.com |
+| `HOSAKA_REGISTRY_GITLAB_AUTHURL` | :red_circle: | Gitlab Authentication base url |                                          | https://gitlab.com          |
+| `HOSAKA_REGISTRY_GITLAB_TOKEN`   | :red_circle: | Gitlab Personal Access Token   |                                          |                             |
 
 ### Examples
 
@@ -25,12 +25,12 @@ services:
     image: getwud/wud
     ...
     environment:
-      - WUD_REGISTRY_GITLAB_TOKEN=xxxxx 
+      - HOSAKA_REGISTRY_GITLAB_TOKEN=xxxxx 
 ```
 #### **Docker**
 ```bash
 docker run \
-  -e WUD_REGISTRY_GITLAB_TOKEN="xxxxx" \
+  -e HOSAKA_REGISTRY_GITLAB_TOKEN="xxxxx" \
   ...
   getwud/wud
 ```
@@ -48,16 +48,16 @@ services:
     image: getwud/wud
     ...
     environment:
-      - WUD_REGISTRY_GITLAB_URL=https://registry.mygitlab.acme.com
-      - WUD_REGISTRY_GITLAB_AUTHURL=https://mygitlab.acme.com
-      - WUD_REGISTRY_GITLAB_TOKEN=xxxxx 
+      - HOSAKA_REGISTRY_GITLAB_URL=https://registry.mygitlab.acme.com
+      - HOSAKA_REGISTRY_GITLAB_AUTHURL=https://mygitlab.acme.com
+      - HOSAKA_REGISTRY_GITLAB_TOKEN=xxxxx 
 ```
 #### **Docker**
 ```bash
 docker run \
-  -e WUD_REGISTRY_GITLAB_URL="https://registry.mygitlab.acme.com"
-  -e WUD_REGISTRY_GITLAB_AUTHURL="https://mygitlab.acme.com"
-  -e WUD_REGISTRY_GITLAB_TOKEN="xxxxx" \
+  -e HOSAKA_REGISTRY_GITLAB_URL="https://registry.mygitlab.acme.com"
+  -e HOSAKA_REGISTRY_GITLAB_AUTHURL="https://mygitlab.acme.com"
+  -e HOSAKA_REGISTRY_GITLAB_TOKEN="xxxxx" \
   ...
   getwud/wud
 ```
@@ -71,5 +71,5 @@ docker run \
 Choose an expiration time & appropriate scopes (`read_registry` is only needed for wud) and generate.
 ![image](gitlab_01.png)
 
-#### Copy the token & use it as the WUD_REGISTRY_GITLAB_TOKEN value
+#### Copy the token & use it as the HOSAKA_REGISTRY_GITLAB_TOKEN value
 ![image](gitlab_02.png)

--- a/docs/configuration/registries/hub/README.md
+++ b/docs/configuration/registries/hub/README.md
@@ -15,10 +15,10 @@ Don't forget to configure authentication if you're using [Docker Hub Private Rep
 
 | Env var                     | Required       | Description                                                                   | Supported values                                  | Default value when missing |
 | --------------------------- |:--------------:| ----------------------------------------------------------------------------- | ------------------------------------------------- | -------------------------- | 
-| `WUD_REGISTRY_HUB_LOGIN`    | :white_circle: | A valid Docker Hub Login                                                      | WUD_REGISTRY_HUB_TOKEN must be defined            |                            |
-| `WUD_REGISTRY_HUB_PASSWORD` | :white_circle: | A valid Docker Hub Token                                                      | WUD_REGISTRY_HUB_LOGIN must be defined            |                            |
-| `WUD_REGISTRY_HUB_TOKEN`    | :white_circle: | A valid Docker Hub Token (deprecated; replaced by `WUD_REGISTRY_HUB_PASSWORD` | WUD_REGISTRY_HUB_LOGIN must be defined            |                            |
-| `WUD_REGISTRY_HUB_AUTH`     | :white_circle: | A valid Docker Hub Base64 Auth String                                         | WUD_REGISTRY_HUB_LOGIN/TOKEN  must not be defined |                            |
+| `HOSAKA_REGISTRY_HUB_LOGIN`    | :white_circle: | A valid Docker Hub Login                                                      | HOSAKA_REGISTRY_HUB_TOKEN must be defined            |                            |
+| `HOSAKA_REGISTRY_HUB_PASSWORD` | :white_circle: | A valid Docker Hub Token                                                      | HOSAKA_REGISTRY_HUB_LOGIN must be defined            |                            |
+| `HOSAKA_REGISTRY_HUB_TOKEN`    | :white_circle: | A valid Docker Hub Token (deprecated; replaced by `HOSAKA_REGISTRY_HUB_PASSWORD` | HOSAKA_REGISTRY_HUB_LOGIN must be defined            |                            |
+| `HOSAKA_REGISTRY_HUB_AUTH`     | :white_circle: | A valid Docker Hub Base64 Auth String                                         | HOSAKA_REGISTRY_HUB_LOGIN/TOKEN  must not be defined |                            |
 
 ### Examples
 
@@ -33,12 +33,12 @@ services:
     image: getwud/wud
     ...
     environment:
-      - WUD_REGISTRY_HUB=
+      - HOSAKA_REGISTRY_HUB=
 ```
 #### **Docker**
 ```bash
 docker run \
-  -e WUD_REGISTRY_HUB= \
+  -e HOSAKA_REGISTRY_HUB= \
   ...
   getwud/wud
 ```
@@ -51,7 +51,7 @@ docker run \
 
 ##### 2. Go to your&nbsp;[Security Settings](https://hub.docker.com/settings/security)
 - Create a new Access Token
-- Copy it and use it as the `WUD_REGISTRY_HUB_TOKEN` value
+- Copy it and use it as the `HOSAKA_REGISTRY_HUB_TOKEN` value
 
 ![image](hub_token.png)
 
@@ -65,14 +65,14 @@ services:
     image: getwud/wud
     ...
     environment:
-      - WUD_REGISTRY_HUB_LOGIN=mylogin
-      - WUD_REGISTRY_HUB_PASSWORD=fb4d5db9-e64d-3648-8846-74d0846e55de
+      - HOSAKA_REGISTRY_HUB_LOGIN=mylogin
+      - HOSAKA_REGISTRY_HUB_PASSWORD=fb4d5db9-e64d-3648-8846-74d0846e55de
 ```
 #### **Docker**
 ```bash
 docker run \
-  -e WUD_REGISTRY_HUB_LOGIN="mylogin"
-  -e WUD_REGISTRY_HUB_PASSWORD="fb4d5db9-e64d-3648-8846-74d0846e55de"
+  -e HOSAKA_REGISTRY_HUB_LOGIN="mylogin"
+  -e HOSAKA_REGISTRY_HUB_PASSWORD="fb4d5db9-e64d-3648-8846-74d0846e55de"
   ...
   getwud/wud
 ```
@@ -101,12 +101,12 @@ services:
     image: getwud/wud
     ...
     environment:
-      - WUD_REGISTRY_HUB_AUTH=am9obmRvZToyYzFiZDg3Mi1lZmI2LTRmM2EtODFhYS03MjQ1MThhMGE1OTI=
+      - HOSAKA_REGISTRY_HUB_AUTH=am9obmRvZToyYzFiZDg3Mi1lZmI2LTRmM2EtODFhYS03MjQ1MThhMGE1OTI=
 ```
 #### **Docker**
 ```bash
 docker run \
-  -e WUD_REGISTRY_HUB_AUTH="am9obmRvZToyYzFiZDg3Mi1lZmI2LTRmM2EtODFhYS03MjQ1MThhMGE1OTI="
+  -e HOSAKA_REGISTRY_HUB_AUTH="am9obmRvZToyYzFiZDg3Mi1lZmI2LTRmM2EtODFhYS03MjQ1MThhMGE1OTI="
   ...
   getwud/wud
 ```

--- a/docs/configuration/registries/lscr/README.md
+++ b/docs/configuration/registries/lscr/README.md
@@ -7,8 +7,8 @@ The `lscr` registry lets you configure [LSCR](https://fleet.linuxserver.io/) int
 
 | Env var                      |   Required    | Description     | Supported values                         | Default value when missing |
 |------------------------------|:-------------:|-----------------|------------------------------------------|----------------------------|
-| `WUD_REGISTRY_LSCR_USERNAME` | :red_circle:  | Github username |                                          |                            |
-| `WUD_REGISTRY_LSCR_TOKEN`    | :red_circle:  | Github token    | Github password or Github Personal Token |                            |
+| `HOSAKA_REGISTRY_LSCR_USERNAME` | :red_circle:  | Github username |                                          |                            |
+| `HOSAKA_REGISTRY_LSCR_TOKEN`    | :red_circle:  | Github token    | Github password or Github Personal Token |                            |
 
 ### Examples
 
@@ -22,14 +22,14 @@ services:
     image: getwud/wud
     ...
     environment:
-      - WUD_REGISTRY_LSCR_USERNAME=john@doe
-      - WUD_REGISTRY_LSCR_TOKEN=xxxxx 
+      - HOSAKA_REGISTRY_LSCR_USERNAME=john@doe
+      - HOSAKA_REGISTRY_LSCR_TOKEN=xxxxx 
 ```
 #### **Docker**
 ```bash
 docker run \
-  -e WUD_REGISTRY_LSCR_USERNAME="john@doe" \
-  -e WUD_REGISTRY_LSCR_TOKEN="xxxxx" \
+  -e HOSAKA_REGISTRY_LSCR_USERNAME="john@doe" \
+  -e HOSAKA_REGISTRY_LSCR_TOKEN="xxxxx" \
   ...
   getwud/wud
 ```
@@ -43,5 +43,5 @@ docker run \
 Choose an expiration time & appropriate scopes (`read:packages` is only needed for wud) and generate.
 ![image](lscr_01.png)
 
-#### Copy the token & use it as the WUD_REGISTRY_LSCR_TOKEN value
+#### Copy the token & use it as the HOSAKA_REGISTRY_LSCR_TOKEN value
 ![image](lscr_02.png)

--- a/docs/configuration/registries/quay/README.md
+++ b/docs/configuration/registries/quay/README.md
@@ -7,9 +7,9 @@ The `quay` registry lets you configure [QUAY](https://quay.io/) integration.
 
 | Env var                      | Required        | Description    | Supported values | Default value when missing |
 | ----------------------------- |:--------------:| -------------- | ---------------- | -------------------------- | 
-| `WUD_REGISTRY_QUAY_NAMESPACE` | :white_circle: | Quay namespace |                  |                            |
-| `WUD_REGISTRY_QUAY_ACCOUNT`   | :white_circle: | Quay account   |                  |                            |
-| `WUD_REGISTRY_QUAY_TOKEN`     | :white_circle: | Quay token     |                  |                            |
+| `HOSAKA_REGISTRY_QUAY_NAMESPACE` | :white_circle: | Quay namespace |                  |                            |
+| `HOSAKA_REGISTRY_QUAY_ACCOUNT`   | :white_circle: | Quay account   |                  |                            |
+| `HOSAKA_REGISTRY_QUAY_TOKEN`     | :white_circle: | Quay token     |                  |                            |
 
 ### Examples
 
@@ -25,12 +25,12 @@ services:
     image: getwud/wud
     ...
     environment:
-      - WUD_REGISTRY_QUAY
+      - HOSAKA_REGISTRY_QUAY
 ```
 #### **Docker**
 ```bash
 docker run \
-  -e WUD_REGISTRY_QUAY= \
+  -e HOSAKA_REGISTRY_QUAY= \
   ...
   getwud/wud
 ```
@@ -48,16 +48,16 @@ services:
     image: getwud/wud
     ...
     environment:
-      - WUD_REGISTRY_QUAY_NAMESPACE=mynamespace
-      - WUD_REGISTRY_QUAY_ACCOUNT=myaccount
-      - WUD_REGISTRY_QUAY_TOKEN=BA8JI3Y2BWQDH849RYT3YD5J0J6CYEORYTQMMJK364B4P88VPTJIAI704L0BBP8D6CYE4P88V 
+      - HOSAKA_REGISTRY_QUAY_NAMESPACE=mynamespace
+      - HOSAKA_REGISTRY_QUAY_ACCOUNT=myaccount
+      - HOSAKA_REGISTRY_QUAY_TOKEN=BA8JI3Y2BWQDH849RYT3YD5J0J6CYEORYTQMMJK364B4P88VPTJIAI704L0BBP8D6CYE4P88V 
 ```
 #### **Docker**
 ```bash
 docker run \
-  -e WUD_REGISTRY_QUAY_NAMESPACE="mynamespace" \
-  -e WUD_REGISTRY_QUAY_ACCOUNT="myaccount" \
-  -e WUD_REGISTRY_QUAY_TOKEN="BA8JI3Y2BWQDH849RYT3YD5J0J6CYEORYTQMMJK364B4P88VPTJIAI704L0BBP8D6CYE4P88V" \
+  -e HOSAKA_REGISTRY_QUAY_NAMESPACE="mynamespace" \
+  -e HOSAKA_REGISTRY_QUAY_ACCOUNT="myaccount" \
+  -e HOSAKA_REGISTRY_QUAY_TOKEN="BA8JI3Y2BWQDH849RYT3YD5J0J6CYEORYTQMMJK364B4P88VPTJIAI704L0BBP8D6CYE4P88V" \
   ...
   getwud/wud
 ```

--- a/docs/configuration/server/README.md
+++ b/docs/configuration/server/README.md
@@ -6,15 +6,15 @@ You can adjust the server configuration with the following environment variables
 
 | Env var                    | Required       | Description                                                                  | Supported values                         | Default value when missing       |
 | -------------------------- |:--------------:|----------------------------------------------------------------------------- | ---------------------------------------- | -------------------------------- | 
-| `WUD_SERVER_ENABLED`       | :white_circle: | If REST API must be exposed                                                  | `true`, `false`                          | `true`                           |
-| `WUD_SERVER_PORT`          | :white_circle: | Http listener port                                                           | from `0` to `65535`                      | `3000`                           |
-| `WUD_SERVER_TLS_ENABLED`   | :white_circle: | Enable HTTPS+TLS                                                             | `true`, `false`                          | `false`                          |
-| `WUD_SERVER_TLS_KEY`       | :white_circle: | TLS server key (required when `WUD_SERVER_TLS_ENABLED` is enabled)           | File path to the key file                |                                  |
-| `WUD_SERVER_TLS_CERT`      | :white_circle: | TLS server certificate (required when `WUD_SERVER_TLS_ENABLED` is enabled)   | File path to the cert file               |                                  |
-| `WUD_SERVER_CORS_ENABLED`  | :white_circle: | Enable [CORS](https://developer.mozilla.org/fr/docs/Web/HTTP/CORS) Requests  | `true`, `false`                          | `false`                          |
-| `WUD_SERVER_CORS_ORIGIN`   | :white_circle: | Supported CORS origin                                                        |                                          | `*`                              |
-| `WUD_SERVER_CORS_METHODS`  | :white_circle: | Supported CORS methods                                                       | Comma separated list of valid HTTP verbs | `GET,HEAD,PUT,PATCH,POST,DELETE` |
-| `WUD_SERVER_FEATURE_DELETE`| :white_circle: | If deleting operations are enabled through API & UI                          | `true`, `false`                          | `true`                           |
+| `HOSAKA_SERVER_ENABLED`       | :white_circle: | If REST API must be exposed                                                  | `true`, `false`                          | `true`                           |
+| `HOSAKA_SERVER_PORT`          | :white_circle: | Http listener port                                                           | from `0` to `65535`                      | `3000`                           |
+| `HOSAKA_SERVER_TLS_ENABLED`   | :white_circle: | Enable HTTPS+TLS                                                             | `true`, `false`                          | `false`                          |
+| `HOSAKA_SERVER_TLS_KEY`       | :white_circle: | TLS server key (required when `HOSAKA_SERVER_TLS_ENABLED` is enabled)           | File path to the key file                |                                  |
+| `HOSAKA_SERVER_TLS_CERT`      | :white_circle: | TLS server certificate (required when `HOSAKA_SERVER_TLS_ENABLED` is enabled)   | File path to the cert file               |                                  |
+| `HOSAKA_SERVER_CORS_ENABLED`  | :white_circle: | Enable [CORS](https://developer.mozilla.org/fr/docs/Web/HTTP/CORS) Requests  | `true`, `false`                          | `false`                          |
+| `HOSAKA_SERVER_CORS_ORIGIN`   | :white_circle: | Supported CORS origin                                                        |                                          | `*`                              |
+| `HOSAKA_SERVER_CORS_METHODS`  | :white_circle: | Supported CORS methods                                                       | Comma separated list of valid HTTP verbs | `GET,HEAD,PUT,PATCH,POST,DELETE` |
+| `HOSAKA_SERVER_FEATURE_DELETE`| :white_circle: | If deleting operations are enabled through API & UI                          | `true`, `false`                          | `true`                           |
 
 ### Examples
 
@@ -30,12 +30,12 @@ services:
     image: getwud/wud
     ...
     environment:
-      - WUD_SERVER_ENABLED=false
+      - HOSAKA_SERVER_ENABLED=false
 ```
 #### **Docker**
 ```bash
 docker run \
-  -e WUD_SERVER_ENABLED=false \
+  -e HOSAKA_SERVER_ENABLED=false \
   ...
   getwud/wud
 ```
@@ -53,12 +53,12 @@ services:
     image: getwud/wud
     ...
     environment:
-      - WUD_SERVER_PORT=8080
+      - HOSAKA_SERVER_PORT=8080
 ```
 #### **Docker**
 ```bash
 docker run \
-  -e WUD_SERVER_PORT=8080 \
+  -e HOSAKA_SERVER_PORT=8080 \
   ...
   getwud/wud
 ```
@@ -76,16 +76,16 @@ services:
     image: getwud/wud
     ...
     environment:
-      - WUD_SERVER_TLS_ENABLED=true
-      - WUD_SERVER_TLS_KEY=/wud_certs/server.key
-      - WUD_SERVER_TLS_CERT=/wud_certs/server.crt
+      - HOSAKA_SERVER_TLS_ENABLED=true
+      - HOSAKA_SERVER_TLS_KEY=/wud_certs/server.key
+      - HOSAKA_SERVER_TLS_CERT=/wud_certs/server.crt
 ```
 #### **Docker**
 ```bash
 docker run \
-  -e "WUD_SERVER_TLS_ENABLED=true" \
-  -e "WUD_SERVER_TLS_KEY=/wud_certs/server.key" \
-  -e "WUD_SERVER_TLS_CERT=/wud_certs/server.crt" \
+  -e "HOSAKA_SERVER_TLS_ENABLED=true" \
+  -e "HOSAKA_SERVER_TLS_KEY=/wud_certs/server.key" \
+  -e "HOSAKA_SERVER_TLS_CERT=/wud_certs/server.crt" \
   ...
   getwud/wud
 ```

--- a/docs/configuration/triggers/README.md
+++ b/docs/configuration/triggers/README.md
@@ -5,7 +5,7 @@ Triggers are responsible for performing actions when a new container version is 
 Triggers are enabled using environment variables.
 
 ```bash
-WUD_TRIGGER_{{ trigger_type }}_{{trigger_name }}_{{ trigger_configuration_item }}=XXX
+HOSAKA_TRIGGER_{{ trigger_type }}_{{trigger_name }}_{{ trigger_configuration_item }}=XXX
 ```
 
 !> Multiple triggers of the same type can be configured (for example multiple Smtp addresses).  
@@ -18,12 +18,12 @@ All implemented triggers, in addition to their specific configuration, also supp
 
 | Env var                                                    |    Required    | Description                                                                            | Supported values                                                                                                     | Default value when missing                                                                       |
 |------------------------------------------------------------|:--------------:|----------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------|--------------------------------------------------------------------------------------------------|
-| `WUD_TRIGGER_{{trigger_type}}}_{trigger_name}_MODE`        | :white_circle: | Trigger for each container update or trigger once with all available updates as a list | `simple`, `batch`                                                                                                    | `simple`                                                                                         |
-| `WUD_TRIGGER_{{trigger_type}}}_{trigger_name}_ONCE`        | :white_circle: | Run trigger once (do not repeat previous results)                                      | `true`, `false`                                                                                                      | `true`                                                                                           |
-| `WUD_TRIGGER_{{trigger_type}}}_{trigger_name}_THRESHOLD`   | :white_circle: | The threshold to reach to run the trigger                                              | `all`, `major`, `minor`, `patch`                                                                                     | `all`                                                                                            |
-| `WUD_TRIGGER_{{trigger_type}}}_{trigger_name}_SIMPLETITLE` | :white_circle: | The template to use to render the title of the notification (simple mode)              | String template with placeholders `${id}` `${name}` `${watcher}` `${kind}` `${semver}` `${local}` `${remote}` `${link}` | `New ${kind} found for container ${name}`                                                        |
-| `WUD_TRIGGER_{{trigger_type}}}_{trigger_name}_BATCHTITLE`  | :white_circle: | The template to use to render the title of the notification (batch mode)               | String template with placeholders `${count}`                                                                         | `${count} updates available`                                                                     |
-| `WUD_TRIGGER_{{trigger_type}}}_{trigger_name}_SIMPLEBODY`  | :white_circle: | The template to use to render the body of the notification                             | String template with placeholders `${id}` `${name}` `${watcher}` `${kind}` `${semver}` `${local}` `${remote}` `${link}` | `Container ${name} running with ${kind} ${local} can be updated to ${kind} ${remote} \n ${link}` |
+| `HOSAKA_TRIGGER_{{trigger_type}}}_{trigger_name}_MODE`        | :white_circle: | Trigger for each container update or trigger once with all available updates as a list | `simple`, `batch`                                                                                                    | `simple`                                                                                         |
+| `HOSAKA_TRIGGER_{{trigger_type}}}_{trigger_name}_ONCE`        | :white_circle: | Run trigger once (do not repeat previous results)                                      | `true`, `false`                                                                                                      | `true`                                                                                           |
+| `HOSAKA_TRIGGER_{{trigger_type}}}_{trigger_name}_THRESHOLD`   | :white_circle: | The threshold to reach to run the trigger                                              | `all`, `major`, `minor`, `patch`                                                                                     | `all`                                                                                            |
+| `HOSAKA_TRIGGER_{{trigger_type}}}_{trigger_name}_SIMPLETITLE` | :white_circle: | The template to use to render the title of the notification (simple mode)              | String template with placeholders `${id}` `${name}` `${watcher}` `${kind}` `${semver}` `${local}` `${remote}` `${link}` | `New ${kind} found for container ${name}`                                                        |
+| `HOSAKA_TRIGGER_{{trigger_type}}}_{trigger_name}_BATCHTITLE`  | :white_circle: | The template to use to render the title of the notification (batch mode)               | String template with placeholders `${count}`                                                                         | `${count} updates available`                                                                     |
+| `HOSAKA_TRIGGER_{{trigger_type}}}_{trigger_name}_SIMPLEBODY`  | :white_circle: | The template to use to render the body of the notification                             | String template with placeholders `${id}` `${name}` `${watcher}` `${kind}` `${semver}` `${local}` `${remote}` `${link}` | `Container ${name} running with ${kind} ${local} can be updated to ${kind} ${remote} \n ${link}` |
 
 ?> Threshold `all` means that the trigger will run regardless of the nature of the change
 
@@ -33,7 +33,7 @@ All implemented triggers, in addition to their specific configuration, also supp
 
 ?> Threshold `patch` means that the trigger will run only if this is a `patch` semver change
 
-?> `WUD_TRIGGER_{{trigger_type}}}_{trigger_name}_ONCE=false` can be useful when `WUD_TRIGGER_{{trigger_type}}}_{trigger_name}_MODE=batch` to get a report with all pending updates.
+?> `HOSAKA_TRIGGER_{{trigger_type}}}_{trigger_name}_ONCE=false` can be useful when `HOSAKA_TRIGGER_{{trigger_type}}}_{trigger_name}_MODE=batch` to get a report with all pending updates.
 
 
 ### Examples
@@ -48,14 +48,14 @@ services:
     image: getwud/wud
     ...
     environment:
-      - WUD_TRIGGER_SMTP_GMAIL_SIMPLETITLE=Container $${name} can be updated
-      - WUD_TRIGGER_SMTP_GMAIL_SIMPLEBODY=Container $${name} can be updated from version $${local} to version $${remote}
+      - HOSAKA_TRIGGER_SMTP_GMAIL_SIMPLETITLE=Container $${name} can be updated
+      - HOSAKA_TRIGGER_SMTP_GMAIL_SIMPLEBODY=Container $${name} can be updated from version $${local} to version $${remote}
 ```
 #### **Docker**
 ```bash
 docker run \
-  -e 'WUD_TRIGGER_SMTP_GMAIL_SIMPLETITLE=Container ${name} can be updated' \
-  -e 'WUD_TRIGGER_SMTP_GMAIL_SIMPLEBODY=Container ${name} can be updated from version ${local} to version ${remote}'
+  -e 'HOSAKA_TRIGGER_SMTP_GMAIL_SIMPLETITLE=Container ${name} can be updated' \
+  -e 'HOSAKA_TRIGGER_SMTP_GMAIL_SIMPLEBODY=Container ${name} can be updated from version ${local} to version ${remote}'
   ...
   getwud/wud
 ```

--- a/docs/configuration/triggers/apprise/README.md
+++ b/docs/configuration/triggers/apprise/README.md
@@ -7,10 +7,10 @@ The `apprise` trigger lets you send container update notifications via the [Appr
 
 | Env var                                     |    Required    | Description                                                             | Supported values                                                                                                           | Default value when missing |
 |---------------------------------------------|:--------------:|-------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------|----------------------------| 
-| `WUD_TRIGGER_APPRISE_{trigger_name}_URL`    | :red_circle:   | The Base URL of the Apprise API                                         |                                                                                                                            |                            |
-| `WUD_TRIGGER_APPRISE_{trigger_name}_URLS`   | :white_circle: | The comma separated list of Apprise service urls                        | [See the list of the supported Apprise notification URLs](https://github.com/caronc/apprise#popular-notification-services) |                            |
-| `WUD_TRIGGER_APPRISE_{trigger_name}_CONFIG` | :white_circle: | The name of an Apprise yaml configuration                               | [See Apprise persistent configuration documentation](https://github.com/caronc/apprise/wiki/config_yaml)                   |                            |
-| `WUD_TRIGGER_APPRISE_{trigger_name}_TAG`    | :white_circle: | The optional tags(s) to expand when using an Apprise yaml configuration | [See Apprise persistent configuration documentation](https://github.com/caronc/apprise/wiki/config_yaml)                   |                            |
+| `HOSAKA_TRIGGER_APPRISE_{trigger_name}_URL`    | :red_circle:   | The Base URL of the Apprise API                                         |                                                                                                                            |                            |
+| `HOSAKA_TRIGGER_APPRISE_{trigger_name}_URLS`   | :white_circle: | The comma separated list of Apprise service urls                        | [See the list of the supported Apprise notification URLs](https://github.com/caronc/apprise#popular-notification-services) |                            |
+| `HOSAKA_TRIGGER_APPRISE_{trigger_name}_CONFIG` | :white_circle: | The name of an Apprise yaml configuration                               | [See Apprise persistent configuration documentation](https://github.com/caronc/apprise/wiki/config_yaml)                   |                            |
+| `HOSAKA_TRIGGER_APPRISE_{trigger_name}_TAG`    | :white_circle: | The optional tags(s) to expand when using an Apprise yaml configuration | [See Apprise persistent configuration documentation](https://github.com/caronc/apprise/wiki/config_yaml)                   |                            |
 
 ?> This trigger also supports the [common configuration variables](configuration/triggers/?id=common-trigger-configuration).
 
@@ -28,14 +28,14 @@ services:
     image: getwud/wud
     ...
     environment:
-      - WUD_TRIGGER_APPRISE_LOCAL_URL=http://apprise:8000
-      - WUD_TRIGGER_APPRISE_LOCAL_URLS=mailto://john.doe:secret@gmail.com,sns://AHIAJGNT76XIMXDBIJYA/bu1dHSdO22pfaaVy/wmNsdljF4C07D3bndi9PQJ9/us-east-2/+1(800)555-1223
+      - HOSAKA_TRIGGER_APPRISE_LOCAL_URL=http://apprise:8000
+      - HOSAKA_TRIGGER_APPRISE_LOCAL_URLS=mailto://john.doe:secret@gmail.com,sns://AHIAJGNT76XIMXDBIJYA/bu1dHSdO22pfaaVy/wmNsdljF4C07D3bndi9PQJ9/us-east-2/+1(800)555-1223
 ```
 #### **Docker**
 ```bash
 docker run \
-  -e WUD_TRIGGER_APPRISE_LOCAL_URL="http://apprise:8000" \
-  -e WUD_TRIGGER_APPRISE_LOCAL_URLS="mailto://john.doe:secret@gmail.com,sns://AHIAJGNT76XIMXDBIJYA/bu1dHSdO22pfaaVy/wmNsdljF4C07D3bndi9PQJ9/us-east-2/+1(800)555-1223" \
+  -e HOSAKA_TRIGGER_APPRISE_LOCAL_URL="http://apprise:8000" \
+  -e HOSAKA_TRIGGER_APPRISE_LOCAL_URLS="mailto://john.doe:secret@gmail.com,sns://AHIAJGNT76XIMXDBIJYA/bu1dHSdO22pfaaVy/wmNsdljF4C07D3bndi9PQJ9/us-east-2/+1(800)555-1223" \
   ...
   getwud/wud
 ```
@@ -60,16 +60,16 @@ services:
     image: getwud/wud
     ...
     environment:
-      - WUD_TRIGGER_APPRISE_LOCAL_URL=http://apprise:8000
-      - WUD_TRIGGER_APPRISE_LOCAL_CONFIG=wud # the name of the yaml config file
-      - WUD_TRIGGER_APPRISE_LOCAL_TAG=devops # the tags to use with the config (optional)
+      - HOSAKA_TRIGGER_APPRISE_LOCAL_URL=http://apprise:8000
+      - HOSAKA_TRIGGER_APPRISE_LOCAL_CONFIG=wud # the name of the yaml config file
+      - HOSAKA_TRIGGER_APPRISE_LOCAL_TAG=devops # the tags to use with the config (optional)
 ```
 #### **Docker**
 ```bash
 docker run \
-  -e WUD_TRIGGER_APPRISE_LOCAL_URL="http://apprise:8000" \
-  -e WUD_TRIGGER_APPRISE_LOCAL_CONFIG="wud" \
-  -e WUD_TRIGGER_APPRISE_LOCAL_TAG="devops" \  
+  -e HOSAKA_TRIGGER_APPRISE_LOCAL_URL="http://apprise:8000" \
+  -e HOSAKA_TRIGGER_APPRISE_LOCAL_CONFIG="wud" \
+  -e HOSAKA_TRIGGER_APPRISE_LOCAL_TAG="devops" \  
   ...
   getwud/wud
 ```

--- a/docs/configuration/triggers/discord/README.md
+++ b/docs/configuration/triggers/discord/README.md
@@ -7,10 +7,10 @@ The `discord` trigger lets you send realtime notifications using [Discord](https
 
 | Env var                                          | Required       | Description                              | Supported values      | Default value when missing  |
 |--------------------------------------------------|:--------------:|------------------------------------------|-----------------------|-----------------------------|
-| `WUD_TRIGGER_DISCORD_{trigger_name}_URL`         | :red_circle:   | The Discord webhook URL                  | HTTPS URL             |                             |
-| `WUD_TRIGGER_DISCORD_{trigger_name}_BOTUSERNAME` | :white_circle: | The bot username                         |                       | WUD                         |
-| `WUD_TRIGGER_DISCORD_{trigger_name}_CARDCOLOR`   | :white_circle: | Color of the message card                | Color in decimal base | 65280                       |
-| `WUD_TRIGGER_DISCORD_{trigger_name}_CARDLABEL`   | :white_circle: | Optional label to display in the message | String                |                             |
+| `HOSAKA_TRIGGER_DISCORD_{trigger_name}_URL`         | :red_circle:   | The Discord webhook URL                  | HTTPS URL             |                             |
+| `HOSAKA_TRIGGER_DISCORD_{trigger_name}_BOTUSERNAME` | :white_circle: | The bot username                         |                       | WUD                         |
+| `HOSAKA_TRIGGER_DISCORD_{trigger_name}_CARDCOLOR`   | :white_circle: | Color of the message card                | Color in decimal base | 65280                       |
+| `HOSAKA_TRIGGER_DISCORD_{trigger_name}_CARDLABEL`   | :white_circle: | Optional label to display in the message | String                |                             |
 
 ?> This trigger also supports the [common configuration variables](configuration/triggers/?id=common-trigger-configuration).
 
@@ -27,15 +27,15 @@ services:
     image: getwud/wud
     ...
     environment:
-      - WUD_TRIGGER_DISCORD_1_URL=https://discord.com/api/webhooks/123/456
-      - WUD_TRIGGER_DISCORD_1_BOTUSERNAME=WUD
+      - HOSAKA_TRIGGER_DISCORD_1_URL=https://discord.com/api/webhooks/123/456
+      - HOSAKA_TRIGGER_DISCORD_1_BOTUSERNAME=WUD
 ```
 
 #### **Docker**
 ```bash
 docker run \
-  -e WUD_TRIGGER_DISCORD_1_URL="https://discord.com/api/webhooks/123/456" \
-  -e WUD_TRIGGER_DISCORD_1_BOTUSERNAME="WUD" \
+  -e HOSAKA_TRIGGER_DISCORD_1_URL="https://discord.com/api/webhooks/123/456" \
+  -e HOSAKA_TRIGGER_DISCORD_1_BOTUSERNAME="WUD" \
   ...
   getwud/wud
 ```

--- a/docs/configuration/triggers/docker-compose/README.md
+++ b/docs/configuration/triggers/docker-compose/README.md
@@ -17,10 +17,10 @@ The trigger will:
 
 | Env var                                           | Required       | Description                                                    | Supported values | Default value when missing |
 | ------------------------------------------------- |:--------------:| -------------------------------------------------------------- | ---------------- | -------------------------- | 
-| `WUD_TRIGGER_DOCKERCOMPOSE_{trigger_name}_FILE`   | :red_circle:   | The docker-compose.yml file location                           |                  |                            |
-| `WUD_TRIGGER_DOCKERCOMPOSE_{trigger_name}_BACKUP` | :white_circle: | Backup the docker-compose.yml file as `.back` before updating? | `true`, `false`  | `false`                    |
-| `WUD_TRIGGER_DOCKERCOMPOSE_{trigger_name}_PRUNE`  | :white_circle: | If the old image must be pruned after upgrade                  | `true`, `false`  | `false`                    |
-| `WUD_TRIGGER_DOCKERCOMPOSE_{trigger_name}_DRYRUN` | :white_circle: | When enabled, only pull the new image ahead of time            | `true`, `false`  | `false`                    |
+| `HOSAKA_TRIGGER_DOCKERCOMPOSE_{trigger_name}_FILE`   | :red_circle:   | The docker-compose.yml file location                           |                  |                            |
+| `HOSAKA_TRIGGER_DOCKERCOMPOSE_{trigger_name}_BACKUP` | :white_circle: | Backup the docker-compose.yml file as `.back` before updating? | `true`, `false`  | `false`                    |
+| `HOSAKA_TRIGGER_DOCKERCOMPOSE_{trigger_name}_PRUNE`  | :white_circle: | If the old image must be pruned after upgrade                  | `true`, `false`  | `false`                    |
+| `HOSAKA_TRIGGER_DOCKERCOMPOSE_{trigger_name}_DRYRUN` | :white_circle: | When enabled, only pull the new image ahead of time            | `true`, `false`  | `false`                    |
 
 ?> This trigger also supports the [common configuration variables](configuration/triggers/?id=common-trigger-configuration). but only supports the `batch` mode.
 
@@ -42,13 +42,13 @@ services:
     volumes:
     - /etc/my-services/docker-compose.yml:/wud/docker-compose.yml
     environment:
-      - WUD_TRIGGER_DOCKERCOMPOSE_EXAMPLE_FILE=/wud/docker-compose.yml
+      - HOSAKA_TRIGGER_DOCKERCOMPOSE_EXAMPLE_FILE=/wud/docker-compose.yml
 ```
 #### **Docker**
 ```bash
 docker run \
   -v /etc/my-services/docker-compose.yml:/wud/docker-compose.yml
-  -e "WUD_TRIGGER_DOCKERCOMPOSE_EXAMPLE_FILE=/wud/docker-compose.yml" \
+  -e "HOSAKA_TRIGGER_DOCKERCOMPOSE_EXAMPLE_FILE=/wud/docker-compose.yml" \
   ...
   getwud/wud
 ```

--- a/docs/configuration/triggers/docker/README.md
+++ b/docs/configuration/triggers/docker/README.md
@@ -16,8 +16,8 @@ The trigger will:
 
 | Env var                                    | Required       | Description                                         | Supported values | Default value when missing |
 | ------------------------------------------ |:--------------:|-----------------------------------------------------| ---------------- | -------------------------- | 
-| `WUD_TRIGGER_DOCKER_{trigger_name}_PRUNE`  | :white_circle: | If old image versions must be pruned                | `true`, `false`  | `false`                    |
-| `WUD_TRIGGER_DOCKER_{trigger_name}_DRYRUN` | :white_circle: | When enabled, only pull the new image ahead of time | `true`, `false`  | `false`                    |
+| `HOSAKA_TRIGGER_DOCKER_{trigger_name}_PRUNE`  | :white_circle: | If old image versions must be pruned                | `true`, `false`  | `false`                    |
+| `HOSAKA_TRIGGER_DOCKER_{trigger_name}_DRYRUN` | :white_circle: | When enabled, only pull the new image ahead of time | `true`, `false`  | `false`                    |
 
 ?> This trigger also supports the [common configuration variables](configuration/triggers/?id=common-trigger-configuration).
 
@@ -35,12 +35,12 @@ services:
     image: getwud/wud
     ...
     environment:
-      - WUD_TRIGGER_DOCKER_EXAMPLE_PRUNE=true
+      - HOSAKA_TRIGGER_DOCKER_EXAMPLE_PRUNE=true
 ```
 #### **Docker**
 ```bash
 docker run \
-  -e "WUD_TRIGGER_DOCKER_EXAMPLE_PRUNE=true" \
+  -e "HOSAKA_TRIGGER_DOCKER_EXAMPLE_PRUNE=true" \
   ...
   getwud/wud
 ```

--- a/docs/configuration/triggers/http/README.md
+++ b/docs/configuration/triggers/http/README.md
@@ -6,14 +6,14 @@ The `http` trigger lets you send container update notifications via HTTP.
 
 | Env var                                         |    Required    | Description                                       | Supported values             | Default value when missing |
 |-------------------------------------------------|:--------------:|---------------------------------------------------|------------------------------|----------------------------| 
-| `WUD_TRIGGER_HTTP_{trigger_name}_URL`           |  :red_circle:  | The URL of the webhook                            | Valid http or https endpoint |                            |
-| `WUD_TRIGGER_HTTP_{trigger_name}_METHOD`        | :white_circle: | The HTTP method to use                            | `GET`, `POST`                | `POST`                     |
-| `WUD_TRIGGER_HTTP_{trigger_name}_AUTH_TYPE`     | :white_circle: | The Auth type (among )                            | `BASIC`, `BEARER`            | `BASIC`                    |
-| `WUD_TRIGGER_HTTP_{trigger_name}_AUTH_USER`     | :white_circle: | The Auth user if BASIC Auth is enabled            |                              |                            |
-| `WUD_TRIGGER_HTTP_{trigger_name}_AUTH_PASSWORD` | :white_circle: | The Auth user password if `BASIC` Auth is enabled |                              |                            |
-| `WUD_TRIGGER_HTTP_{trigger_name}_AUTH_BEARER`   | :white_circle: | The Auth bearer token if `BEARER` Auth is enabled |                              |                            |
-| `WUD_TRIGGER_HTTP_{trigger_name}_PROXY`         | :white_circle: | The HTTP Proxy                                    |                              |                            |
-| `WUD_TRIGGER_HTTP_{trigger_name}_INSTALL`       | :white_circle: | Sets this HTTP trigger as an install type\*       | `true`, or `false`           | `false`                    |
+| `HOSAKA_TRIGGER_HTTP_{trigger_name}_URL`           |  :red_circle:  | The URL of the webhook                            | Valid http or https endpoint |                            |
+| `HOSAKA_TRIGGER_HTTP_{trigger_name}_METHOD`        | :white_circle: | The HTTP method to use                            | `GET`, `POST`                | `POST`                     |
+| `HOSAKA_TRIGGER_HTTP_{trigger_name}_AUTH_TYPE`     | :white_circle: | The Auth type (among )                            | `BASIC`, `BEARER`            | `BASIC`                    |
+| `HOSAKA_TRIGGER_HTTP_{trigger_name}_AUTH_USER`     | :white_circle: | The Auth user if BASIC Auth is enabled            |                              |                            |
+| `HOSAKA_TRIGGER_HTTP_{trigger_name}_AUTH_PASSWORD` | :white_circle: | The Auth user password if `BASIC` Auth is enabled |                              |                            |
+| `HOSAKA_TRIGGER_HTTP_{trigger_name}_AUTH_BEARER`   | :white_circle: | The Auth bearer token if `BEARER` Auth is enabled |                              |                            |
+| `HOSAKA_TRIGGER_HTTP_{trigger_name}_PROXY`         | :white_circle: | The HTTP Proxy                                    |                              |                            |
+| `HOSAKA_TRIGGER_HTTP_{trigger_name}_INSTALL`       | :white_circle: | Sets this HTTP trigger as an install type\*       | `true`, or `false`           | `false`                    |
 
 \* By setting the INSTALL variable to `true`, this trigger is only executed manually in the containers UI page by clicking the "Install" button next to the upgrade version. Typical scheduled watch triggers for this http trigger will not occur when INSTALL is `true`. Only one INSTALL variable can be set across all trigger types - if more than one is set the UI will throw an error and the trigger will not be executed. 
 
@@ -33,12 +33,12 @@ services:
     image: getwud/wud
     ...
     environment:
-      - WUD_TRIGGER_HTTP_MYREMOTEHOST_URL=https://my-remote-host/new-version
+      - HOSAKA_TRIGGER_HTTP_MYREMOTEHOST_URL=https://my-remote-host/new-version
 ```
 #### **Docker**
 ```bash
 docker run \
-  -e WUD_TRIGGER_HTTP_MYREMOTEHOST_URL="https://my-remote-host/new-version" \
+  -e HOSAKA_TRIGGER_HTTP_MYREMOTEHOST_URL="https://my-remote-host/new-version" \
   ...
   getwud/wud
 ```

--- a/docs/configuration/triggers/ifttt/README.md
+++ b/docs/configuration/triggers/ifttt/README.md
@@ -7,8 +7,8 @@ The `ifttt` trigger lets you send container update notifications to Ifttt via th
 
 | Env var                                  | Required       | Description     | Supported values | Default value when missing |
 | ---------------------------------------- |:--------------:| --------------- | ---------------- | -------------------------- | 
-| `WUD_TRIGGER_IFTTT_{trigger_name}_KEY`   | :red_circle:   | The Webhook key |                  |                            |
-| `WUD_TRIGGER_IFTTT_{trigger_name}_EVENT` | :white_circle: | The event name  |                  | `wud-image`.               |
+| `HOSAKA_TRIGGER_IFTTT_{trigger_name}_KEY`   | :red_circle:   | The Webhook key |                  |                            |
+| `HOSAKA_TRIGGER_IFTTT_{trigger_name}_EVENT` | :white_circle: | The event name  |                  | `wud-image`.               |
 
 ?> This trigger also supports the [common configuration variables](configuration/triggers/?id=common-trigger-configuration).
 
@@ -34,13 +34,13 @@ services:
     image: getwud/wud
     ...
     environment:
-      - WUD_TRIGGER_IFTTT_PROD_KEY=*******************************************
+      - HOSAKA_TRIGGER_IFTTT_PROD_KEY=*******************************************
 ```
 
 #### **Docker**
 ```bash
 docker run \
-  -e WUD_TRIGGER_IFTTT_PROD_KEY="*******************************************" \
+  -e HOSAKA_TRIGGER_IFTTT_PROD_KEY="*******************************************" \
   ...
   getwud/wud
 ```

--- a/docs/configuration/triggers/kafka/README.md
+++ b/docs/configuration/triggers/kafka/README.md
@@ -7,12 +7,12 @@ The `kafka` trigger lets you publish container update notifications to a Kafka t
 
 | Env var                                                    | Required       | Description                                                      | Supported values                         | Default value when missing |
 | ---------------------------------------------------------- |:--------------:| ---------------------------------------------------------------- | ---------------------------------------- | -------------------------- | 
-| `WUD_TRIGGER_KAFKA_{trigger_name}_BROKERS`                 | :red_circle:   | Comma separated list of Kafka brokers                            |                                          |                            |
-| `WUD_TRIGGER_KAFKA_{trigger_name}_SSL`                     | :white_circle: | Is SSL enabled on the TLS connection                             | `true`, `false`                          | `false`                    |
-| `WUD_TRIGGER_KAFKA_{trigger_name}_TOPIC`                   | :white_circle: | The name of the topic to publish                                 |                                          | `wud-container`            |
-| `WUD_TRIGGER_KAFKA_{trigger_name}_AUTHENTICATION_TYPE`     | :white_circle: | The type for authentication                                      | `PLAIN`, `SCRAM-SHA-256`, `SCRAM-SHA-12` | `PLAIN`                    |
-| `WUD_TRIGGER_KAFKA_{trigger_name}_AUTHENTICATION_USER`     | :white_circle: | The name of the user (required if authentication is enabled)     |                                          |                            |
-| `WUD_TRIGGER_KAFKA_{trigger_name}_AUTHENTICATION_PASSWORD` | :white_circle: | The password of the user (required if authentication is enabled) |                                          |                            |
+| `HOSAKA_TRIGGER_KAFKA_{trigger_name}_BROKERS`                 | :red_circle:   | Comma separated list of Kafka brokers                            |                                          |                            |
+| `HOSAKA_TRIGGER_KAFKA_{trigger_name}_SSL`                     | :white_circle: | Is SSL enabled on the TLS connection                             | `true`, `false`                          | `false`                    |
+| `HOSAKA_TRIGGER_KAFKA_{trigger_name}_TOPIC`                   | :white_circle: | The name of the topic to publish                                 |                                          | `wud-container`            |
+| `HOSAKA_TRIGGER_KAFKA_{trigger_name}_AUTHENTICATION_TYPE`     | :white_circle: | The type for authentication                                      | `PLAIN`, `SCRAM-SHA-256`, `SCRAM-SHA-12` | `PLAIN`                    |
+| `HOSAKA_TRIGGER_KAFKA_{trigger_name}_AUTHENTICATION_USER`     | :white_circle: | The name of the user (required if authentication is enabled)     |                                          |                            |
+| `HOSAKA_TRIGGER_KAFKA_{trigger_name}_AUTHENTICATION_PASSWORD` | :white_circle: | The password of the user (required if authentication is enabled) |                                          |                            |
 
 !> The topic must already exist on the broker (the trigger won't automatically create it)
 
@@ -32,23 +32,23 @@ services:
     image: getwud/wud
     ...
     environment:
-        - WUD_TRIGGER_KAFKA_KARAKFA_BROKERS=ark-01.srvs.cloudkafka.com:9094,ark-02.srvs.cloudkafka.com:9094,ark-03.srvs.cloudkafka.com:9094
-        - WUD_TRIGGER_KAFKA_KARAKFA_SSL="true
-        - WUD_TRIGGER_KAFKA_KARAKFA_TOPIC=my-user-id-wud-image
-        - WUD_TRIGGER_KAFKA_KARAKFA_AUTHENTICATION_USER=my-user-id
-        - WUD_TRIGGER_KAFKA_KARAKFA_AUTHENTICATION_PASSWORD=my-secret
-        - WUD_TRIGGER_KAFKA_KARAKFA_AUTHENTICATION_TYPE=SCRAM-SHA-256
+        - HOSAKA_TRIGGER_KAFKA_KARAKFA_BROKERS=ark-01.srvs.cloudkafka.com:9094,ark-02.srvs.cloudkafka.com:9094,ark-03.srvs.cloudkafka.com:9094
+        - HOSAKA_TRIGGER_KAFKA_KARAKFA_SSL="true
+        - HOSAKA_TRIGGER_KAFKA_KARAKFA_TOPIC=my-user-id-wud-image
+        - HOSAKA_TRIGGER_KAFKA_KARAKFA_AUTHENTICATION_USER=my-user-id
+        - HOSAKA_TRIGGER_KAFKA_KARAKFA_AUTHENTICATION_PASSWORD=my-secret
+        - HOSAKA_TRIGGER_KAFKA_KARAKFA_AUTHENTICATION_TYPE=SCRAM-SHA-256
 ```
 
 #### **Docker**
 ```bash
 docker run \
-    -e WUD_TRIGGER_KAFKA_KARAKFA_BROKERS="ark-01.srvs.cloudkafka.com:9094,ark-02.srvs.cloudkafka.com:9094,ark-03.srvs.cloudkafka.com:9094" \
-    -e WUD_TRIGGER_KAFKA_KARAKFA_SSL="true" \
-    -e WUD_TRIGGER_KAFKA_KARAKFA_TOPIC="my-user-id-wud-image" \
-    -e WUD_TRIGGER_KAFKA_KARAKFA_AUTHENTICATION_USER="my-user-id" \
-    -e WUD_TRIGGER_KAFKA_KARAKFA_AUTHENTICATION_PASSWORD="my-secret" \
-    -e WUD_TRIGGER_KAFKA_KARAKFA_AUTHENTICATION_TYPE="SCRAM-SHA-256" \
+    -e HOSAKA_TRIGGER_KAFKA_KARAKFA_BROKERS="ark-01.srvs.cloudkafka.com:9094,ark-02.srvs.cloudkafka.com:9094,ark-03.srvs.cloudkafka.com:9094" \
+    -e HOSAKA_TRIGGER_KAFKA_KARAKFA_SSL="true" \
+    -e HOSAKA_TRIGGER_KAFKA_KARAKFA_TOPIC="my-user-id-wud-image" \
+    -e HOSAKA_TRIGGER_KAFKA_KARAKFA_AUTHENTICATION_USER="my-user-id" \
+    -e HOSAKA_TRIGGER_KAFKA_KARAKFA_AUTHENTICATION_PASSWORD="my-secret" \
+    -e HOSAKA_TRIGGER_KAFKA_KARAKFA_AUTHENTICATION_TYPE="SCRAM-SHA-256" \
   ...
   getwud/wud
 ```

--- a/docs/configuration/triggers/mqtt/README.md
+++ b/docs/configuration/triggers/mqtt/README.md
@@ -7,23 +7,23 @@ The `mqtt` trigger lets you send container update notifications to an MQTT broke
 
 | Env var                                                  | Required       | Description                                                                                         | Supported values                    | Default value when missing |
 |----------------------------------------------------------|:--------------:|-----------------------------------------------------------------------------------------------------|-------------------------------------|----------------------------| 
-| `WUD_TRIGGER_MQTT_{trigger_name}_URL`                    | :red_circle:   | The URL of the MQTT broker                                                                          | Valid mqtt, mqtts, tcp, ws, wss url |                            |
-| `WUD_TRIGGER_MQTT_{trigger_name}_USER`                   | :white_circle: | The username if broker authentication is enabled                                                    |                                     |                            |
-| `WUD_TRIGGER_MQTT_{trigger_name}_PASSWORD`               | :white_circle: | The password if broker authentication is enabled                                                    |                                     |                            |
-| `WUD_TRIGGER_MQTT_{trigger_name}_CLIENTID`               | :white_circle: | The Mqtt client Id to use                                                                           |                                     | `wud_$random`              |
-| `WUD_TRIGGER_MQTT_{trigger_name}_TOPIC`                  | :white_circle: | The base topic where the updates are published to                                                   |                                     | `wud/container`            |
-| `WUD_TRIGGER_MQTT_{trigger_name}_HASS_ENABLED`           | :white_circle: | Enable [Home-assistant](https://www.home-assistant.io/) integration and deliver additional topics   | `true`, `false`                     | `false`                    |
-| `WUD_TRIGGER_MQTT_{trigger_name}_HASS_DISCOVERY`         | :white_circle: | Enable [Home-assistant](https://www.home-assistant.io/) integration including discovery             | `true`, `false`                     | `false`                    |
-| `WUD_TRIGGER_MQTT_{trigger_name}_HASS_PREFIX`            | :white_circle: | Base topic for hass entity discovery                                                                |                                     | `homeassistant`            |
-| `WUD_TRIGGER_MQTT_{trigger_name}_TLS_CACHAIN`            | :white_circle: | The path to the file containing the server CA chain (when TLS with a private Certificate Authority) | Any valid file path                 |                            |
-| `WUD_TRIGGER_MQTT_{trigger_name}_TLS_CLIENTCERT`         | :white_circle: | The path to the file containing the client public certificate (when TLS mutual authzentication)     | Any valid file path                 |                            |
-| `WUD_TRIGGER_MQTT_{trigger_name}_TLS_CLIENTKEY`          | :white_circle: | The path to the file containing the client private key (when TLS mutual authzentication)            | Any valid file path                 |                            |
-| `WUD_TRIGGER_MQTT_{trigger_name}_TLS_REJECTUNAUTHORIZED` | :white_circle: | Accept or reject when the TLS server certificate cannot be trusted                                  | `true`, `false`                     | `true`                     |
+| `HOSAKA_TRIGGER_MQTT_{trigger_name}_URL`                    | :red_circle:   | The URL of the MQTT broker                                                                          | Valid mqtt, mqtts, tcp, ws, wss url |                            |
+| `HOSAKA_TRIGGER_MQTT_{trigger_name}_USER`                   | :white_circle: | The username if broker authentication is enabled                                                    |                                     |                            |
+| `HOSAKA_TRIGGER_MQTT_{trigger_name}_PASSWORD`               | :white_circle: | The password if broker authentication is enabled                                                    |                                     |                            |
+| `HOSAKA_TRIGGER_MQTT_{trigger_name}_CLIENTID`               | :white_circle: | The Mqtt client Id to use                                                                           |                                     | `wud_$random`              |
+| `HOSAKA_TRIGGER_MQTT_{trigger_name}_TOPIC`                  | :white_circle: | The base topic where the updates are published to                                                   |                                     | `wud/container`            |
+| `HOSAKA_TRIGGER_MQTT_{trigger_name}_HASS_ENABLED`           | :white_circle: | Enable [Home-assistant](https://www.home-assistant.io/) integration and deliver additional topics   | `true`, `false`                     | `false`                    |
+| `HOSAKA_TRIGGER_MQTT_{trigger_name}_HASS_DISCOVERY`         | :white_circle: | Enable [Home-assistant](https://www.home-assistant.io/) integration including discovery             | `true`, `false`                     | `false`                    |
+| `HOSAKA_TRIGGER_MQTT_{trigger_name}_HASS_PREFIX`            | :white_circle: | Base topic for hass entity discovery                                                                |                                     | `homeassistant`            |
+| `HOSAKA_TRIGGER_MQTT_{trigger_name}_TLS_CACHAIN`            | :white_circle: | The path to the file containing the server CA chain (when TLS with a private Certificate Authority) | Any valid file path                 |                            |
+| `HOSAKA_TRIGGER_MQTT_{trigger_name}_TLS_CLIENTCERT`         | :white_circle: | The path to the file containing the client public certificate (when TLS mutual authzentication)     | Any valid file path                 |                            |
+| `HOSAKA_TRIGGER_MQTT_{trigger_name}_TLS_CLIENTKEY`          | :white_circle: | The path to the file containing the client private key (when TLS mutual authzentication)            | Any valid file path                 |                            |
+| `HOSAKA_TRIGGER_MQTT_{trigger_name}_TLS_REJECTUNAUTHORIZED` | :white_circle: | Accept or reject when the TLS server certificate cannot be trusted                                  | `true`, `false`                     | `true`                     |
 
 ?> This trigger also supports the [common configuration variables](configuration/triggers/?id=common-trigger-configuration). but only supports the `simple` mode.
 
 ?> You want to customize the name & icon of the Home-Assistant entity? \
-[Use the `wud.display.name` and `wud.display.icon` labels](configuration/watchers/?id=labels).
+[Use the `hosaka.display.name` and `hosaka.display.icon` labels](configuration/watchers/?id=labels).
 
 ### Examples
 
@@ -39,13 +39,13 @@ services:
     image: getwud/wud
     ...
     environment:
-      - WUD_TRIGGER_MQTT_MOSQUITTO_URL=mqtt://localhost:1883
+      - HOSAKA_TRIGGER_MQTT_MOSQUITTO_URL=mqtt://localhost:1883
 ```
 
 #### **Docker**
 ```bash
 docker run \
-    -e WUD_TRIGGER_MQTT_MOSQUITTO_URL="mqtt://localhost:1883" \
+    -e HOSAKA_TRIGGER_MQTT_MOSQUITTO_URL="mqtt://localhost:1883" \
   ...
   getwud/wud
 ```
@@ -63,10 +63,10 @@ services:
     image: getwud/wud
     ...
     environment:
-      - WUD_TRIGGER_MQTT_MOSQUITTO_URL=mqtts://localhost:8883
-      - WUD_TRIGGER_MQTT_MOSQUITTO_TLS_CLIENTKEY=/wud/mqtt/client-key.pem
-      - WUD_TRIGGER_MQTT_MOSQUITTO_TLS_CLIENTCERT=/wud/mqtt/client-cert.pem
-      - WUD_TRIGGER_MQTT_MOSQUITTO_TLS_CACHAIN=/wud/mqtt/ca.pem
+      - HOSAKA_TRIGGER_MQTT_MOSQUITTO_URL=mqtts://localhost:8883
+      - HOSAKA_TRIGGER_MQTT_MOSQUITTO_TLS_CLIENTKEY=/wud/mqtt/client-key.pem
+      - HOSAKA_TRIGGER_MQTT_MOSQUITTO_TLS_CLIENTCERT=/wud/mqtt/client-cert.pem
+      - HOSAKA_TRIGGER_MQTT_MOSQUITTO_TLS_CACHAIN=/wud/mqtt/ca.pem
     volumes:
       - /mosquitto/tls/client/client-key.pem:/wud/mqtt/client-key.pem
       - /mosquitto/tls/client/client-cert.pem:/wud/mqtt/client-cert.pem
@@ -76,10 +76,10 @@ services:
 #### **Docker**
 ```bash
 docker run \
-    -e WUD_TRIGGER_MQTT_MOSQUITTO_URL="mqtts://localhost:8883" \
-    -e WUD_TRIGGER_MQTT_MOSQUITTO_TLS_CLIENTKEY="/wud/mqtt/client-key.pem" \
-    -e WUD_TRIGGER_MQTT_MOSQUITTO_TLS_CLIENTCERT="/wud/mqtt/client-cert.pem" \
-    -e WUD_TRIGGER_MQTT_MOSQUITTO_TLS_CACHAIN="/wud/mqtt/ca.pem" \
+    -e HOSAKA_TRIGGER_MQTT_MOSQUITTO_URL="mqtts://localhost:8883" \
+    -e HOSAKA_TRIGGER_MQTT_MOSQUITTO_TLS_CLIENTKEY="/wud/mqtt/client-key.pem" \
+    -e HOSAKA_TRIGGER_MQTT_MOSQUITTO_TLS_CLIENTCERT="/wud/mqtt/client-cert.pem" \
+    -e HOSAKA_TRIGGER_MQTT_MOSQUITTO_TLS_CACHAIN="/wud/mqtt/ca.pem" \
   ...
   getwud/wud
 ```
@@ -97,19 +97,19 @@ services:
     image: getwud/wud
     ...
     environment:
-      - WUD_TRIGGER_MQTT_MAQIATTO_URL=tcp://maqiatto.com:1883
-      - WUD_TRIGGER_MQTT_MAQIATTO_USER=john@doe.com
-      - WUD_TRIGGER_MQTT_MAQIATTO_PASSWORD=mysecretpassword
-      - WUD_TRIGGER_MQTT_MAQIATTO_TOPIC=john@doe.com/wud/image
+      - HOSAKA_TRIGGER_MQTT_MAQIATTO_URL=tcp://maqiatto.com:1883
+      - HOSAKA_TRIGGER_MQTT_MAQIATTO_USER=john@doe.com
+      - HOSAKA_TRIGGER_MQTT_MAQIATTO_PASSWORD=mysecretpassword
+      - HOSAKA_TRIGGER_MQTT_MAQIATTO_TOPIC=john@doe.com/wud/image
 ```
 
 #### **Docker**
 ```bash
 docker run \
-    -e WUD_TRIGGER_MQTT_MAQIATTO_URL="tcp://maqiatto.com:1883" \
-    -e WUD_TRIGGER_MQTT_MAQIATTO_USER="john@doe.com" \
-    -e WUD_TRIGGER_MQTT_MAQIATTO_PASSWORD="mysecretpassword" \
-    -e WUD_TRIGGER_MQTT_MAQIATTO_TOPIC="john@doe.com/wud/image" \
+    -e HOSAKA_TRIGGER_MQTT_MAQIATTO_URL="tcp://maqiatto.com:1883" \
+    -e HOSAKA_TRIGGER_MQTT_MAQIATTO_USER="john@doe.com" \
+    -e HOSAKA_TRIGGER_MQTT_MAQIATTO_PASSWORD="mysecretpassword" \
+    -e HOSAKA_TRIGGER_MQTT_MAQIATTO_TOPIC="john@doe.com/wud/image" \
   ...
   getwud/wud
 ```
@@ -152,17 +152,17 @@ services:
     image: getwud/wud
     ...
     environment:
-      - WUD_TRIGGER_MQTT_MOSQUITTO_URL=mqtt://localhost:1883
-      - WUD_TRIGGER_MQTT_MOSQUITTO_HASS_ENABLED=true
-      - WUD_TRIGGER_MQTT_MOSQUITTO_HASS_DISCOVERY=true
+      - HOSAKA_TRIGGER_MQTT_MOSQUITTO_URL=mqtt://localhost:1883
+      - HOSAKA_TRIGGER_MQTT_MOSQUITTO_HASS_ENABLED=true
+      - HOSAKA_TRIGGER_MQTT_MOSQUITTO_HASS_DISCOVERY=true
 ```
 
 #### **Docker**
 ```bash
 docker run \
-    -e WUD_TRIGGER_MQTT_MOSQUITTO_URL="mqtt://localhost:1883" \
-    -e WUD_TRIGGER_MQTT_MOSQUITTO_HASS_ENABLED="true" \
-    -e WUD_TRIGGER_MQTT_MOSQUITTO_HASS_DISCOVERY="true" \
+    -e HOSAKA_TRIGGER_MQTT_MOSQUITTO_URL="mqtt://localhost:1883" \
+    -e HOSAKA_TRIGGER_MQTT_MOSQUITTO_HASS_ENABLED="true" \
+    -e HOSAKA_TRIGGER_MQTT_MOSQUITTO_HASS_DISCOVERY="true" \
   ...
   getwud/wud
 ```

--- a/docs/configuration/triggers/pushover/README.md
+++ b/docs/configuration/triggers/pushover/README.md
@@ -7,14 +7,14 @@ The `pushover` trigger lets you send realtime notifications to your devices (And
 
 | Env var                                        | Required       | Description                                                          | Supported values                                                                                   | Default value when missing  |
 |------------------------------------------------|:--------------:|----------------------------------------------------------------------| -------------------------------------------------------------------------------------------------- |-----------------------------| 
-| `WUD_TRIGGER_PUSHOVER_{trigger_name}_TOKEN`    | :red_circle:   | The API token                                                        |                                                                                                    |                             |
-| `WUD_TRIGGER_PUSHOVER_{trigger_name}_USER`     | :red_circle:   | The User key                                                         |                                                                                                    |                             |
-| `WUD_TRIGGER_PUSHOVER_{trigger_name}_DEVICE`   | :white_circle: | The Device(s) to notify                                              | Coma separated list of devices (e.g. dev1,dev2) ([see here](https://pushover.net/api#identifiers)) |                             |
-| `WUD_TRIGGER_PUSHOVER_{trigger_name}_SOUND`    | :white_circle: | The notification sound                                               | [see here](https://pushover.net/api#sounds)                                                        | `pushover`                  |
-| `WUD_TRIGGER_PUSHOVER_{trigger_name}_PRIORITY` | :white_circle: | The notification priority                                            | [see here](https://pushover.net/api#priority)                                                      | `0`                         |
-| `WUD_TRIGGER_PUSHOVER_{trigger_name}_EXPIRE`   | :white_circle: | The notification expire in seconds (only when priority=2)            | [see here](https://pushover.net/api#priority)                                                      |                             |
-| `WUD_TRIGGER_PUSHOVER_{trigger_name}_RETRY`    | :white_circle: | The notification retry in seconds (only when priority=2)             | [see here](https://pushover.net/api#priority)                                                      |                             |
-| `WUD_TRIGGER_PUSHOVER_{trigger_name}_HTML`     | :white_circle: | Allow HTML formatting in message body (supported in Pushover 2.3+)   | [see here](https://pushover.net/api#html)                                                          | `0`                         |
+| `HOSAKA_TRIGGER_PUSHOVER_{trigger_name}_TOKEN`    | :red_circle:   | The API token                                                        |                                                                                                    |                             |
+| `HOSAKA_TRIGGER_PUSHOVER_{trigger_name}_USER`     | :red_circle:   | The User key                                                         |                                                                                                    |                             |
+| `HOSAKA_TRIGGER_PUSHOVER_{trigger_name}_DEVICE`   | :white_circle: | The Device(s) to notify                                              | Coma separated list of devices (e.g. dev1,dev2) ([see here](https://pushover.net/api#identifiers)) |                             |
+| `HOSAKA_TRIGGER_PUSHOVER_{trigger_name}_SOUND`    | :white_circle: | The notification sound                                               | [see here](https://pushover.net/api#sounds)                                                        | `pushover`                  |
+| `HOSAKA_TRIGGER_PUSHOVER_{trigger_name}_PRIORITY` | :white_circle: | The notification priority                                            | [see here](https://pushover.net/api#priority)                                                      | `0`                         |
+| `HOSAKA_TRIGGER_PUSHOVER_{trigger_name}_EXPIRE`   | :white_circle: | The notification expire in seconds (only when priority=2)            | [see here](https://pushover.net/api#priority)                                                      |                             |
+| `HOSAKA_TRIGGER_PUSHOVER_{trigger_name}_RETRY`    | :white_circle: | The notification retry in seconds (only when priority=2)             | [see here](https://pushover.net/api#priority)                                                      |                             |
+| `HOSAKA_TRIGGER_PUSHOVER_{trigger_name}_HTML`     | :white_circle: | Allow HTML formatting in message body (supported in Pushover 2.3+)   | [see here](https://pushover.net/api#html)                                                          | `0`                         |
 
 
 ?> This trigger also supports the [common configuration variables](configuration/triggers/?id=common-trigger-configuration).
@@ -33,15 +33,15 @@ services:
     image: getwud/wud
     ...
     environment:
-      - WUD_TRIGGER_PUSHOVER_1_TOKEN=*****************************
-      - WUD_TRIGGER_PUSHOVER_1_USER=******************************
+      - HOSAKA_TRIGGER_PUSHOVER_1_TOKEN=*****************************
+      - HOSAKA_TRIGGER_PUSHOVER_1_USER=******************************
 ```
 
 #### **Docker**
 ```bash
 docker run \
-  -e WUD_TRIGGER_PUSHOVER_1_TOKEN="*****************************" \
-  -e WUD_TRIGGER_PUSHOVER_1_USER="******************************" \
+  -e HOSAKA_TRIGGER_PUSHOVER_1_TOKEN="*****************************" \
+  -e HOSAKA_TRIGGER_PUSHOVER_1_USER="******************************" \
   ...
   getwud/wud
 ```
@@ -58,21 +58,21 @@ services:
     image: getwud/wud
     ...
     environment:
-        - WUD_TRIGGER_PUSHOVER_1_TOKEN=*****************************
-        - WUD_TRIGGER_PUSHOVER_1_USER=******************************
-        - WUD_TRIGGER_PUSHOVER_1_DEVICE=myIphone,mySamsung
-        - WUD_TRIGGER_PUSHOVER_1_SOUND=cosmic
-        - WUD_TRIGGER_PUSHOVER_1_PRIORITY=2
+        - HOSAKA_TRIGGER_PUSHOVER_1_TOKEN=*****************************
+        - HOSAKA_TRIGGER_PUSHOVER_1_USER=******************************
+        - HOSAKA_TRIGGER_PUSHOVER_1_DEVICE=myIphone,mySamsung
+        - HOSAKA_TRIGGER_PUSHOVER_1_SOUND=cosmic
+        - HOSAKA_TRIGGER_PUSHOVER_1_PRIORITY=2
 ```
 
 #### **Docker**
 ```bash
 docker run \
-    -e WUD_TRIGGER_PUSHOVER_1_TOKEN="*****************************" \
-    -e WUD_TRIGGER_PUSHOVER_1_USER="******************************" \
-    -e WUD_TRIGGER_PUSHOVER_1_DEVICE="myIphone,mySamsung" \
-    -e WUD_TRIGGER_PUSHOVER_1_SOUND="cosmic" \
-    -e WUD_TRIGGER_PUSHOVER_1_PRIORITY="2" \
+    -e HOSAKA_TRIGGER_PUSHOVER_1_TOKEN="*****************************" \
+    -e HOSAKA_TRIGGER_PUSHOVER_1_USER="******************************" \
+    -e HOSAKA_TRIGGER_PUSHOVER_1_DEVICE="myIphone,mySamsung" \
+    -e HOSAKA_TRIGGER_PUSHOVER_1_SOUND="cosmic" \
+    -e HOSAKA_TRIGGER_PUSHOVER_1_PRIORITY="2" \
   ...
   getwud/wud
 ```

--- a/docs/configuration/triggers/slack/README.md
+++ b/docs/configuration/triggers/slack/README.md
@@ -7,8 +7,8 @@ The `slack` trigger lets you post image update notifications to a Slack channel.
 
 | Env var                                    | Required     | Description                      | Supported values | Default value when missing |
 | ------------------------------------------ |:------------:| -------------------------------- | ---------------- | -------------------------- | 
-| `WUD_TRIGGER_SLACK_{trigger_name}_TOKEN`   | :red_circle: | The Oauth Token of the Slack app |                  |                            |
-| `WUD_TRIGGER_SLACK_{trigger_name}_CHANNEL` | :red_circle: | The name of the channel to post  |                  |                            |
+| `HOSAKA_TRIGGER_SLACK_{trigger_name}_TOKEN`   | :red_circle: | The Oauth Token of the Slack app |                  |                            |
+| `HOSAKA_TRIGGER_SLACK_{trigger_name}_CHANNEL` | :red_circle: | The name of the channel to post  |                  |                            |
 
 !> The Slack channel must already exist on the workspace (the trigger won't automatically create it)
 
@@ -26,15 +26,15 @@ services:
     image: getwud/wud
     ...
     environment:
-        - WUD_TRIGGER_SLACK_TEST_TOKEN=xoxp-743817063446-xxx
-        - WUD_TRIGGER_SLACK_TEST_CHANNEL=wud
+        - HOSAKA_TRIGGER_SLACK_TEST_TOKEN=xoxp-743817063446-xxx
+        - HOSAKA_TRIGGER_SLACK_TEST_CHANNEL=wud
 ```
 
 #### **Docker**
 ```bash
 docker run \
-    -e WUD_TRIGGER_SLACK_TEST_TOKEN="xoxp-743817063446-xxx" \
-    -e WUD_TRIGGER_SLACK_TEST_CHANNEL="wud" \
+    -e HOSAKA_TRIGGER_SLACK_TEST_TOKEN="xoxp-743817063446-xxx" \
+    -e HOSAKA_TRIGGER_SLACK_TEST_CHANNEL="wud" \
   ...
   getwud/wud
 ```

--- a/docs/configuration/triggers/smtp/README.md
+++ b/docs/configuration/triggers/smtp/README.md
@@ -6,14 +6,14 @@ The `smtp` trigger lets you send emails with smtp.
 
 | Env var                                       | Required       | Description                   | Supported values              | Default value when missing |
 | --------------------------------------------- |:--------------:|:----------------------------- | ----------------------------- | -------------------------- | 
-| `WUD_TRIGGER_SMTP_{trigger_name}_HOST`        | :red_circle:   | Smtp server host              | Valid hostname or IP address  |                            |
-| `WUD_TRIGGER_SMTP_{trigger_name}_PORT`        | :red_circle:   | Smtp server port              | Valid smtp port               |                            |
-| `WUD_TRIGGER_SMTP_{trigger_name}_FROM`        | :red_circle:   | Email from address            | Valid email address           |                            |
-| `WUD_TRIGGER_SMTP_{trigger_name}_TO`          | :red_circle:   | Email to address              | Valid email address           |                            |
-| `WUD_TRIGGER_SMTP_{trigger_name}_USER`        | :white_circle: | Smtp user                     |                               |                            |
-| `WUD_TRIGGER_SMTP_{trigger_name}_PASS`        | :white_circle: | Smtp password                 |                               |                            |
-| `WUD_TRIGGER_SMTP_{trigger_name}_TLS_ENABLED` | :white_circle: | Use TLS                       | `true`, `false`               | `false`                    |
-| `WUD_TRIGGER_SMTP_{trigger_name}_TLS_VERIFY`  | :white_circle: | Verify server TLS certificate | `true`, `false`               | `true`                     |
+| `HOSAKA_TRIGGER_SMTP_{trigger_name}_HOST`        | :red_circle:   | Smtp server host              | Valid hostname or IP address  |                            |
+| `HOSAKA_TRIGGER_SMTP_{trigger_name}_PORT`        | :red_circle:   | Smtp server port              | Valid smtp port               |                            |
+| `HOSAKA_TRIGGER_SMTP_{trigger_name}_FROM`        | :red_circle:   | Email from address            | Valid email address           |                            |
+| `HOSAKA_TRIGGER_SMTP_{trigger_name}_TO`          | :red_circle:   | Email to address              | Valid email address           |                            |
+| `HOSAKA_TRIGGER_SMTP_{trigger_name}_USER`        | :white_circle: | Smtp user                     |                               |                            |
+| `HOSAKA_TRIGGER_SMTP_{trigger_name}_PASS`        | :white_circle: | Smtp password                 |                               |                            |
+| `HOSAKA_TRIGGER_SMTP_{trigger_name}_TLS_ENABLED` | :white_circle: | Use TLS                       | `true`, `false`               | `false`                    |
+| `HOSAKA_TRIGGER_SMTP_{trigger_name}_TLS_VERIFY`  | :white_circle: | Verify server TLS certificate | `true`, `false`               | `true`                     |
 
 ?> This trigger also supports the [common configuration variables](configuration/triggers/?id=common-trigger-configuration).
 
@@ -31,25 +31,25 @@ services:
     image: getwud/wud
     ...
     environment:
-        - WUD_TRIGGER_SMTP_GMAIL_HOST=smtp.gmail.com
-        - WUD_TRIGGER_SMTP_GMAIL_PORT=465
-        - WUD_TRIGGER_SMTP_GMAIL_USER=john.doe@gmail.com
-        - WUD_TRIGGER_SMTP_GMAIL_PASS=mysecretpass
-        - WUD_TRIGGER_SMTP_GMAIL_FROM=john.doe@gmail.com
-        - WUD_TRIGGER_SMTP_GMAIL_TO=jane.doe@gmail.com
-        - WUD_TRIGGER_SMTP_GMAIL_TLS_ENABLED=true 
+        - HOSAKA_TRIGGER_SMTP_GMAIL_HOST=smtp.gmail.com
+        - HOSAKA_TRIGGER_SMTP_GMAIL_PORT=465
+        - HOSAKA_TRIGGER_SMTP_GMAIL_USER=john.doe@gmail.com
+        - HOSAKA_TRIGGER_SMTP_GMAIL_PASS=mysecretpass
+        - HOSAKA_TRIGGER_SMTP_GMAIL_FROM=john.doe@gmail.com
+        - HOSAKA_TRIGGER_SMTP_GMAIL_TO=jane.doe@gmail.com
+        - HOSAKA_TRIGGER_SMTP_GMAIL_TLS_ENABLED=true 
 ```
 
 #### **Docker**
 ```bash
 docker run \
-    -e WUD_TRIGGER_SMTP_GMAIL_HOST="smtp.gmail.com" \
-    -e WUD_TRIGGER_SMTP_GMAIL_PORT="465" \
-    -e WUD_TRIGGER_SMTP_GMAIL_USER="john.doe@gmail.com" \
-    -e WUD_TRIGGER_SMTP_GMAIL_PASS="mysecretpass" \
-    -e WUD_TRIGGER_SMTP_GMAIL_FROM="john.doe@gmail.com" \
-    -e WUD_TRIGGER_SMTP_GMAIL_TO="jane.doe@gmail.com" \
-    -e WUD_TRIGGER_SMTP_GMAIL_TLS_ENABLED="true" \
+    -e HOSAKA_TRIGGER_SMTP_GMAIL_HOST="smtp.gmail.com" \
+    -e HOSAKA_TRIGGER_SMTP_GMAIL_PORT="465" \
+    -e HOSAKA_TRIGGER_SMTP_GMAIL_USER="john.doe@gmail.com" \
+    -e HOSAKA_TRIGGER_SMTP_GMAIL_PASS="mysecretpass" \
+    -e HOSAKA_TRIGGER_SMTP_GMAIL_FROM="john.doe@gmail.com" \
+    -e HOSAKA_TRIGGER_SMTP_GMAIL_TO="jane.doe@gmail.com" \
+    -e HOSAKA_TRIGGER_SMTP_GMAIL_TLS_ENABLED="true" \
   ...
   getwud/wud
 ```

--- a/docs/configuration/triggers/telegram/README.md
+++ b/docs/configuration/triggers/telegram/README.md
@@ -7,8 +7,8 @@ The `telegram` trigger lets you send realtime notifications using [Telegram](htt
 
 | Env var                                        | Required       | Description   | Supported values                                                                                   | Default value when missing  |
 |------------------------------------------------|:--------------:|---------------| -------------------------------------------------------------------------------------------------- |-----------------------------| 
-| `WUD_TRIGGER_TELEGRAM_{trigger_name}_BOTTOKEN` | :red_circle:   | The Bot token |                                                                                                    |                             |
-| `WUD_TRIGGER_TELEGRAM_{trigger_name}_CHATID`   | :red_circle:   | The Chat ID   |                                                                                                    |                             |
+| `HOSAKA_TRIGGER_TELEGRAM_{trigger_name}_BOTTOKEN` | :red_circle:   | The Bot token |                                                                                                    |                             |
+| `HOSAKA_TRIGGER_TELEGRAM_{trigger_name}_CHATID`   | :red_circle:   | The Chat ID   |                                                                                                    |                             |
 
 ?> This trigger also supports the [common configuration variables](configuration/triggers/?id=common-trigger-configuration).
 
@@ -25,15 +25,15 @@ services:
     image: getwud/wud
     ...
     environment:
-      - WUD_TRIGGER_TELEGRAM_1_BOTTOKEN=your-telegram-bot-token
-      - WUD_TRIGGER_TELEGRAM_1_CHATID=9876543210
+      - HOSAKA_TRIGGER_TELEGRAM_1_BOTTOKEN=your-telegram-bot-token
+      - HOSAKA_TRIGGER_TELEGRAM_1_CHATID=9876543210
 ```
 
 #### **Docker**
 ```bash
 docker run \
-  -e WUD_TRIGGER_TELEGRAM_1_BOTTOKEN="your-telegram-bot-token" \
-  -e WUD_TRIGGER_TELEGRAM_1_CHATID="9876543210" \
+  -e HOSAKA_TRIGGER_TELEGRAM_1_BOTTOKEN="your-telegram-bot-token" \
+  -e HOSAKA_TRIGGER_TELEGRAM_1_CHATID="9876543210" \
   ...
   getwud/wud
 ```

--- a/docs/configuration/watchers/README.md
+++ b/docs/configuration/watchers/README.md
@@ -9,18 +9,18 @@ The ```docker``` watcher lets you configure the Docker hosts you want to watch.
 
 | Env var                                                   | Required       | Description                                                     | Supported values                               | Default value when missing                                      |
 | --------------------------------------------------------- |:--------------:| --------------------------------------------------------------- | ---------------------------------------------- | --------------------------------------------------------------- | 
-| `WUD_WATCHER_{watcher_name}_SOCKET`                       | :white_circle: | Docker socket to watch                                          | Valid unix socket                              | `/var/run/docker.sock`                                          |
-| `WUD_WATCHER_{watcher_name}_HOST`                         | :white_circle: | Docker hostname or ip of the host to watch                      |                                                |                                                                 |
-| `WUD_WATCHER_{watcher_name}_PORT`                         | :white_circle: | Docker port of the host to watch                                |                                                | `2375`                                                          |
-| `WUD_WATCHER_{watcher_name}_CAFILE`                       | :white_circle: | CA pem file path (only for TLS connection)                      |                                                |                                                                 |
-| `WUD_WATCHER_{watcher_name}_CERTFILE`                     | :white_circle: | Certificate pem file path (only for TLS connection)             |                                                |                                                                 |
-| `WUD_WATCHER_{watcher_name}_KEYFILE`                      | :white_circle: | Key pem file path (only for TLS connection)                     |                                                |                                                                 |
-| `WUD_WATCHER_{watcher_name}_CRON`                         | :white_circle: | Scheduling options                                              | [Valid CRON expression](https://crontab.guru/) | `0 * * * *` (every hour)                                        |
-| `WUD_WATCHER_{watcher_name}_WATCHBYDEFAULT`               | :white_circle: | If WUD must monitor all containers by default                   | `true`, `false`                                | `true`                                                          |
-| `WUD_WATCHER_{watcher_name}_WATCHALL`                     | :white_circle: | If WUD must monitor all containers instead of just running ones | `true`, `false`                                | `false`                                                         |
-| `WUD_WATCHER_{watcher_name}_WATCHEVENTS`                  | :white_circle: | If WUD must monitor docker events                               | `true`, `false`                                | `true`                                                          |
-| `WUD_WATCHER_{watcher_name}_WATCHATSTART`                 | :white_circle: | If WUD must check for image updates during startup              | `true`, `false`                                | `true`                                                          |
-| ~~`WUD_WATCHER_{watcher_name}_WATCHDIGEST`~~ (deprecated) | :white_circle: | If WUD must monitor container digests                           |                                                | `false` for semver image tags, `true` for non semver image tags |
+| `HOSAKA_WATCHER_{watcher_name}_SOCKET`                       | :white_circle: | Docker socket to watch                                          | Valid unix socket                              | `/var/run/docker.sock`                                          |
+| `HOSAKA_WATCHER_{watcher_name}_HOST`                         | :white_circle: | Docker hostname or ip of the host to watch                      |                                                |                                                                 |
+| `HOSAKA_WATCHER_{watcher_name}_PORT`                         | :white_circle: | Docker port of the host to watch                                |                                                | `2375`                                                          |
+| `HOSAKA_WATCHER_{watcher_name}_CAFILE`                       | :white_circle: | CA pem file path (only for TLS connection)                      |                                                |                                                                 |
+| `HOSAKA_WATCHER_{watcher_name}_CERTFILE`                     | :white_circle: | Certificate pem file path (only for TLS connection)             |                                                |                                                                 |
+| `HOSAKA_WATCHER_{watcher_name}_KEYFILE`                      | :white_circle: | Key pem file path (only for TLS connection)                     |                                                |                                                                 |
+| `HOSAKA_WATCHER_{watcher_name}_CRON`                         | :white_circle: | Scheduling options                                              | [Valid CRON expression](https://crontab.guru/) | `0 * * * *` (every hour)                                        |
+| `HOSAKA_WATCHER_{watcher_name}_WATCHBYDEFAULT`               | :white_circle: | If WUD must monitor all containers by default                   | `true`, `false`                                | `true`                                                          |
+| `HOSAKA_WATCHER_{watcher_name}_WATCHALL`                     | :white_circle: | If WUD must monitor all containers instead of just running ones | `true`, `false`                                | `false`                                                         |
+| `HOSAKA_WATCHER_{watcher_name}_WATCHEVENTS`                  | :white_circle: | If WUD must monitor docker events                               | `true`, `false`                                | `true`                                                          |
+| `HOSAKA_WATCHER_{watcher_name}_WATCHATSTART`                 | :white_circle: | If WUD must check for image updates during startup              | `true`, `false`                                | `true`                                                          |
+| ~~`HOSAKA_WATCHER_{watcher_name}_WATCHDIGEST`~~ (deprecated) | :white_circle: | If WUD must monitor container digests                           |                                                | `false` for semver image tags, `true` for non semver image tags |
 
 ?> If no watcher is configured, a default one named `local` will be automatically created (reading the Docker socket).
 
@@ -39,8 +39,8 @@ You just need to give them different names.
 
 !> Watching image digests causes an extensive usage of _Docker Registry Pull API_ which is restricted by [**Quotas on the Docker Hub**](https://docs.docker.com/docker-hub/download-rate-limit/). \
 By default, WUD enables it only for **non semver** image tags. \
-You can tune this behavior per container using the `wud.watch.digest` label. \
-If you face [quota related errors](https://docs.docker.com/docker-hub/download-rate-limit/#how-do-i-know-my-pull-requests-are-being-limited), consider slowing down the watcher rate by adjusting the `WUD_WATCHER_{watcher_name}_CRON` variable.
+You can tune this behavior per container using the `hosaka.watch.digest` label. \
+If you face [quota related errors](https://docs.docker.com/docker-hub/download-rate-limit/#how-do-i-know-my-pull-requests-are-being-limited), consider slowing down the watcher rate by adjusting the `HOSAKA_WATCHER_{watcher_name}_CRON` variable.
 
 ## Variable examples
 
@@ -56,13 +56,13 @@ services:
     image: getwud/wud
     ...
     environment:
-        - WUD_WATCHER_LOCAL_CRON=0 1 * * *
+        - HOSAKA_WATCHER_LOCAL_CRON=0 1 * * *
 ```
 
 #### **Docker**
 ```bash
 docker run \
-    -e WUD_WATCHER_LOCAL_CRON="0 1 * * *" \
+    -e HOSAKA_WATCHER_LOCAL_CRON="0 1 * * *" \
   ...
   getwud/wud
 ```
@@ -80,13 +80,13 @@ services:
     image: getwud/wud
     ...
     environment:
-        - WUD_WATCHER_LOCAL_WATCHALL=true
+        - HOSAKA_WATCHER_LOCAL_WATCHALL=true
 ```
 
 #### **Docker**
 ```bash
 docker run \
-    -e WUD_WATCHER_LOCAL_WATCHALL="true" \
+    -e HOSAKA_WATCHER_LOCAL_WATCHALL="true" \
   ...
   getwud/wud
 ```
@@ -104,13 +104,13 @@ services:
     image: getwud/wud
     ...
     environment:
-        - WUD_WATCHER_MYREMOTEHOST_HOST=myremotehost 
+        - HOSAKA_WATCHER_MYREMOTEHOST_HOST=myremotehost 
 ```
 
 #### **Docker**
 ```bash
 docker run \
-    -e WUD_WATCHER_MYREMOTEHOST_HOST="myremotehost" \
+    -e HOSAKA_WATCHER_MYREMOTEHOST_HOST="myremotehost" \
   ...
   getwud/wud
 ```
@@ -128,11 +128,11 @@ services:
     image: getwud/wud
     ...
     environment:
-        - WUD_WATCHER_MYREMOTEHOST_HOST=myremotehost
-        - WUD_WATCHER_MYREMOTEHOST_PORT=2376
-        - WUD_WATCHER_MYREMOTEHOST_CAFILE=/certs/ca.pem
-        - WUD_WATCHER_MYREMOTEHOST_CERTFILE=/certs/cert.pem
-        - WUD_WATCHER_MYREMOTEHOST_KEYFILE=/certs/key.pem
+        - HOSAKA_WATCHER_MYREMOTEHOST_HOST=myremotehost
+        - HOSAKA_WATCHER_MYREMOTEHOST_PORT=2376
+        - HOSAKA_WATCHER_MYREMOTEHOST_CAFILE=/certs/ca.pem
+        - HOSAKA_WATCHER_MYREMOTEHOST_CERTFILE=/certs/cert.pem
+        - HOSAKA_WATCHER_MYREMOTEHOST_KEYFILE=/certs/key.pem
     volumes:
         - /my-host/my-certs/ca.pem:/certs/ca.pem:ro
         - /my-host/my-certs/ca.pem:/certs/cert.pem:ro
@@ -142,11 +142,11 @@ services:
 #### **Docker**
 ```bash
 docker run \
-    -e WUD_WATCHER_MYREMOTEHOST_HOST="myremotehost" \
-    -e WUD_WATCHER_MYREMOTEHOST_PORT="2376" \
-    -e WUD_WATCHER_MYREMOTEHOST_CAFILE="/certs/ca.pem" \
-    -e WUD_WATCHER_MYREMOTEHOST_CERTFILE="/certs/cert.pem" \
-    -e WUD_WATCHER_MYREMOTEHOST_KEYFILE="/certs/key.pem" \
+    -e HOSAKA_WATCHER_MYREMOTEHOST_HOST="myremotehost" \
+    -e HOSAKA_WATCHER_MYREMOTEHOST_PORT="2376" \
+    -e HOSAKA_WATCHER_MYREMOTEHOST_CAFILE="/certs/ca.pem" \
+    -e HOSAKA_WATCHER_MYREMOTEHOST_CERTFILE="/certs/cert.pem" \
+    -e HOSAKA_WATCHER_MYREMOTEHOST_KEYFILE="/certs/key.pem" \
     -v /my-host/my-certs/ca.pem:/certs/ca.pem:ro \
     -v /my-host/my-certs/ca.pem:/certs/cert.pem:ro \
     -v /my-host/my-certs/ca.pem:/certs/key.pem:ro \
@@ -169,17 +169,17 @@ services:
     image: getwud/wud
     ...
     environment:
-        -  WUD_WATCHER_LOCAL_SOCKET=/var/run/docker.sock
-        -  WUD_WATCHER_MYREMOTEHOST1_HOST=myremotehost1
-        -  WUD_WATCHER_MYREMOTEHOST2_HOST=myremotehost2
+        -  HOSAKA_WATCHER_LOCAL_SOCKET=/var/run/docker.sock
+        -  HOSAKA_WATCHER_MYREMOTEHOST1_HOST=myremotehost1
+        -  HOSAKA_WATCHER_MYREMOTEHOST2_HOST=myremotehost2
 ```
 
 #### **Docker**
 ```bash
 docker run \
-    -e  WUD_WATCHER_LOCAL_SOCKET="/var/run/docker.sock" \
-    -e  WUD_WATCHER_MYREMOTEHOST1_HOST="myremotehost1" \
-    -e  WUD_WATCHER_MYREMOTEHOST2_HOST="myremotehost2" \
+    -e  HOSAKA_WATCHER_LOCAL_SOCKET="/var/run/docker.sock" \
+    -e  HOSAKA_WATCHER_MYREMOTEHOST1_HOST="myremotehost1" \
+    -e  HOSAKA_WATCHER_MYREMOTEHOST2_HOST="myremotehost2" \
   ...
   getwud/wud
 ```
@@ -191,14 +191,14 @@ To fine-tune the behaviour of WUD _per container_, you can add labels on them.
 
 | Label               |    Required    | Description                                        | Supported values                                                                                                                                                            | Default value when missing                                                            |
 |---------------------|:--------------:|----------------------------------------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------------------------------------------------------------------------------------|
-| `wud.watch`         | :white_circle: | Watch this container                               | Valid Boolean                                                                                                                                                               | `true` when `WUD_WATCHER_{watcher_name}_WATCHBYDEFAULT` is `true` (`false` otherwise) |
-| `wud.watch.digest`  | :white_circle: | Watch this container digest                        | Valid Boolean                                                                                                                                                               | `false`                                                                               |
-| `wud.tag.include`   | :white_circle: | Regex to include specific tags only                | Valid JavaScript Regex                                                                                                                                                      |                                                                                       |
-| `wud.tag.exclude`   | :white_circle: | Regex to exclude specific tags                     | Valid JavaScript Regex                                                                                                                                                      |                                                                                       |
-| `wud.tag.transform` | :white_circle: | Transform function to apply to the tag             | `$valid_regex => $valid_string_with_placeholders` (see below)                                                                                                               |                                                                                       |
-| `wud.link.template` | :white_circle: | Browsable link associated to the container version | String template with placeholders `${raw}` `${major}` `${minor}` `${patch}` `${prerelease}`                                                                                 |                                                                                       |
-| `wud.display.name`  | :white_circle: | Custom display name for the container              | Valid String                                                                                                                                                                | Container name                                                                        |
-| `wud.display.icon`  | :white_circle: | Custom display icon for the container              | Valid [Material Design Icon](https://materialdesignicons.com/), [Fontawesome Icon](https://fontawesome.com/) or [Simple icon](https://simpleicons.org/) (see details below) | `mdi:docker`                                                                          |
+| `hosaka.watch`         | :white_circle: | Watch this container                               | Valid Boolean                                                                                                                                                               | `true` when `HOSAKA_WATCHER_{watcher_name}_WATCHBYDEFAULT` is `true` (`false` otherwise) |
+| `hosaka.watch.digest`  | :white_circle: | Watch this container digest                        | Valid Boolean                                                                                                                                                               | `false`                                                                               |
+| `hosaka.tag.include`   | :white_circle: | Regex to include specific tags only                | Valid JavaScript Regex                                                                                                                                                      |                                                                                       |
+| `hosaka.tag.exclude`   | :white_circle: | Regex to exclude specific tags                     | Valid JavaScript Regex                                                                                                                                                      |                                                                                       |
+| `hosaka.tag.transform` | :white_circle: | Transform function to apply to the tag             | `$valid_regex => $valid_string_with_placeholders` (see below)                                                                                                               |                                                                                       |
+| `hosaka.link.template` | :white_circle: | Browsable link associated to the container version | String template with placeholders `${raw}` `${major}` `${minor}` `${patch}` `${prerelease}`                                                                                 |                                                                                       |
+| `hosaka.display.name`  | :white_circle: | Custom display name for the container              | Valid String                                                                                                                                                                | Container name                                                                        |
+| `hosaka.display.icon`  | :white_circle: | Custom display icon for the container              | Valid [Material Design Icon](https://materialdesignicons.com/), [Fontawesome Icon](https://fontawesome.com/) or [Simple icon](https://simpleicons.org/) (see details below) | `mdi:docker`                                                                          |
 
 ## Label examples
 
@@ -214,19 +214,19 @@ services:
     image: getwud/wud
     ...
     environment:
-      - WUD_WATCHER_LOCAL_WATCHBYDEFAULT=false
+      - HOSAKA_WATCHER_LOCAL_WATCHBYDEFAULT=false
 ```
 
 #### **Docker**
 ```bash
 docker run \
-    -e WUD_WATCHER_LOCAL_WATCHBYDEFAULT="false" \
+    -e HOSAKA_WATCHER_LOCAL_WATCHBYDEFAULT="false" \
   ...
   getwud/wud
 ```
 <!-- tabs:end -->
 
-Then add the `wud.watch=true` label on the containers you want to watch.
+Then add the `hosaka.watch=true` label on the containers you want to watch.
 <!-- tabs:start -->
 #### **Docker Compose**
 ```yaml
@@ -237,19 +237,19 @@ services:
     image: mariadb:10.4.5
     ...
     labels:
-      - wud.watch=true
+      - hosaka.watch=true
 ```
 
 #### **Docker**
 ```bash
-docker run -d --name mariadb --label wud.watch=true mariadb:10.4.5
+docker run -d --name mariadb --label hosaka.watch=true mariadb:10.4.5
 ```
 <!-- tabs:end -->
 
 ### Exclude specific containers to watch
-Ensure `WUD_WATCHER_{watcher_name}_WATCHBYDEFAULT` is true (default value).
+Ensure `HOSAKA_WATCHER_{watcher_name}_WATCHBYDEFAULT` is true (default value).
 
-Then add the `wud.watch=false` label on the containers you want to exclude from being watched.
+Then add the `hosaka.watch=false` label on the containers you want to exclude from being watched.
 <!-- tabs:start -->
 #### **Docker Compose**
 ```yaml
@@ -260,12 +260,12 @@ services:
     image: mariadb:10.4.5
     ...
     labels:
-      - wud.watch=false
+      - hosaka.watch=false
 ```
 
 #### **Docker**
 ```bash
-docker run -d --name mariadb --label wud.watch=false mariadb:10.4.5
+docker run -d --name mariadb --label hosaka.watch=false mariadb:10.4.5
 ```
 <!-- tabs:end -->
 
@@ -283,12 +283,12 @@ services:
   mariadb:
     image: mariadb:10.4.5
     labels:
-      - wud.tag.include=^\d+\.\d+\.\d+$$
+      - hosaka.tag.include=^\d+\.\d+\.\d+$$
 ```
 
 #### **Docker**
 ```bash
-docker run -d --name mariadb --label 'wud.tag.include=^\d+\.\d+\.\d+$' mariadb:10.4.5
+docker run -d --name mariadb --label 'hosaka.tag.include=^\d+\.\d+\.\d+$' mariadb:10.4.5
 ```
 <!-- tabs:end -->
 
@@ -327,15 +327,15 @@ services:
   searx:
     image: searx/searx:1.0.0-269-7b368146
     labels:
-      - wud.tag.include=^\d+\.\d+\.\d+-\d+-.*$$
-      - wud.tag.transform=^(\d+\.\d+\.\d+-\d+)-.*$$ => $$1
+      - hosaka.tag.include=^\d+\.\d+\.\d+-\d+-.*$$
+      - hosaka.tag.transform=^(\d+\.\d+\.\d+-\d+)-.*$$ => $$1
 ```
 
 #### **Docker**
 ```bash
 docker run -d --name searx \
---label 'wud.tag.include=^\d+\.\d+\.\d+-\d+-.*$' \
---label 'wud.tag.transform=^(\d+\.\d+\.\d+-\d+)-.*$ => $1' \
+--label 'hosaka.tag.include=^\d+\.\d+\.\d+-\d+-.*$' \
+--label 'hosaka.tag.transform=^(\d+\.\d+\.\d+-\d+)-.*$ => $1' \
 searx/searx:1.0.0-269-7b368146
 ```
 <!-- tabs:end -->
@@ -354,12 +354,12 @@ services:
   mariadb:
     image: mariadb:10
     labels:
-      - wud.tag.include=^\d+$$
-      - wud.watch.digest=true
+      - hosaka.tag.include=^\d+$$
+      - hosaka.watch.digest=true
 ```
 #### **Docker**
 ```bash
-docker run -d --name mariadb --label 'wud.tag.include=^\d+$' --label wud.watch.digest=true mariadb:10
+docker run -d --name mariadb --label 'hosaka.tag.include=^\d+$' --label hosaka.watch.digest=true mariadb:10
 ```
 <!-- tabs:end -->
 
@@ -386,12 +386,12 @@ services:
   mariadb:
     image: mariadb:10.6.4
     labels:
-      - wud.link.template=https://mariadb.com/kb/en/mariadb-$${major}$${minor}$${patch}-changelog
+      - hosaka.link.template=https://mariadb.com/kb/en/mariadb-$${major}$${minor}$${patch}-changelog
 ```
 
 #### **Docker**
 ```bash
-docker run -d --name mariadb --label 'wud.link.template=https://mariadb.com/kb/en/mariadb-${major}${minor}${patch}-changelog' mariadb:10
+docker run -d --name mariadb --label 'hosaka.link.template=https://mariadb.com/kb/en/mariadb-${major}${minor}${patch}-changelog' mariadb:10
 ```
 <!-- tabs:end -->
 
@@ -418,12 +418,12 @@ services:
   mariadb:
     image: mariadb:10.6.4
     labels:
-      - wud.display.name=Maria DB
-      - wud.display.icon=si:mariadb
+      - hosaka.display.name=Maria DB
+      - hosaka.display.icon=si:mariadb
 ```
 
 #### **Docker**
 ```bash
-docker run -d --name mariadb --label 'wud.display.name=Maria DB' --label 'wud.display.icon=mdi-database' mariadb:10
+docker run -d --name mariadb --label 'hosaka.display.name=Maria DB' --label 'hosaka.display.icon=mdi-database' mariadb:10
 ```
 <!-- tabs:end -->


### PR DESCRIPTION
Docs documented the old `WUD_` env vars, `wud.*` labels, and `wud.json` store file, but the app was renamed: env vars are now `HOSAKA_` (`app/configuration/index.js`), labels `hosaka.*` (`app/watchers/providers/docker/label.js`), and the default store file is `hosaka.json` (`app/store/index.js`). Following the docs as written set dead vars.

This sweeps `docs/configuration/**` and `docs/api/**` to the current contract:
- env var prefix `WUD_` -> `HOSAKA_`
- the 8 container labels `wud.{watch,watch.digest,tag.include,tag.exclude,tag.transform,link.template,display.name,display.icon}` -> `hosaka.*`
- store file `wud.json` -> `hosaka.json`

Each token was verified against app source, not blind find/replace. Example/prose strings (`wud.yml`, `wud.com`) and product-name prose are intentionally left for the rebrand PR. Scope: 32 files, all under docs/configuration and docs/api.