### PR TITLE
docs(features): document fork-unique functionality and reconcile providers

### DIFF
--- a/docs/configuration/triggers/README.md
+++ b/docs/configuration/triggers/README.md
@@ -35,6 +35,21 @@ All implemented triggers, in addition to their specific configuration, also supp
 
 ?> `HOSAKA_TRIGGER_{{trigger_type}}}_{trigger_name}_ONCE=false` can be useful when `HOSAKA_TRIGGER_{{trigger_type}}}_{trigger_name}_MODE=batch` to get a report with all pending updates.
 
+### Per-container trigger routing
+
+By default every configured trigger fires for every container that reports an
+update. You can override this on individual containers using Docker labels:
+
+- `hosaka.trigger.include` - comma-separated list of trigger ids that are
+  allowed to fire for the container. Only triggers in this list will run.
+- `hosaka.trigger.exclude` - comma-separated list of trigger ids that must not
+  fire for the container.
+
+Each entry in either label can carry an optional per-entry threshold suffix
+(`id:threshold`) so a single container can route major updates to one trigger
+and patch updates to another.
+
+?> See the [watcher label reference](configuration/watchers/) for the full threshold vocabulary and examples.
 
 ### Examples
 

--- a/docs/configuration/triggers/script/README.md
+++ b/docs/configuration/triggers/script/README.md
@@ -6,6 +6,30 @@ The `script` trigger executes a local script file mounted inside the Hosaka cont
 > want one-click Portainer updates, see [Portainer update script](configuration/triggers/script/portainer.md)
 > - you do not need to set `PATH` or mount anything.
 
+## Notify mode vs install mode
+
+The script trigger operates in one of two modes depending on the `INSTALL` setting.
+
+**Notify mode** (`INSTALL=false`, the default): the script fires automatically
+on the normal watch schedule whenever an update is detected. Use this to send a
+notification, run a webhook, or do any automated action that does not require
+user confirmation.
+
+**Install mode** (`INSTALL=true`): the script is only executed when a user
+clicks the **Update** button in the container row. The scheduled watch still
+detects the update and shows the button, but the script itself does not run
+automatically. Only one install-mode trigger may exist across all trigger types;
+configuring more than one causes the UI to surface an error.
+
+## Live script output
+
+In install mode, the script's stdout and stderr are streamed line-by-line to the
+UI in real time over a Server-Sent Events connection. A console dialog opens
+automatically when the install starts and stays open until the script exits,
+letting you watch progress without polling.
+
+## Script parameters
+
 Parameters passed to the script in this order are:
 1. container name
 2. image name
@@ -20,13 +44,11 @@ Supported shells for scripts are `/bin/bash`, `/bin/ash`, and `/bin/sh`.
 
 #### Variables
 
-| Env var                                       |    Required    | Description                                                                   | Supported values             | Default value when missing |
-|-----------------------------------------------|:--------------:|-------------------------------------------------------------------------------|------------------------------|----------------------------|
-| `HOSAKA_TRIGGER_SCRIPT_{trigger_name}_PATH`      | :white_circle: | The absolute path with script file name. Omit to use the bundled Portainer script. | Any local path               | `/scripts/portainer_stack_update.sh` |
-| `HOSAKA_TRIGGER_SCRIPT_{trigger_name}_INSTALL`   | :white_circle: | If `true`, makes this a manual Update button trigger in the UI\*              | `true`, `false`              | `false`                    |
-| `HOSAKA_TRIGGER_SCRIPT_{trigger_name}_TIMEOUT`   | :white_circle: | The amount of time in milliseconds before considering the script timed out    | integer in ms                | `300000` (5 minutes)       |
-
-\* By setting the INSTALL variable to `true`, this trigger is only executed manually in the containers UI page by clicking the "Update" button next to the upgrade version. Typical scheduled watch triggers for this trigger will not occur when INSTALL is `true`. Only one INSTALL variable can be set across all trigger types - if more than one is set the UI will throw an error and the trigger will not be executed.
+| Env var                                          |    Required    | Description                                                                                  | Supported values             | Default value when missing           |
+|--------------------------------------------------|:--------------:|----------------------------------------------------------------------------------------------|------------------------------|--------------------------------------|
+| `HOSAKA_TRIGGER_SCRIPT_{trigger_name}_PATH`      | :white_circle: | Absolute path to the script file inside the container. Omit to use the bundled Portainer script. | Any local path               | `/scripts/portainer_stack_update.sh` |
+| `HOSAKA_TRIGGER_SCRIPT_{trigger_name}_INSTALL`   | :white_circle: | If `true`, switches to install mode (manual Update button only - see above)                  | `true`, `false`              | `false`                              |
+| `HOSAKA_TRIGGER_SCRIPT_{trigger_name}_TIMEOUT`   | :white_circle: | Milliseconds before the script execution is considered timed out                             | integer in ms                | `300000` (5 minutes)                 |
 
 ### Examples
 

--- a/docs/configuration/watchers/README.md
+++ b/docs/configuration/watchers/README.md
@@ -445,13 +445,13 @@ suffix of the form `id:threshold`.
 | Value        | Fires when the semver diff is...          |
 |--------------|-------------------------------------------|
 | `all`        | Any change (default when omitted)         |
-| `major`      | major, minor, or patch                    |
-| `minor`      | minor or patch (not major)                |
-| `patch`      | patch only (not minor or major)           |
+| `major`      | Any change (same as `all`)                |
+| `minor`      | minor, patch, or prerelease (not major)   |
+| `patch`      | patch or prerelease (not major or minor)  |
 | `major-only` | major only (exact)                        |
 | `minor-only` | minor only (exact)                        |
 
-?> `major`, `minor`, and `patch` are cumulative: `minor` means "minor or anything less severe". `major-only` and `minor-only` are exact matches.
+?> `minor` and `patch` are cumulative: each also fires on anything less severe (a `minor` threshold fires on minor, patch, and prerelease updates). `major` currently behaves the same as `all`. `major-only` and `minor-only` are exact matches.
 
 **Precedence:** `hosaka.trigger.include` is evaluated first. If set, only the
 listed triggers are eligible. `hosaka.trigger.exclude` is then evaluated against

--- a/docs/configuration/watchers/README.md
+++ b/docs/configuration/watchers/README.md
@@ -189,16 +189,18 @@ docker run \
 
 To fine-tune the behaviour of Hosaka _per container_, you can add labels on them.
 
-| Label               |    Required    | Description                                        | Supported values                                                                                                                                                            | Default value when missing                                                            |
-|---------------------|:--------------:|----------------------------------------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------------------------------------------------------------------------------------|
-| `hosaka.watch`         | :white_circle: | Watch this container                               | Valid Boolean                                                                                                                                                               | `true` when `HOSAKA_WATCHER_{watcher_name}_WATCHBYDEFAULT` is `true` (`false` otherwise) |
-| `hosaka.watch.digest`  | :white_circle: | Watch this container digest                        | Valid Boolean                                                                                                                                                               | `false`                                                                               |
-| `hosaka.tag.include`   | :white_circle: | Regex to include specific tags only                | Valid JavaScript Regex                                                                                                                                                      |                                                                                       |
-| `hosaka.tag.exclude`   | :white_circle: | Regex to exclude specific tags                     | Valid JavaScript Regex                                                                                                                                                      |                                                                                       |
-| `hosaka.tag.transform` | :white_circle: | Transform function to apply to the tag             | `$valid_regex => $valid_string_with_placeholders` (see below)                                                                                                               |                                                                                       |
-| `hosaka.link.template` | :white_circle: | Browsable link associated to the container version | String template with placeholders `${raw}` `${major}` `${minor}` `${patch}` `${prerelease}`                                                                                 |                                                                                       |
-| `hosaka.display.name`  | :white_circle: | Custom display name for the container              | Valid String                                                                                                                                                                | Container name                                                                        |
-| `hosaka.display.icon`  | :white_circle: | Custom display icon for the container              | Valid [Material Design Icon](https://materialdesignicons.com/), [Fontawesome Icon](https://fontawesome.com/) or [Simple icon](https://simpleicons.org/) (see details below) | `mdi:docker`                                                                          |
+| Label                    |    Required    | Description                                        | Supported values                                                                                                                                                            | Default value when missing                                                            |
+|--------------------------|:--------------:|----------------------------------------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------------------------------------------------------------------------------------|
+| `hosaka.watch`           | :white_circle: | Watch this container                               | Valid Boolean                                                                                                                                                               | `true` when `HOSAKA_WATCHER_{watcher_name}_WATCHBYDEFAULT` is `true` (`false` otherwise) |
+| `hosaka.watch.digest`    | :white_circle: | Watch this container digest                        | Valid Boolean                                                                                                                                                               | `false`                                                                               |
+| `hosaka.tag.include`     | :white_circle: | Regex to include specific tags only                | Valid JavaScript Regex                                                                                                                                                      |                                                                                       |
+| `hosaka.tag.exclude`     | :white_circle: | Regex to exclude specific tags                     | Valid JavaScript Regex                                                                                                                                                      |                                                                                       |
+| `hosaka.tag.transform`   | :white_circle: | Transform function to apply to the tag             | `$valid_regex => $valid_string_with_placeholders` (see below)                                                                                                               |                                                                                       |
+| `hosaka.link.template`   | :white_circle: | Browsable link associated to the container version | String template with placeholders `${raw}` `${major}` `${minor}` `${patch}` `${prerelease}`                                                                                 |                                                                                       |
+| `hosaka.display.name`    | :white_circle: | Custom display name for the container              | Valid String                                                                                                                                                                | Container name                                                                        |
+| `hosaka.display.icon`    | :white_circle: | Custom display icon for the container              | Valid [Material Design Icon](https://materialdesignicons.com/), [Fontawesome Icon](https://fontawesome.com/) or [Simple icon](https://simpleicons.org/) (see details below) | `mdi:docker`                                                                          |
+| `hosaka.trigger.include` | :white_circle: | Triggers that may fire for this container          | Comma-separated trigger ids, each optionally suffixed with `:threshold` (see [Per-container trigger routing](#per-container-trigger-routing) below)                         | All configured triggers fire                                                          |
+| `hosaka.trigger.exclude` | :white_circle: | Triggers that must not fire for this container     | Comma-separated trigger ids, each optionally suffixed with `:threshold` (see [Per-container trigger routing](#per-container-trigger-routing) below)                         | No triggers excluded                                                                  |
 
 ## Label examples
 
@@ -427,3 +429,75 @@ services:
 docker run -d --name mariadb --label 'hosaka.display.name=Maria DB' --label 'hosaka.display.icon=mdi-database' mariadb:10
 ```
 <!-- tabs:end -->
+
+## Per-container trigger routing
+
+By default every configured trigger fires for every container that has an update.
+The `hosaka.trigger.include` and `hosaka.trigger.exclude` labels let you override
+that on a per-container basis.
+
+**Label values** are comma-separated trigger ids (the name you gave the trigger in
+its env var, lowercased). Each entry may optionally carry a per-entry threshold
+suffix of the form `id:threshold`.
+
+**Threshold vocabulary**
+
+| Value        | Fires when the semver diff is...          |
+|--------------|-------------------------------------------|
+| `all`        | Any change (default when omitted)         |
+| `major`      | major, minor, or patch                    |
+| `minor`      | minor or patch (not major)                |
+| `patch`      | patch only (not minor or major)           |
+| `major-only` | major only (exact)                        |
+| `minor-only` | minor only (exact)                        |
+
+?> `major`, `minor`, and `patch` are cumulative: `minor` means "minor or anything less severe". `major-only` and `minor-only` are exact matches.
+
+**Precedence:** `hosaka.trigger.include` is evaluated first. If set, only the
+listed triggers are eligible. `hosaka.trigger.exclude` is then evaluated against
+the remaining set and removes matching entries. A container with neither label
+fires all triggers as normal.
+
+### Examples
+
+#### Route a container to one trigger only
+```yaml
+labels:
+  - hosaka.trigger.include=notify
+```
+
+#### Route major updates to a pager trigger, minor/patch to a chat trigger
+```yaml
+labels:
+  - hosaka.trigger.include=pager:major-only,chat:minor
+```
+
+#### Exclude a noisy container from one trigger
+```yaml
+labels:
+  - hosaka.trigger.exclude=smtp
+```
+
+?> See [Triggers](configuration/triggers/) for the full trigger configuration reference.
+
+## Tag candidate filters
+
+Hosaka applies the following automatic filters to the tag list returned by the
+registry before comparing candidates to the running tag. These run in addition to
+any `hosaka.tag.include` / `hosaka.tag.exclude` regex you set on the container.
+
+- **`.sig` tags are always dropped.** Cosign signature tags (e.g. `1.2.3.sig`)
+  would otherwise coerce to a semver value and appear as bogus candidates.
+
+- **`sha`-prefixed tags are dropped** when `hosaka.tag.include` is not set on
+  the container. Content-addressed tags (e.g. `sha256-abc123`) are not version
+  candidates and would coerce to very high semver values if left in.
+
+- **Tag-prefix propagation** is applied when `hosaka.tag.include` is not set.
+  Candidates are limited to tags that share the non-numeric prefix of the
+  currently-running tag. For example, a container running `v1.2.3` will only be
+  offered `v*` candidates, not bare `1.3.0`. This prevents cross-stream updates
+  when an image publishes both prefixed and unprefixed variants.
+
+!> Setting `hosaka.tag.include` disables both the `sha`-prefix drop and the
+tag-prefix propagation, giving your regex full control over the candidate set.

--- a/docs/ui/README.md
+++ b/docs/ui/README.md
@@ -11,9 +11,9 @@ In addition to the REST API, Hosaka exposes a web UI on the same port.
 Each container row with an available update shows an **Update** button. Clicking
 it sends `POST /api/containers/:id/install` to the backend, which hands off to
 whichever trigger has `INSTALL=true` configured (typically the
-[script trigger](configuration/triggers/script/)). The button is only visible
-when exactly one install-mode trigger is configured; if more than one is set the
-UI surfaces an error instead.
+[script trigger](configuration/triggers/script/)). The button is shown whenever
+an install-mode trigger is configured; if more than one is set, clicking it
+surfaces an error notification instead of running the install.
 
 ## Live install output
 

--- a/docs/ui/README.md
+++ b/docs/ui/README.md
@@ -1,7 +1,71 @@
 # UI
 
-In addition to the REST API, Hosaka is exposing a Web UI on the same port.
+In addition to the REST API, Hosaka exposes a web UI on the same port.
 
 > [**http://localhost:3000**](http://localhost:3000)
 
 ![image](ui.png)
+
+## One-click container updates
+
+Each container row with an available update shows an **Update** button. Clicking
+it sends `POST /api/containers/:id/install` to the backend, which hands off to
+whichever trigger has `INSTALL=true` configured (typically the
+[script trigger](configuration/triggers/script/)). The button is only visible
+when exactly one install-mode trigger is configured; if more than one is set the
+UI surfaces an error instead.
+
+## Live install output
+
+When an install runs, a dialog opens and streams the script's stdout and stderr
+in real time over a Server-Sent Events connection at
+`GET /api/containers/:id/install/logs`. The stream stays open until the script
+exits, so you can follow the progress of a Portainer stack redeploy or any
+other update script without polling.
+
+## Live container state
+
+The container list updates in place without a full-page refresh. The UI holds an
+SSE connection to `GET /api/containers/stream`, which pushes container-state
+changes as they are written to the store. Only real state changes produce events,
+so there is no event flood during idle periods or between watch cycles.
+
+## Responsive mobile layout
+
+The container list adapts to narrow viewports. On small screens the table header
+and some columns collapse to keep the most relevant information visible without
+horizontal scrolling.
+
+## Multi-key container sort
+
+The filter bar exposes a **Sort** dropdown with three sort keys:
+
+- **Name** (default) - alphabetical by container name
+- **Update type** - groups containers by semver diff severity, then by name
+- **Watcher** - groups containers by the watcher that monitors them, then by name
+
+The selected sort key is remembered for the browser session.
+
+## Semver color ladder
+
+The update icon in each row is colored to reflect the severity of the available
+change:
+
+| Semver diff  | Color                    |
+|--------------|--------------------------|
+| `major`      | Red (error)              |
+| `minor`      | Orange (warning)         |
+| `patch`      | Green (success)          |
+| `prerelease` | Cyan (`#00BCD4`)         |
+
+The prerelease color is a custom Vuetify theme token that keeps pre-release
+candidates visually distinct from stable releases without implying a higher or
+lower urgency than patch.
+
+## Update-lifecycle reliability
+
+Container recreation (new Docker id, same name) is tracked across the watch
+cycle. The SSE stream is key-stable through recreation events, so the UI row
+stays pinned and the install-output dialog is not torn down mid-script. The
+watcher emits store updates only when state actually changes, keeping the event
+stream quiet between cycles.


### PR DESCRIPTION
Third docs-overhaul PR. Documents the fork's functionality that the upstream-derived docs never covered, all verified against app source:

- **Per-container trigger routing**: `hosaka.trigger.include` / `hosaka.trigger.exclude` labels (comma-separated trigger ids, optional `:threshold` per id) with the threshold vocabulary, added to the watcher label reference and the triggers overview.
- **Ported tag filters**: `.sig` always dropped; `sha`-prefix drop + tag-prefix propagation, gated on no `hosaka.tag.include`.
- **UI features** (`docs/ui/README.md`, was a 7-line stub): one-click row Update (`POST /api/containers/:id/install`), live install console over `GET /api/containers/:id/install/logs` (SSE), live container state over `GET /api/containers/stream` (SSE, no full-page refresh), responsive mobile, multi-key sort, the semver update color ladder (major=red/minor=orange/patch=green/prerelease=cyan), and recreation-tracking / change-only streaming.
- **Script trigger**: documented `HOSAKA_TRIGGER_SCRIPT_<name>_PATH` (default `/scripts/portainer_stack_update.sh`), `_INSTALL`, `_TIMEOUT` (300000ms), notify vs install mode, and the bundled Portainer updater behavior.
- **Provider reconcile**: documented trigger/registry/auth lists match the shipped providers (no change needed).

A fact-check review caught and fixed three inaccuracies before this PR: the threshold table now reflects that `minor`/`patch` also fire on prereleases, and the Update-button visibility wording matches the actual UI behavior.

Note: the fact-check surfaced that the `major` per-trigger threshold currently behaves identically to `all` (there is no `case 'major'` in `isThresholdReached`, so it falls through to the default). The docs now describe it accurately as "same as all"; if that is unintended, it is a small follow-up code fix (add a `major` case), tracked separately from these docs.