### PR TITLE
docs(readme): consolidate dangling sections into a Works-with directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,8 +20,7 @@ rebuilt around a faster, mobile-friendly UI and one-click updates.
   <img src="docs/demo.gif" alt="Clicking Update streams the install live, line by line, until the container is healthy" width="820">
 </p>
 
-<details>
-<summary><h2>Table of Contents</h2></summary>
+## Table of Contents
 
 - [Why Hosaka](#why-hosaka)
 - [What's different from WUD](#whats-different-from-wud)
@@ -32,8 +31,6 @@ rebuilt around a faster, mobile-friendly UI and one-click updates.
 - [Works with](#works-with)
 - [Security](#security)
 - [More of my projects](#more-of-my-projects)
-
-</details>
 
 ## Why Hosaka
 

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ rebuilt around a faster, mobile-friendly UI and one-click updates.
 </p>
 
 <details>
-<summary>Contents</summary>
+<summary><h2>Table of Contents</h2></summary>
 
 - [Why Hosaka](#why-hosaka)
 - [What's different from WUD](#whats-different-from-wud)

--- a/README.md
+++ b/README.md
@@ -20,6 +20,21 @@ rebuilt around a faster, mobile-friendly UI and one-click updates.
   <img src="docs/demo.gif" alt="Clicking Update streams the install live, line by line, until the container is healthy" width="820">
 </p>
 
+<details>
+<summary>Contents</summary>
+
+- [Why Hosaka](#why-hosaka)
+- [What's different from WUD](#whats-different-from-wud)
+- [How it works](#how-it-works)
+- [Features](#features)
+- [Get started](#get-started)
+- [Documentation](#documentation)
+- [Works with](#works-with)
+- [Security](#security)
+- [More of my projects](#more-of-my-projects)
+
+</details>
+
 ## Why Hosaka
 
 Keeping self-hosted containers up to date is a chore with bad default options.
@@ -205,40 +220,24 @@ Full docs are published at **[nopoz.github.io/hosaka](https://nopoz.github.io/ho
 - [REST API](https://nopoz.github.io/hosaka/#/api/)
 - [Monitoring](https://nopoz.github.io/hosaka/#/monitoring/)
 
-## Triggers
-- Send notifications using [**SMTP**](https://en.wikipedia.org/wiki/Simple_Mail_Transfer_Protocol), [**Apprise**](https://github.com/caronc/apprise-api), [**IFTTT**](https://ifttt.com), [**Pushover**](https://pushover.net), [**Slack**](https://slack.com), [**Telegram**](https://telegram.org/), and [**Discord**](https://discord.com/)
-- Update your [**docker**](https://www.docker.com) containers or your [**docker-compose**](https://docs.docker.com/compose) stack, automatically or with a single click in the UI
-- Update Portainer-managed stacks with the built-in one-click script, or run your own update script and watch its output live
-- Integrate with third-party systems using [**Kafka**](https://kafka.apache.org), [**MQTT**](https://mqtt.org), and **HTTP webhooks**
-- Set up your own update strategies (e.g. auto-update on minor and patch versions, notify by email on major versions)
+## Works with
 
-## Registries
+Quick reference for what Hosaka plugs into. Full setup lives in the
+[documentation](https://nopoz.github.io/hosaka/).
 
-- [**AWS Elastic Container Registry**](https://aws.amazon.com/ecr)
-- [**Azure Container Registry**](https://azure.microsoft.com/services/container-registry)
-- [**Docker Hub**](http://hub.docker.com)
-- [**Forgejo Container Registry**](https://forgejo.org/)
-- [**Gitea Container Registry**](https://gitea.com/)
-- [**GitHub Container Registry**](https://docs.github.com/en/packages/working-with-a-github-packages-registry/working-with-the-docker-registry)
-- [**GitLab Container Registry**](https://docs.gitlab.com/ee/user/packages/container_registry/)
-- [**Google Container Registry**](https://cloud.google.com/container-registry)
-- [**LinuxServer Container Registry (lscr.io)**](https://fleet.linuxserver.io/)
-- [**Red Hat Quay**](https://quay.io/)
-- [**Self-hosted Docker Registry**](https://docs.docker.com/registry/)
+**Registries:** Docker Hub, GitHub (GHCR), GitLab, Gitea, Forgejo, AWS ECR,
+Azure ACR, Google GCR, LinuxServer (lscr.io), Red Hat Quay, and any self-hosted
+Docker registry.
 
-## Authentication
-- [Openid Connect](https://openid.net/connect/)
-- [Basic authentication](https://developer.mozilla.org/en-US/docs/Web/HTTP/Authentication)
+**Notifications:** SMTP, Slack, Discord, Telegram, Apprise, IFTTT, Pushover,
+Kafka, MQTT, and HTTP webhooks.
 
-## Integrations
+**Auth / SSO:** Basic auth, or OpenID Connect (Authelia, Authentik, Auth0,
+Keycloak, and other OIDC providers).
 
-- [**Authelia**](https://www.authelia.com/)
-- [**Authentik**](https://goauthentik.io/)
-- [**Auth0**](https://auth0.com/)
-- [**Grafana**](https://grafana.com/)
-- [**Home-Assistant**](https://www.home-assistant.io/)
-- [**Keycloak**](https://www.keycloak.org/)
-- [**Prometheus**](https://prometheus.io/)
+**Monitoring:** Prometheus metrics and a `/health` endpoint, ready for Grafana.
+
+**Home:** Home-Assistant.
 
 ## Security
 


### PR DESCRIPTION
## What

Tightens the back half of the README, which had drifted into duplicated and dangling list sections.

- **Remove `## Triggers`** - it restated the Features "Notify or update" + Portainer blocks with no new info.
- **Merge `## Registries` + `## Authentication` + `## Integrations`** into one framed `## Works with` reference. They previously dangled as bare link lists right after the rich Features pitch and read like leftover boilerplate. Now grouped into a single scannable compatibility directory: Registries, Notifications, Auth/SSO, Monitoring, Home.
- **Add a collapsible Contents ToC** after the demo gif. Placed so the logo, pitch, and gif stay the first thing a reader sees; the ToC sits at the natural "where do I go" moment as the prose starts, and stays out of the way until expanded.

## Notes

- Tradeoff: collapsing the per-item lists into prose drops the individual homepage hyperlinks. The Documentation section above already links into setup docs, so the reference path is intact.
- No emdashes (matches existing README style).

## Verification

Rendered the Markdown and checked the ToC anchors resolve against GitHub slug rules.