### PR TITLE
docs(readme): note the theme picker in the WUD comparison

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ Hosaka sits in the middle, where most people actually want to be:
 | **Live container state** | manual refresh | list updates in place over SSE, no full-page reload |
 | **Update lifecycle** | trigger fires; output is logged server-side after it exits | tracks the container recreation, confirms the new container is live, and carries the "update complete" state onto the new container ID |
 | **In-app UX** | filter + oldest-first toggle | sort by name, update type, or watcher; distinct color per update type, including prerelease |
+| **Theming** | single look, dark/light toggle | five built-in themes via an in-app picker, on a distinct cyberpunk identity |
 
 ## How it works
 


### PR DESCRIPTION
Adds a `Theming` row to the "What's different from WUD" table: WUD ships a single look with a dark/light toggle, while Hosaka offers five built-in themes via an in-app picker on a distinct cyberpunk identity.