### PR TITLE
fix(metrics): register trigger_include/trigger_exclude container labels

### DIFF
--- a/app/prometheus/container.js
+++ b/app/prometheus/container.js
@@ -48,6 +48,8 @@ function init() {
             'include_tags',
             'exclude_tags',
             'transform_tags',
+            'trigger_include',
+            'trigger_exclude',
             'link_template',
             'link',
             'image_id',


### PR DESCRIPTION
Containers using the `trigger.include`/`trigger.exclude` labels flatten to `trigger_include`/`trigger_exclude`, which were missing from the `hosaka_containers` gauge labelset. prom-client rejects labels not in the initial set, so those containers logged `Error when adding container to the metrics ... is not included in initial labelset` and were dropped from metrics. Adds both names to the gauge.