### PR TITLE
fix(ci): pass bare semver as HOSAKA_VERSION

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -66,7 +66,7 @@ jobs:
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           build-args: |
-            HOSAKA_VERSION=${{ github.event.release.tag_name }}
+            HOSAKA_VERSION=${{ steps.meta.outputs.version }}
           # Attach an SBOM attestation to the pushed image (supply-chain
           # transparency). Provenance is left to the dedicated
           # attest-build-provenance step below to avoid duplicate provenance


### PR DESCRIPTION
The release tag (`v1.0.0`) was passed verbatim as `HOSAKA_VERSION`, and the UI prepends its own `v`, rendering `vv1.0.0` in the nav. Use the metadata-action's stripped semver output (`1.0.0`) so the UI owns the single `v` prefix.