### PR TITLE
fix(ui): stop container row chips truncating while the row has room

### DIFF
--- a/ui/src/components/ContainerItem.vue
+++ b/ui/src/components/ContainerItem.vue
@@ -40,7 +40,6 @@
           {{ container.image.tag.value }}
         </v-chip>
       </v-toolbar-title>
-      <v-spacer />
       <v-chip
         v-if="(container.install === true || container.install === 'multiple') && container.updateAvailable"
         label
@@ -554,7 +553,15 @@ export default {
 .v-toolbar :deep(.v-toolbar__content) {
   padding-inline: 8px;
 }
+/* Let the title reserve its content width and grow into the leftover space so it
+   pushes the right-hand chips to the edge on its own. Without a v-spacer (which
+   would otherwise grow alongside a basis-0 title and split the row 50/50,
+   truncating the left chips while a gap sits unused), the title only clips when
+   the chips would genuinely collide with the right-hand cluster. */
 .v-toolbar :deep(.v-toolbar-title) {
   margin-inline-start: 4px;
+  flex: 1 1 auto !important;
+  min-width: 0;
+  overflow: hidden;
 }
 </style>


### PR DESCRIPTION
## Problem

On desktop, a container row would truncate its left-hand chips (container name / current tag collapsed to `..`) as soon as the window narrowed, even while a wide empty gap remained in the middle of the row.

## Cause

The `v-toolbar-title` resolves to `flex: 1 1 0%` (basis 0), and the row also carried a `<v-spacer>` with `flex-grow: 1`. With both growing, they split the row's free space 50/50, capping the title at half the available width and forcing its chips to truncate long before anything would actually collide.

## Fix

- Remove the redundant `<v-spacer>`.
- Give the title `flex: 1 1 auto; min-width: 0; overflow: hidden` so it reserves its content width and grows into the leftover space on its own, pushing the right-hand chips to the edge.

The title now only clips when its chips would genuinely collide with the right-hand cluster. Wide-screen layout is unchanged.

## Verification

Checked across the desktop range (965 / 1000 / 1280px) on a running instance: long values like `version-11.0.0-SNAPSHOT.20240424015024` now render in full at every width, and the wide-screen layout is identical to before.