### PR TITLE
chore(docker): set image maintainer label to nopoz

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 # Common Stage
 FROM node:18-alpine as base
 
-LABEL maintainer="fmartinou"
+LABEL maintainer="nopoz"
 EXPOSE 3000
 
 ARG HOSAKA_VERSION=unknown


### PR DESCRIPTION
Updates the stale `LABEL maintainer` from the upstream author to `nopoz` so the published image metadata reflects the fork. Prep for the first Hosaka release.