### PR TITLE
feat(portainer-script): opt-in TLS skip-verify for self-signed endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,7 +147,8 @@ marked done until the new container comes back healthy.
   `latest`, and step from one known version to the next when you choose, so you
   always know what is running and can roll back by redeploying the old tag
 - Nothing to write or mount; point it at your Portainer URL and API key and the
-  Update button does the rest
+  Update button does the rest. Connecting over HTTPS to a self-signed certificate
+  (or by IP) works too, by opting in with `PORTAINER_INSECURE=true`
 - Health-aware progress: the run streams to the UI line by line and waits for the
   container to come back healthy on the new image before reporting success
 - Reference stack in [`docker-compose.example.yml`](docker-compose.example.yml);

--- a/docker-compose.example.yml
+++ b/docker-compose.example.yml
@@ -49,6 +49,7 @@ services:
       - HOSAKA_TRIGGER_SCRIPT_PORTAINER_INSTALL=true
       # - PORTAINER_API_ENDPOINT=https://portainer.example.com:9443/api   # must include /api
       # - PORTAINER_API_KEY=ptr_xxxxxxxxxxxxxxxx                          # Portainer access token
+      # - PORTAINER_INSECURE=true                                         # skip TLS verify (self-signed cert / IP)
       # - UPDATE_TIMEOUT=300                                              # script: wait for healthy (s)
       # - POLL_INTERVAL=5                                                 # script: health poll interval (s)
       # - HOSAKA_TRIGGER_SCRIPT_PORTAINER_TIMEOUT=300000                  # hard kill the script after (ms)

--- a/docs/configuration/triggers/script/portainer.md
+++ b/docs/configuration/triggers/script/portainer.md
@@ -59,6 +59,7 @@ one makes the UI throw an error.
 |---------------------------|:--------------:|---------------------------------------------------------------------------------------|---------|
 | `PORTAINER_API_ENDPOINT`  |  :red_circle:  | Portainer API base URL, including the `/api` suffix (e.g. `https://host:9443/api`).    |         |
 | `PORTAINER_API_KEY`       |  :red_circle:  | A Portainer API access token. Prefer a Docker secret over an inline value.             |         |
+| `PORTAINER_INSECURE`      | :white_circle: | Set `true` to skip TLS certificate verification (self-signed cert / connect by IP).    | `false` |
 | `UPDATE_TIMEOUT`          | :white_circle: | Seconds to wait for the container to reach the target image.                           | `300`   |
 | `POLL_INTERVAL`           | :white_circle: | Seconds between container-state polls.                                                 | `5`     |
 
@@ -67,6 +68,13 @@ one makes the UI throw an error.
 > Docker-secret convention. To keep the key out of your compose file, use the
 > compose `secrets` mechanism and export it into the env in your own entrypoint,
 > or supply it via your secret manager.
+
+> **HTTPS with a self-signed certificate.** By default the script verifies the
+> Portainer endpoint's TLS certificate, so an `https://` endpoint with a
+> self-signed certificate (or one reached by IP, where the certificate's name
+> won't match) fails the connectivity preflight with a certificate error. If you
+> trust the endpoint, set `PORTAINER_INSECURE=true` to skip verification.
+> Accepted values are `true`, `1`, or `yes`.
 
 ## Example
 

--- a/scripts/portainer_stack_update.sh
+++ b/scripts/portainer_stack_update.sh
@@ -15,6 +15,18 @@ compose_project="$6"
 update_timeout="${UPDATE_TIMEOUT:-300}"  # Overall timeout for update operations (default 300s)
 poll_interval="${POLL_INTERVAL:-5}"      # Interval for polling container state (default 5s)
 
+# Opt-in TLS skip-verify for Portainer endpoints with a self-signed certificate
+# (or accessed by IP, where the cert won't match). Off by default so verification
+# stays on; set PORTAINER_INSECURE=true/1 to accept an untrusted cert. Every
+# Portainer API call goes through pcurl so the flag applies uniformly.
+insecure_opt=()
+case "${PORTAINER_INSECURE,,}" in
+	true|1|yes) insecure_opt=(--insecure) ;;
+esac
+pcurl() {
+	curl "${insecure_opt[@]}" "$@"
+}
+
 # Inspect the container once; echo its state vs the target:
 # ready | unhealthy | sameimage (target tag but image ID unchanged) | waiting | absent
 check_container_state() {
@@ -24,7 +36,7 @@ check_container_state() {
 	local initial_img_id="$4"
 
 	local containers_json container_id container_info
-	containers_json=$(curl -s --location --request GET "$portainer_url/endpoints/$endpoint_id/docker/containers/json?all=true" \
+	containers_json=$(pcurl -s --location --request GET "$portainer_url/endpoints/$endpoint_id/docker/containers/json?all=true" \
 		--header 'Accept: application/json' \
 		--header "X-API-Key: $api_key")
 	container_id=$(echo "$containers_json" | jq -r --arg container_name "$container_name" \
@@ -35,7 +47,7 @@ check_container_state() {
 		return
 	fi
 
-	container_info=$(curl -s --location --request GET "$portainer_url/endpoints/$endpoint_id/docker/containers/$container_id/json" \
+	container_info=$(pcurl -s --location --request GET "$portainer_url/endpoints/$endpoint_id/docker/containers/$container_id/json" \
 		--header 'Accept: application/json' \
 		--header "X-API-Key: $api_key")
 
@@ -159,7 +171,7 @@ wait_for_container_update() {
 			verify_and_finish; local rc=$?
 			[[ $rc -ne 2 ]] && return $rc
 		fi
-	done < <(curl -sN --max-time "$timeout" --location --request GET \
+	done < <(pcurl -sN --max-time "$timeout" --location --request GET \
 		"$portainer_url/endpoints/$endpoint_id/docker/events?since=$since&filters=$filters" \
 		--header 'Accept: application/json' \
 		--header "X-API-Key: $api_key" 2>/dev/null)
@@ -190,7 +202,7 @@ fetch_container_logs() {
 
 	echo -e "\nFetching last $lines lines of logs for container \"$container_name\"..."
 
-	local containers_json=$(curl -s --location --request GET "$portainer_url/endpoints/$endpoint_id/docker/containers/json?all=true" \
+	local containers_json=$(pcurl -s --location --request GET "$portainer_url/endpoints/$endpoint_id/docker/containers/json?all=true" \
 		--header 'Accept: application/json' \
 		--header "X-API-Key: $api_key")
 
@@ -204,7 +216,7 @@ fetch_container_logs() {
 
 	# Fetch logs via Docker API proxy, demuxing the stream so binary frame
 	# headers don't end up in the console. Pipe directly (NULs survive).
-	local logs=$(curl -s --location --request GET "$portainer_url/endpoints/$endpoint_id/docker/containers/$container_id/logs?stdout=true&stderr=true&tail=$lines" \
+	local logs=$(pcurl -s --location --request GET "$portainer_url/endpoints/$endpoint_id/docker/containers/$container_id/logs?stdout=true&stderr=true&tail=$lines" \
 		--header "X-API-Key: $api_key" 2>/dev/null | demux_docker_stream | tail -n "$lines")
 
 	if [[ -n "$logs" ]]; then
@@ -243,11 +255,18 @@ fi
 
 # Verify connectivity and auth up front so any failure is attributable to the
 # right cause (unreachable endpoint vs bad key vs missing /api suffix).
-preflight_code=$(curl -s -o /dev/null -w '%{http_code}' --max-time 15 --location \
+preflight_code=$(pcurl -s -o /dev/null -w '%{http_code}' --max-time 15 --location \
 	--request GET "$portainer_url/endpoints" \
 	--header 'Accept: application/json' \
 	--header "X-API-Key: $api_key")
 preflight_rc=$?
+if [[ $preflight_rc -eq 60 ]]; then
+	echo "ERROR: TLS certificate verification failed for \"$portainer_url\" (curl exit 60)."
+	echo "Portainer is reachable but presented a certificate that could not be verified - expected"
+	echo "if it uses a self-signed certificate or you connect to it by IP address. If you trust this"
+	echo "endpoint, set PORTAINER_INSECURE=true on the Hosaka container to skip certificate verification."
+	exit 1
+fi
 if [[ $preflight_rc -ne 0 ]]; then
 	echo "ERROR: could not reach Portainer at \"$portainer_url\" (curl exit $preflight_rc)."
 	echo "Check PORTAINER_API_ENDPOINT (scheme, host, port) and that the Hosaka container can"
@@ -282,7 +301,7 @@ echo -e "\nretrieving portainer info for container \"$container_name\" in stack 
 if [[ $watcher_name == "local" ]]; then
 	endpoint_id=1
 else
-	endpoints_json=$(curl -s --location --request GET "$portainer_url/endpoints?name=$watcher_name" \
+	endpoints_json=$(pcurl -s --location --request GET "$portainer_url/endpoints?name=$watcher_name" \
 		--header 'Accept: application/json' \
 		--header "X-API-KEY: $api_key")
 
@@ -291,7 +310,7 @@ else
 	candidate_ids=$(echo "$endpoints_json" | jq -r 'if type == "array" then .[] else . end | .Id')
 	endpoint_id=""
 	for candidate_id in $candidate_ids; do
-		proxy_containers=$(curl -s --location --request GET "$portainer_url/endpoints/$candidate_id/docker/containers/json?all=true" \
+		proxy_containers=$(pcurl -s --location --request GET "$portainer_url/endpoints/$candidate_id/docker/containers/json?all=true" \
 			--header 'Accept: application/json' \
 			--header "X-API-Key: $api_key")
 		match=$(echo "$proxy_containers" | jq -r --arg container_name "$container_name" --arg compose_project "$compose_project" \
@@ -313,7 +332,7 @@ echo "container endpoint id: $endpoint_id"
 
 # get image id from endpoints output
 filter_encoded=$(printf '{"name":["/%s"]}' "$container_name" | jq -sRr @uri)
-endpoint_inspect=$(curl -s --location -g \
+endpoint_inspect=$(pcurl -s --location -g \
 	--request GET "$portainer_url/endpoints/$endpoint_id/docker/containers/json?all=true&filters=$filter_encoded" \
 	--header 'Accept: application/json' \
 	--header "X-API-Key: $api_key")
@@ -329,7 +348,7 @@ echo "container image id: $image_id"
 
 # get stack id
 filter_encoded=$(printf '{"EndpointID":%s}' "$endpoint_id" | jq -sRr @uri)
-endpoint_stacks=$(curl -s --location -g \
+endpoint_stacks=$(pcurl -s --location -g \
 	--request GET "$portainer_url/stacks?filters=${filter_encoded}" \
 	--header 'Accept: application/json' \
 	--header "X-API-Key: $api_key")
@@ -346,7 +365,7 @@ echo "container stack id: $stack_id"
 env_data=$(echo "$endpoint_stacks" | jq --arg id "$stack_id" '.[] | select(.Id == ($id | tonumber)) | .Env')
 
 # get stack file contents:
-stack_contents=$(curl -s --location --request GET "$portainer_url/stacks/$stack_id/file" \
+stack_contents=$(pcurl -s --location --request GET "$portainer_url/stacks/$stack_id/file" \
 	--header 'Accept: application/json' \
 	--header "X-API-KEY: $api_key")
 if [[ -n $stack_contents ]]; then
@@ -412,7 +431,7 @@ fi
 
 # Capture initial container state before update
 echo -e "\ncapturing initial container state..."
-initial_containers_json=$(curl -s --location --request GET "$portainer_url/endpoints/$endpoint_id/docker/containers/json?all=true" \
+initial_containers_json=$(pcurl -s --location --request GET "$portainer_url/endpoints/$endpoint_id/docker/containers/json?all=true" \
 	--header 'Accept: application/json' \
 	--header "X-API-Key: $api_key")
 
@@ -441,7 +460,7 @@ payload=$(jq -n \
 
 # push stack update to portainer API
 echo -e "\npushing $compose_project stack file update to portainer..."
-response=$(curl -s --max-time 300 -i --location \
+response=$(pcurl -s --max-time 300 -i --location \
 	--request PUT "$portainer_url/stacks/$stack_id?endpointId=$endpoint_id" \
 	--header 'Content-Type: application/json' \
 	--header 'Accept: application/json' \
@@ -471,7 +490,7 @@ fi
 
 # Echo how many containers are still running the old image.
 check_old_container_present() {
-	containers_json=$(curl -s --location --request GET "$portainer_url/endpoints/$endpoint_id/docker/containers/json?all=true" \
+	containers_json=$(pcurl -s --location --request GET "$portainer_url/endpoints/$endpoint_id/docker/containers/json?all=true" \
 		--header 'Accept: application/json' \
 		--header "X-API-Key: $api_key")
 	echo "$containers_json" | jq --arg old_image "$old_image" \


### PR DESCRIPTION
## What

The bundled Portainer updater (`scripts/portainer_stack_update.sh`) verified TLS on every API call, with no way to opt out. Connecting to a Portainer instance over HTTPS with a self-signed certificate (or by IP, where the cert name won't match) failed the connectivity preflight, and the error misattributed the cause to host/port/network rather than certificate verification.

## Changes

- Add an opt-in `PORTAINER_INSECURE` flag (`true`/`1`/`yes`) that skips TLS verification. It is routed through a `pcurl` wrapper so it applies uniformly to all Portainer API calls; verification stays **on by default**.
- Detect the curl exit-60 certificate failure in the preflight and print a TLS-specific message that names the flag, instead of the generic "could not reach" guidance.
- Document the flag in the Portainer script docs (variables table + note), the README Portainer feature bullet, and the `docker-compose.example.yml` reference stack.

## Verified

- `bash -n` syntax check clean; shellcheck error-level clean.
- Flag parsing tested across `""`/`true`/`TRUE`/`1`/`yes`/`false`/`nope` (only the affirmative values enable skip-verify).
- Compose example re-validated as YAML.