### PR TITLE
feat(portainer): native Node updater replacing the bundled bash script

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,8 +67,8 @@ Hosaka sits in the middle, where most people actually want to be:
 | Area | WUD | Hosaka |
 |------|-----|--------|
 | **Updating from the UI** | run a trigger from the container's Triggers tab | one-click **Update** on the container row |
-| **Update progress** | none | live console output of the update script, streamed line by line |
-| **Portainer stacks** | generic script trigger, write your own | bundled one-click updater that rewrites the stack file and redeploys through the Portainer API |
+| **Update progress** | none | live console output of the update, streamed line by line |
+| **Portainer stacks** | generic script trigger, write your own | built-in one-click updater that rewrites the stack file and redeploys through the Portainer API |
 | **Mobile** | desktop-oriented: permanent nav, no mobile layout | fully responsive: hamburger nav, mobile layouts, update from your phone |
 | **Live container state** | manual refresh | list updates in place over SSE, no full-page reload |
 | **Update lifecycle** | trigger fires; output is logged server-side after it exits | tracks the container recreation, confirms the new container is live, and carries the "update complete" state onto the new container ID |

--- a/app/request/index.js
+++ b/app/request/index.js
@@ -1,4 +1,5 @@
 const axios = require('axios');
+const https = require('https');
 
 /**
  * Minimal drop-in replacement for the (deprecated) request-promise-native calls
@@ -24,6 +25,9 @@ async function request(options = {}) {
         auth,
         proxy,
         resolveWithFullResponse = false,
+        insecure = false,
+        responseType,
+        signal,
     } = options;
 
     const config = {
@@ -31,6 +35,19 @@ async function request(options = {}) {
         method: String(method).toLowerCase(),
         headers: { ...headers },
     };
+
+    if (responseType !== undefined) {
+        config.responseType = responseType;
+    }
+    if (signal !== undefined) {
+        config.signal = signal;
+    }
+    // Opt-in skip of TLS verification for self-signed / IP-addressed endpoints.
+    // Off by default so verification stays on; callers pass insecure: true only
+    // when the user has explicitly accepted an untrusted certificate.
+    if (insecure) {
+        config.httpsAgent = new https.Agent({ rejectUnauthorized: false });
+    }
 
     if (qs !== undefined) {
         config.params = qs;

--- a/app/triggers/providers/script/Script.js
+++ b/app/triggers/providers/script/Script.js
@@ -7,6 +7,11 @@ const Docker = require('dockerode');
 const fs = require('fs');
 const registry = require('../../../registry');
 const EventEmitter = require('events');
+const runPortainerUpdate = require('./portainerUpdate');
+
+// Sentinel path value selecting the built-in native Portainer updater instead of
+// exec-ing an external script file. Any other path value is exec'd as before.
+const BUILTIN_PATH = 'built-in';
 
 const scriptOutputEmitter = new EventEmitter();
 
@@ -31,7 +36,7 @@ class ScriptTrigger extends Trigger {
      */
     getConfigurationSchema() {
         return this.joi.object().keys({
-            path: this.joi.string().default('/scripts/portainer_stack_update.sh'),
+            path: this.joi.string().default(BUILTIN_PATH),
             install: this.joi.boolean().truthy('true').falsy('false').default(false),
             timeout: this.joi.number().default(300000),
         });
@@ -459,7 +464,10 @@ async install(container) {
         }
 
         const compose_project = container.compose_project || 'unknown';
-        const command = shell([path, name, imageName, localValue, remoteValue, watcher, compose_project]);
+        const useBuiltin = String(path) === BUILTIN_PATH;
+        const command = useBuiltin
+            ? null
+            : shell([path, name, imageName, localValue, remoteValue, watcher, compose_project]);
 
         // Prepare header
         const header = [
@@ -476,7 +484,7 @@ async install(container) {
             `#   - Watcher: ${watcher}`,
             `#   - Compose Project: ${compose_project}`,
             '#',
-            `# Full Command: ${command}`,
+            useBuiltin ? '# Updater: built-in (native Portainer)' : `# Full Command: ${command}`,
             '# Script Output:',
             '------------------------------------------------------------------------------',
             ''
@@ -495,6 +503,52 @@ async install(container) {
 
         // Emit header
         emitLog(header);
+
+        const buildFooter = (code) => [
+            '------------------------------------------------------------------------------',
+            '# Execution Summary:',
+            `# Container: ${name}`,
+            `# Exit Code: ${code}`,
+            code === 0 ? '# Status: Success' : null,
+            '##############################################################################',
+            '#                             SCRIPT EXECUTION END                           #',
+            '##############################################################################',
+            '',
+        ].filter(Boolean).join('\n');
+
+        // Built-in native Portainer updater: run in-process instead of exec-ing a
+        // script, streaming each line through the same emitLog so the live-output
+        // UI behaves identically to the external-script path.
+        if (useBuiltin) {
+            const emitLine = (line) => emitLog(`# [${name}] ${line}\n`);
+            try {
+                await runPortainerUpdate({
+                    containerName: name,
+                    imageName,
+                    currentVersion: localValue,
+                    targetVersion: remoteValue,
+                    watcher,
+                    composeProject: compose_project,
+                    timeout,
+                }, emitLine);
+                emitLog(buildFooter(0));
+                scriptOutputEmitter.emit('complete', {
+                    containerId: container.id,
+                    containerName: container.name,
+                    timestamp: Date.now(),
+                });
+            } catch (error) {
+                emitLine(`ERROR: ${error.message}`);
+                emitLog(buildFooter(1));
+                scriptOutputEmitter.emit('complete', {
+                    containerId: container.id,
+                    containerName: container.name,
+                    timestamp: Date.now(),
+                });
+                throw error;
+            }
+            return;
+        }
 
         return new Promise((resolve, reject) => {
             const process = exec(command, { timeout }, (error) => {

--- a/app/triggers/providers/script/Script.js
+++ b/app/triggers/providers/script/Script.js
@@ -501,6 +501,9 @@ async install(container) {
             });
         };
 
+        // Prefix each output line with a wall-clock timestamp (HH:MM:SS).
+        const ts = () => new Date().toTimeString().slice(0, 8);
+
         // Emit header
         emitLog(header);
 
@@ -520,7 +523,13 @@ async install(container) {
         // script, streaming each line through the same emitLog so the live-output
         // UI behaves identically to the external-script path.
         if (useBuiltin) {
-            const emitLine = (line) => emitLog(`# [${name}] ${line}\n`);
+            // Split on embedded newlines so each line gets its own timestamp;
+            // trim so lines sit flush after the stamp (the timestamp is the left
+            // margin), and keep blank separator lines blank without a stray stamp.
+            const emitLine = (raw) => String(raw).split('\n').forEach((line) => {
+                const trimmed = line.trim();
+                emitLog(trimmed ? `# [${ts()}] ${trimmed}\n` : '\n');
+            });
             try {
                 await runPortainerUpdate({
                     containerName: name,
@@ -563,7 +572,7 @@ async install(container) {
                 const lines = data.toString().split('\n');
                 lines.forEach(line => {
                     if (line.trim()) {
-                        emitLog(`# [${name}] ${line.trim()}\n`);
+                        emitLog(`# [${ts()}] ${line.trim()}\n`);
                     }
                 });
             });
@@ -572,7 +581,7 @@ async install(container) {
                 const lines = data.toString().split('\n');
                 lines.forEach(line => {
                     if (line.trim()) {
-                        emitLog(`# [${name}] ERROR: ${line.trim()}\n`);
+                        emitLog(`# [${ts()}] ERROR: ${line.trim()}\n`);
                     }
                 });
             });

--- a/app/triggers/providers/script/Script.test.js
+++ b/app/triggers/providers/script/Script.test.js
@@ -203,10 +203,10 @@ describe('Script Trigger Tests', () => {
 });
 
 describe('Script Trigger configuration schema', () => {
-    test('path defaults to the bundled portainer script when omitted', () => {
+    test('path defaults to the built-in native updater when omitted', () => {
         const trigger = new Script();
         const validated = trigger.validateConfiguration({ install: true });
-        expect(validated.path).toEqual('/scripts/portainer_stack_update.sh');
+        expect(validated.path).toEqual('built-in');
         expect(validated.install).toEqual(true);
         expect(validated.timeout).toEqual(300000);
     });

--- a/app/triggers/providers/script/Script.test.js
+++ b/app/triggers/providers/script/Script.test.js
@@ -178,8 +178,8 @@ describe('Script Trigger Tests', () => {
 
         const execCall = exec.mock.results[0].value;
         expect(execCall.stdout.on).toHaveBeenCalledWith('data', expect.any(Function));
-        // Verify log messages were prefixed with container name
-        expect(console.log).toHaveBeenCalledWith(expect.stringContaining('[test-container]'));
+        // Verify log messages were prefixed with an HH:MM:SS timestamp
+        expect(console.log).toHaveBeenCalledWith(expect.stringMatching(/# \[\d{2}:\d{2}:\d{2}\] Script is running/));
     });
 
     test('setContainerNotification should update container with notification', async () => {

--- a/app/triggers/providers/script/portainerUpdate.js
+++ b/app/triggers/providers/script/portainerUpdate.js
@@ -1,0 +1,468 @@
+const readline = require('readline');
+const request = require('../../../request');
+
+/**
+ * Native Node port of scripts/portainer_stack_update.sh.
+ *
+ * Edits a container's Portainer stack file (image:current -> image:target) and
+ * PUTs a stack update, then watches the container reach the target image via the
+ * Portainer-proxied Docker event stream (with an inspect-poll backstop). All
+ * HTTP goes through the shared axios adapter; JSON is handled natively, so the
+ * jq/curl shape bugs the bash version suffered from (issue #97) cannot recur.
+ *
+ * Talks to Portainer through PORTAINER_API_ENDPOINT / PORTAINER_API_KEY (and the
+ * opt-in PORTAINER_INSECURE for self-signed / IP endpoints), read from the
+ * container environment exactly as the bash script did.
+ */
+
+const MOVING_TAGS = /:(latest|stable|edge|main|master|nightly|rolling|dev)(["'\s]|$)/;
+
+function readEnv() {
+    return {
+        portainerUrl: process.env.PORTAINER_API_ENDPOINT,
+        apiKey: process.env.PORTAINER_API_KEY,
+        insecure: /^(true|1|yes)$/i.test(process.env.PORTAINER_INSECURE || ''),
+    };
+}
+
+function nowSec() {
+    return Math.floor(Date.now() / 1000);
+}
+
+function lastSegment(imageRef) {
+    return String(imageRef).split('/').pop();
+}
+
+// A Portainer/Docker proxy list endpoint must return a JSON array. On failure it
+// returns an object like { message: "..." }; surface the real reason instead of
+// letting downstream array access produce a cryptic error (this is the #97 fix,
+// now structural rather than a guard bolted onto a jq pipeline).
+function requireArray(value, context) {
+    if (!Array.isArray(value)) {
+        const msg = value && (value.message || value.details);
+        throw new Error(
+            `unexpected response from Portainer while ${context}`
+            + (msg ? `: ${msg}` : ` (response was not a JSON array)`),
+        );
+    }
+    return value;
+}
+
+function api(env, opts) {
+    return request({
+        uri: `${env.portainerUrl}${opts.path}`,
+        method: opts.method || 'GET',
+        headers: { 'X-API-Key': env.apiKey, Accept: 'application/json', ...(opts.headers || {}) },
+        insecure: env.insecure,
+        body: opts.body,
+        responseType: opts.responseType,
+        signal: opts.signal,
+        resolveWithFullResponse: opts.full,
+    });
+}
+
+// Demux Docker's multiplexed log stream. Non-TTY containers prefix each frame
+// with 8 bytes: [stream:1][000][payload-len:4 BE]. Replaces the od/awk monster.
+function demuxDockerStream(buf) {
+    if (!buf || !buf.length) return '';
+    // A TTY/raw stream won't carry frame headers; the first byte is real text.
+    if (buf[0] > 2) return buf.toString('utf8');
+    let out = '';
+    let i = 0;
+    while (i + 8 <= buf.length) {
+        const len = buf.readUInt32BE(i + 4);
+        i += 8;
+        out += buf.toString('utf8', i, Math.min(i + len, buf.length));
+        i += len;
+    }
+    return out;
+}
+
+async function preflight(env) {
+    const missing = [];
+    if (!env.portainerUrl) missing.push('PORTAINER_API_ENDPOINT');
+    if (!env.apiKey) missing.push('PORTAINER_API_KEY');
+    if (missing.length) {
+        throw new Error(
+            `required environment variable(s) not set: ${missing.join(', ')}. `
+            + 'PORTAINER_API_ENDPOINT must include the /api suffix '
+            + '(e.g. https://portainer.example.com:9443/api); PORTAINER_API_KEY is a Portainer API token.',
+        );
+    }
+
+    const controller = new AbortController();
+    const timer = setTimeout(() => controller.abort(), 15000);
+    try {
+        await api(env, { path: '/endpoints', signal: controller.signal });
+    } catch (err) {
+        const status = err.response && err.response.status;
+        if (status === 401 || status === 403) {
+            throw new Error(
+                `Portainer rejected the API key (HTTP ${status}). `
+                + 'Check PORTAINER_API_KEY - it must be a valid, non-expired token.',
+            );
+        }
+        if (status === 404) {
+            throw new Error(
+                `Portainer returned HTTP 404 for "${env.portainerUrl}/endpoints". `
+                + 'Check that PORTAINER_API_ENDPOINT includes the /api suffix (e.g. https://host:9443/api).',
+            );
+        }
+        if (status) {
+            throw new Error(`unexpected HTTP ${status} from "${env.portainerUrl}/endpoints".`);
+        }
+        if (err.code && /CERT|SELF_SIGNED|VERIFY/i.test(err.code)) {
+            throw new Error(
+                `TLS certificate verification failed for "${env.portainerUrl}". Portainer is reachable but `
+                + 'presented a certificate that could not be verified (expected for a self-signed cert or an IP '
+                + 'address). If you trust this endpoint, set PORTAINER_INSECURE=true to skip verification.',
+            );
+        }
+        throw new Error(
+            `could not reach Portainer at "${env.portainerUrl}" (${err.code || err.message}). `
+            + 'Check PORTAINER_API_ENDPOINT (scheme, host, port) and network reachability.',
+        );
+    } finally {
+        clearTimeout(timer);
+    }
+}
+
+// Discover the environment that actually runs the container in this compose
+// project. No "local watcher == environment 1" assumption (the #97 root cause):
+// narrow by watcher name, fall back to a full scan, and match each candidate
+// against its live Docker proxy. Returns { endpointId, container }.
+async function discoverEndpoint(env, { containerName, composeProject, watcher }) {
+    const named = await api(env, { path: `/endpoints?name=${encodeURIComponent(watcher)}` });
+    requireArray(named, `listing Portainer environments named "${watcher}"`);
+
+    let candidateIds = named.map((e) => e.Id);
+    if (candidateIds.length === 0) {
+        const all = await api(env, { path: '/endpoints' });
+        requireArray(all, 'listing Portainer environments');
+        candidateIds = all.map((e) => e.Id);
+    }
+
+    for (const id of candidateIds) {
+        let containers;
+        try {
+            containers = await api(env, { path: `/endpoints/${id}/docker/containers/json?all=true` });
+        } catch (err) {
+            continue; // environment down/unreachable; try the next one
+        }
+        if (!Array.isArray(containers)) continue;
+        const match = containers.find((c) => (c.Names || []).includes(`/${containerName}`)
+            && (c.Labels || {})['com.docker.compose.project'] === composeProject);
+        if (match) return { endpointId: id, container: match };
+    }
+    return { endpointId: null, container: null };
+}
+
+async function getStackId(env, endpointId, resourceId) {
+    const filters = encodeURIComponent(JSON.stringify({ EndpointID: endpointId }));
+    const stacks = await api(env, { path: `/stacks?filters=${filters}` });
+    requireArray(stacks, `listing Portainer stacks on endpoint ${endpointId}`);
+    const stack = stacks.find((s) => s.ResourceControl && String(s.ResourceControl.Id) === String(resourceId));
+    return { stackId: stack ? stack.Id : null, env: stack ? stack.Env : undefined };
+}
+
+function rewriteStackFile({ stackFileContent, imageName, currentVersion, targetVersion }) {
+    const from = `${imageName}:${currentVersion}`;
+    const to = `${imageName}:${targetVersion}`;
+    if (!stackFileContent.includes(from)) {
+        const lines = stackFileContent.split('\n').filter((l) => l.includes(`${imageName}:`));
+        let hint = '';
+        if (/^sha256:/.test(currentVersion) || /^[0-9a-f]{12,}$/.test(currentVersion)) {
+            hint = `\nHosaka is watching this container by image DIGEST (a moving tag such as "latest"). `
+                + `It passed a digest ("${currentVersion}") instead of a version, and this updater cannot `
+                + `rewrite a moving tag. Pin an explicit version in your stack (e.g. "${imageName}:1.2.3").`;
+        } else if (lines.some((l) => MOVING_TAGS.test(l))) {
+            hint = `\nYour stack pins a moving tag for this image. This updater only works with explicit version `
+                + `tags. Replace the moving tag with a specific version (e.g. "${imageName}:1.2.3").`;
+        }
+        const lineList = lines.length
+            ? `\nLines referencing "${imageName}":\n${lines.map((l) => `  ${l.trim()}`).join('\n')}`
+            : `\nNo lines referencing "${imageName}" were found - check the image name matches your compose file.`;
+        throw new Error(
+            `could not find "${from}" in the stack file. The updater rewrites a pinned image tag, so the stack `
+            + `must pin the exact current version.${hint}${lineList}`,
+        );
+    }
+    const updated = stackFileContent.split(from).join(to);
+    if (!updated.includes(to)) {
+        throw new Error('stack file was not successfully updated with the target version.');
+    }
+    return updated;
+}
+
+async function inspectContainer(env, endpointId, containerName) {
+    const list = await api(env, { path: `/endpoints/${endpointId}/docker/containers/json?all=true` });
+    if (!Array.isArray(list)) return null;
+    const found = list.find((c) => (c.Names || []).includes(`/${containerName}`));
+    if (!found) return null;
+    return api(env, { path: `/endpoints/${endpointId}/docker/containers/${found.Id}/json` });
+}
+
+// ready | unhealthy | sameimage | waiting | absent
+async function checkContainerState(env, endpointId, containerName, expectedImage, initialImageId) {
+    const info = await inspectContainer(env, endpointId, containerName);
+    if (!info) return 'absent';
+    const runningImageName = lastSegment(info.Config && info.Config.Image);
+    const state = info.State && info.State.Status;
+    const currentImageId = info.Image;
+    const health = (info.State && info.State.Health && info.State.Health.Status) || 'none';
+    if (runningImageName === expectedImage && state === 'running') {
+        if (health === 'unhealthy') return 'unhealthy';
+        if (health === 'starting') return 'waiting';
+        if (initialImageId && currentImageId === initialImageId) return 'sameimage';
+        return 'ready';
+    }
+    return 'waiting';
+}
+
+async function fetchContainerLogs(env, endpointId, containerName, lines, emit) {
+    emit(`Fetching last ${lines} lines of logs for "${containerName}"...`);
+    const list = await api(env, { path: `/endpoints/${endpointId}/docker/containers/json?all=true` });
+    if (!Array.isArray(list)) return;
+    const found = list.find((c) => (c.Names || []).includes(`/${containerName}`));
+    if (!found) {
+        emit(`  Could not find container ID for "${containerName}"`);
+        return;
+    }
+    const raw = await api(env, {
+        path: `/endpoints/${endpointId}/docker/containers/${found.Id}/logs?stdout=true&stderr=true&tail=${lines}`,
+        responseType: 'arraybuffer',
+    });
+    const text = demuxDockerStream(Buffer.from(raw)).split('\n').slice(-lines).join('\n');
+    if (text.trim()) {
+        emit('Container logs:');
+        emit('----------------------------------------');
+        text.split('\n').forEach((l) => emit(l));
+        emit('----------------------------------------');
+    } else {
+        emit('  No logs available or error fetching logs');
+    }
+}
+
+// Wait for the container to reach the target image, driven by the live Docker
+// event stream with a periodic inspect backstop (events can be missed) and an
+// overall timeout. Resolves on success; throws on unhealthy/timeout.
+function waitForContainerUpdate(env, { endpointId, containerName, expectedImage, timeoutSec, initialImageId, pollIntervalSec }, emit) {
+    return new Promise((resolve, reject) => {
+        const controller = new AbortController();
+        let settled = false;
+        const since = nowSec();
+        const filters = encodeURIComponent(JSON.stringify({ container: [containerName] }));
+
+        emit(`\nUpdate initiated - waiting for "${containerName}" to reach image "${expectedImage}" (timeout ${timeoutSec}s)`);
+        emit('Streaming live Docker events (inspect backstop every 10s)...');
+
+        const cleanup = () => {
+            clearTimeout(overall);
+            clearInterval(backstop);
+            controller.abort();
+        };
+        const done = (rc) => { if (settled) return; settled = true; cleanup(); resolve(rc); };
+        const fail = (err) => { if (settled) return; settled = true; cleanup(); reject(err); };
+
+        const verify = async () => {
+            if (settled) return;
+            let st;
+            try {
+                st = await checkContainerState(env, endpointId, containerName, expectedImage, initialImageId);
+            } catch (err) {
+                return; // transient inspect error; backstop will retry
+            }
+            if (st === 'ready') {
+                emit(`  Container running target image and healthy: ${expectedImage}`);
+                done('ready');
+            } else if (st === 'sameimage') {
+                emit('  WARNING: running target tag but image ID unchanged - may have already been at target');
+                done('sameimage');
+            } else if (st === 'unhealthy') {
+                fail(new Error('container running but health check is unhealthy'));
+            }
+        };
+
+        const overall = setTimeout(
+            () => fail(new Error(`Timeout waiting for container update after ${timeoutSec}s`)),
+            timeoutSec * 1000,
+        );
+        const backstop = setInterval(() => { verify(); }, 10000);
+
+        api(env, {
+            path: `/endpoints/${endpointId}/docker/events?since=${since}&filters=${filters}`,
+            responseType: 'stream',
+            signal: controller.signal,
+            full: true,
+        }).then(({ body: stream }) => {
+            const rl = readline.createInterface({ input: stream });
+            rl.on('line', (line) => {
+                let ev;
+                try { ev = JSON.parse(line); } catch (err) { return; }
+                const action = ev.Action || ev.status || '';
+                const img = (ev.Actor && ev.Actor.Attributes && ev.Actor.Attributes.image) || '';
+                if (!action || /^exec_/.test(action)) return;
+                if (/^(start|create|stop|kill|destroy|restart|die|oom|rename|health_status)/.test(action)) {
+                    emit(`  - ${action}${img ? ` (${img})` : ''}`);
+                }
+                if (action === 'start' || /^health_status/.test(action)) {
+                    verify();
+                }
+            });
+            stream.on('error', () => { /* aborted on settle, or stream dropped; backstop covers it */ });
+        }).catch(() => {
+            // Event stream could not be opened; fall back to the inspect backstop.
+            if (!settled) emit('  (event stream unavailable - falling back to inspect polling)');
+        });
+
+        // Kick an immediate inspect so an already-complete update resolves fast.
+        verify();
+    });
+}
+
+async function waitOldContainerGone(env, { endpointId, oldImage, timeoutSec, pollIntervalSec }, emit) {
+    emit(`\nensuring the old container is no longer present...`);
+    const start = nowSec();
+    let waited = false;
+    while (nowSec() - start < timeoutSec) {
+        const list = await api(env, { path: `/endpoints/${endpointId}/docker/containers/json?all=true` });
+        const count = Array.isArray(list)
+            ? list.filter((c) => String(c.Image).endsWith(oldImage)).length
+            : 0;
+        if (count === 0) {
+            if (waited) emit(`old container removed after ${nowSec() - start}s`);
+            emit(`no containers are running with the old image version: ${oldImage}`);
+            return;
+        }
+        waited = true;
+        emit(`old container with image "${oldImage}" still present, waiting for cleanup... (elapsed: ${nowSec() - start}s)`);
+        await new Promise((r) => setTimeout(r, pollIntervalSec * 1000));
+    }
+    emit(`WARNING: old container "${oldImage}" still present after ${timeoutSec}s`);
+}
+
+/**
+ * Run the full Portainer stack update for one container.
+ * @param {object} params { containerName, imageName, currentVersion, targetVersion, watcher, composeProject, timeout, pollInterval }
+ * @param {function} emitLine emit one progress line to the UI / console
+ */
+async function runPortainerUpdate(params, emitLine) {
+    const emit = typeof emitLine === 'function' ? emitLine : () => {};
+    const env = readEnv();
+    const {
+        containerName, imageName, currentVersion, targetVersion, watcher, composeProject,
+    } = params;
+    const timeoutSec = Math.round((params.timeout || 300000) / 1000);
+    const pollIntervalSec = params.pollInterval || 5;
+
+    if (!containerName || !imageName || !currentVersion || !targetVersion || !composeProject) {
+        throw new Error(
+            'missing required argument(s). An empty value usually means the container is missing version or '
+            + 'compose-project metadata Hosaka could not resolve.',
+        );
+    }
+
+    await preflight(env);
+
+    emit(`\ncontainer name: ${containerName}`);
+    emit(`image name: ${imageName}`);
+    emit(`current version: ${currentVersion}`);
+    emit(`desired upgrade version: ${targetVersion}`);
+    emit(`compose project name: ${composeProject}`);
+
+    emit(`\nretrieving portainer info for container "${containerName}" in stack "${composeProject}"...`);
+    const { endpointId, container } = await discoverEndpoint(env, { containerName, composeProject, watcher });
+    if (!endpointId) {
+        throw new Error(
+            `could not determine the Portainer endpoint for watcher "${watcher}". No environment matching `
+            + `"${watcher}" has a container "${containerName}" in project "${composeProject}". Check that the `
+            + 'Hosaka watcher name matches the Portainer environment, and that the container is Portainer-managed.',
+        );
+    }
+    emit(`container endpoint id: ${endpointId}`);
+
+    const resourceId = container.Portainer && container.Portainer.ResourceControl && container.Portainer.ResourceControl.Id;
+    if (resourceId === undefined || resourceId === null) {
+        throw new Error(
+            `could not find Portainer stack ownership for "${containerName}" on endpoint ${endpointId}. This `
+            + 'updater only works on containers deployed as part of a Portainer stack. If it is a standalone '
+            + 'container or was created outside Portainer, it cannot be updated this way.',
+        );
+    }
+    emit(`container resource id: ${resourceId}`);
+
+    const { stackId, env: stackEnv } = await getStackId(env, endpointId, resourceId);
+    if (!stackId) {
+        throw new Error(
+            `no Portainer stack found for "${containerName}" on endpoint ${endpointId} (resource id ${resourceId}). `
+            + `Confirm "${composeProject}" is a Portainer-managed stack on this environment.`,
+        );
+    }
+    emit(`container stack id: ${stackId}`);
+
+    const stackFile = await api(env, { path: `/stacks/${stackId}/file` });
+    const stackFileContent = stackFile && stackFile.StackFileContent;
+    if (!stackFileContent) {
+        throw new Error(`${composeProject} stack file contents were not retrieved successfully.`);
+    }
+    emit(`${composeProject} stack file contents retrieved successfully from portainer API`);
+
+    emit(`\nupdating ${composeProject} stack file data with upgrade version: ${targetVersion}`);
+    const updatedStackFile = rewriteStackFile({ stackFileContent, imageName, currentVersion, targetVersion });
+    emit(`successfully updated ${composeProject} stack data with ${targetVersion}`);
+
+    emit('\ncapturing initial container state...');
+    let initialImageId = '';
+    const initial = await inspectContainer(env, endpointId, containerName);
+    if (initial) {
+        initialImageId = initial.Image;
+        emit(`initial container image: ${lastSegment(initial.Config && initial.Config.Image)}`);
+        emit(`initial container state: ${initial.State && initial.State.Status}`);
+        emit(`initial image ID: ${String(initialImageId).slice(0, 19)}...`);
+    } else {
+        emit(`WARNING: could not find container "${containerName}" before update`);
+    }
+
+    emit(`\npushing ${composeProject} stack file update to portainer...`);
+    let putResponse;
+    try {
+        putResponse = await api(env, {
+            path: `/stacks/${stackId}?endpointId=${endpointId}`,
+            method: 'PUT',
+            headers: { 'Content-Type': 'application/json' },
+            body: { env: stackEnv || [], prune: true, pullImage: false, stackFileContent: updatedStackFile },
+            full: true,
+        });
+    } catch (err) {
+        const status = err.response && err.response.status;
+        const detail = err.response && err.response.data;
+        throw new Error(
+            `failed to push update to portainer (HTTP ${status || 'n/a'})`
+            + (detail ? `: ${typeof detail === 'string' ? detail : JSON.stringify(detail)}` : ''),
+        );
+    }
+    emit(`\nstack update successfully pushed to portainer (http ${putResponse.statusCode})`);
+    emit('note: portainer is now processing the update asynchronously...');
+
+    const expectedImage = `${imageName}:${targetVersion}`;
+    try {
+        await waitForContainerUpdate(env, {
+            endpointId, containerName, expectedImage, timeoutSec, initialImageId, pollIntervalSec,
+        }, emit);
+    } catch (err) {
+        emit(`\nERROR: ${err.message}`);
+        await fetchContainerLogs(env, endpointId, containerName, 30, emit).catch(() => {});
+        throw err;
+    }
+
+    await waitOldContainerGone(env, {
+        endpointId, oldImage: `${imageName}:${currentVersion}`, timeoutSec, pollIntervalSec,
+    }, emit);
+
+    emit('\nupdate verification completed successfully.');
+}
+
+module.exports = runPortainerUpdate;
+module.exports.internals = {
+    requireArray, demuxDockerStream, rewriteStackFile, discoverEndpoint, checkContainerState, readEnv,
+};

--- a/app/triggers/providers/script/portainerUpdate.js
+++ b/app/triggers/providers/script/portainerUpdate.js
@@ -341,8 +341,11 @@ async function runPortainerUpdate(params, emitLine) {
     const {
         containerName, imageName, currentVersion, targetVersion, watcher, composeProject,
     } = params;
-    const timeoutSec = Math.round((params.timeout || 300000) / 1000);
-    const pollIntervalSec = params.pollInterval || 5;
+    // UPDATE_TIMEOUT / POLL_INTERVAL env vars override, matching the bash script;
+    // otherwise fall back to the trigger TIMEOUT and a 5s poll.
+    const timeoutSec = parseInt(process.env.UPDATE_TIMEOUT, 10)
+        || Math.round((params.timeout || 300000) / 1000);
+    const pollIntervalSec = parseInt(process.env.POLL_INTERVAL, 10) || params.pollInterval || 5;
 
     if (!containerName || !imageName || !currentVersion || !targetVersion || !composeProject) {
         throw new Error(

--- a/app/triggers/providers/script/portainerUpdate.js
+++ b/app/triggers/providers/script/portainerUpdate.js
@@ -2,17 +2,10 @@ const readline = require('readline');
 const request = require('../../../request');
 
 /**
- * Native Node port of scripts/portainer_stack_update.sh.
- *
- * Edits a container's Portainer stack file (image:current -> image:target) and
- * PUTs a stack update, then watches the container reach the target image via the
- * Portainer-proxied Docker event stream (with an inspect-poll backstop). All
- * HTTP goes through the shared axios adapter; JSON is handled natively, so the
- * jq/curl shape bugs the bash version suffered from (issue #97) cannot recur.
- *
- * Talks to Portainer through PORTAINER_API_ENDPOINT / PORTAINER_API_KEY (and the
- * opt-in PORTAINER_INSECURE for self-signed / IP endpoints), read from the
- * container environment exactly as the bash script did.
+ * Native Node port of scripts/portainer_stack_update.sh: rewrites a container's
+ * Portainer stack file (image:current -> image:target), PUTs the update, and
+ * watches the container reach the target image. Reads PORTAINER_API_ENDPOINT /
+ * PORTAINER_API_KEY / PORTAINER_INSECURE from the environment.
  */
 
 const MOVING_TAGS = /:(latest|stable|edge|main|master|nightly|rolling|dev)(["'\s]|$)/;
@@ -33,10 +26,9 @@ function lastSegment(imageRef) {
     return String(imageRef).split('/').pop();
 }
 
-// A Portainer/Docker proxy list endpoint must return a JSON array. On failure it
-// returns an object like { message: "..." }; surface the real reason instead of
-// letting downstream array access produce a cryptic error (this is the #97 fix,
-// now structural rather than a guard bolted onto a jq pipeline).
+// Proxy list endpoints return a JSON array; on failure they return an object
+// like { message: "..." }. Surface that instead of a cryptic downstream array
+// error (issue #97).
 function requireArray(value, context) {
     if (!Array.isArray(value)) {
         const msg = value && (value.message || value.details);
@@ -61,11 +53,11 @@ function api(env, opts) {
     });
 }
 
-// Demux Docker's multiplexed log stream. Non-TTY containers prefix each frame
-// with 8 bytes: [stream:1][000][payload-len:4 BE]. Replaces the od/awk monster.
+// Demux Docker's multiplexed log stream: non-TTY containers prefix each frame
+// with 8 bytes [stream:1][000][payload-len:4 BE].
 function demuxDockerStream(buf) {
     if (!buf || !buf.length) return '';
-    // A TTY/raw stream won't carry frame headers; the first byte is real text.
+    // A TTY/raw stream has no frame headers; its first byte is real text.
     if (buf[0] > 2) return buf.toString('utf8');
     let out = '';
     let i = 0;
@@ -127,10 +119,8 @@ async function preflight(env) {
     }
 }
 
-// Discover the environment that actually runs the container in this compose
-// project. No "local watcher == environment 1" assumption (the #97 root cause):
-// narrow by watcher name, fall back to a full scan, and match each candidate
-// against its live Docker proxy. Returns { endpointId, container }.
+// Discover the environment that actually runs the container; never assume the
+// "local" watcher maps to environment 1 (the original #97 root cause).
 async function discoverEndpoint(env, { containerName, composeProject, watcher }) {
     const named = await api(env, { path: `/endpoints?name=${encodeURIComponent(watcher)}` });
     requireArray(named, `listing Portainer environments named "${watcher}"`);
@@ -147,7 +137,7 @@ async function discoverEndpoint(env, { containerName, composeProject, watcher })
         try {
             containers = await api(env, { path: `/endpoints/${id}/docker/containers/json?all=true` });
         } catch (err) {
-            continue; // environment down/unreachable; try the next one
+            continue;
         }
         if (!Array.isArray(containers)) continue;
         const match = containers.find((c) => (c.Names || []).includes(`/${containerName}`)
@@ -243,9 +233,8 @@ async function fetchContainerLogs(env, endpointId, containerName, lines, emit) {
     }
 }
 
-// Wait for the container to reach the target image, driven by the live Docker
-// event stream with a periodic inspect backstop (events can be missed) and an
-// overall timeout. Resolves on success; throws on unhealthy/timeout.
+// Wait for the container to reach the target image via the live Docker event
+// stream, with an inspect backstop (events can be missed) and an overall timeout.
 function waitForContainerUpdate(env, { endpointId, containerName, expectedImage, timeoutSec, initialImageId, pollIntervalSec }, emit) {
     return new Promise((resolve, reject) => {
         const controller = new AbortController();
@@ -309,13 +298,13 @@ function waitForContainerUpdate(env, { endpointId, containerName, expectedImage,
                     verify();
                 }
             });
-            stream.on('error', () => { /* aborted on settle, or stream dropped; backstop covers it */ });
+            // A settle aborts the stream; the backstop covers any other drop.
+            stream.on('error', () => {});
         }).catch(() => {
-            // Event stream could not be opened; fall back to the inspect backstop.
             if (!settled) emit('  (event stream unavailable - falling back to inspect polling)');
         });
 
-        // Kick an immediate inspect so an already-complete update resolves fast.
+        // Resolve fast if the update is already complete.
         verify();
     });
 }

--- a/app/triggers/providers/script/portainerUpdate.test.js
+++ b/app/triggers/providers/script/portainerUpdate.test.js
@@ -1,0 +1,137 @@
+const request = require('../../../request');
+const runPortainerUpdate = require('./portainerUpdate');
+
+const {
+    requireArray, demuxDockerStream, rewriteStackFile, discoverEndpoint, checkContainerState,
+} = runPortainerUpdate.internals;
+
+jest.mock('../../../request');
+
+const env = { portainerUrl: 'http://portainer/api', apiKey: 'key', insecure: false };
+
+// Route mocked request() calls by the path suffix of opts.uri.
+function route(map) {
+    request.mockImplementation(async (opts) => {
+        const path = opts.uri.replace(env.portainerUrl, '');
+        for (const [matcher, value] of map) {
+            if (matcher instanceof RegExp ? matcher.test(path) : path === matcher) {
+                if (value instanceof Error) throw value;
+                return typeof value === 'function' ? value(opts) : value;
+            }
+        }
+        throw new Error(`unmocked path: ${path}`);
+    });
+}
+
+beforeEach(() => {
+    request.mockReset();
+});
+
+describe('requireArray', () => {
+    test('passes arrays through', () => {
+        expect(requireArray([1, 2], 'x')).toEqual([1, 2]);
+    });
+    test('surfaces a Portainer error message on a non-array object', () => {
+        expect(() => requireArray({ message: 'endpoint not found' }, 'inspecting foo'))
+            .toThrow(/inspecting foo: endpoint not found/);
+    });
+    test('falls back to a generic message when none is present', () => {
+        expect(() => requireArray('<html>502</html>', 'listing stacks'))
+            .toThrow(/was not a JSON array/);
+    });
+});
+
+describe('demuxDockerStream', () => {
+    test('decodes a multiplexed frame', () => {
+        const payload = Buffer.from('hello world');
+        const header = Buffer.from([1, 0, 0, 0, 0, 0, 0, payload.length]);
+        expect(demuxDockerStream(Buffer.concat([header, payload]))).toBe('hello world');
+    });
+    test('passes raw/TTY output through unframed', () => {
+        expect(demuxDockerStream(Buffer.from('plain log line'))).toBe('plain log line');
+    });
+});
+
+describe('rewriteStackFile', () => {
+    const base = { imageName: 'it-tools', currentVersion: '1.0', targetVersion: '2.0' };
+    test('rewrites the pinned tag', () => {
+        const out = rewriteStackFile({ ...base, stackFileContent: 'image: ghcr.io/c/it-tools:1.0\n' });
+        expect(out).toContain('ghcr.io/c/it-tools:2.0');
+        expect(out).not.toContain('it-tools:1.0');
+    });
+    test('throws an actionable error when the current tag is absent', () => {
+        expect(() => rewriteStackFile({ ...base, stackFileContent: 'image: ghcr.io/c/it-tools:0.9\n' }))
+            .toThrow(/could not find "it-tools:1.0"/);
+    });
+    test('hints when the stack pins a moving tag', () => {
+        expect(() => rewriteStackFile({ ...base, stackFileContent: 'image: it-tools:latest\n' }))
+            .toThrow(/moving tag/);
+    });
+});
+
+describe('discoverEndpoint', () => {
+    const target = { containerName: 'it-tools', composeProject: 'it-tools', watcher: 'local' };
+
+    test('selects the endpoint whose proxy lists the container in the project', async () => {
+        route([
+            ['/endpoints?name=local', [{ Id: 1 }, { Id: 2 }]],
+            ['/endpoints/1/docker/containers/json?all=true', [{ Names: ['/other'], Labels: {} }]],
+            ['/endpoints/2/docker/containers/json?all=true', [{
+                Names: ['/it-tools'],
+                Labels: { 'com.docker.compose.project': 'it-tools' },
+                Portainer: { ResourceControl: { Id: 9 } },
+            }]],
+        ]);
+        const result = await discoverEndpoint(env, target);
+        expect(result.endpointId).toBe(2);
+        expect(result.container.Portainer.ResourceControl.Id).toBe(9);
+    });
+
+    test('falls back to a full scan when the name query is empty', async () => {
+        route([
+            ['/endpoints?name=local', []],
+            ['/endpoints', [{ Id: 5 }]],
+            ['/endpoints/5/docker/containers/json?all=true', [{
+                Names: ['/it-tools'],
+                Labels: { 'com.docker.compose.project': 'it-tools' },
+                Portainer: { ResourceControl: { Id: 3 } },
+            }]],
+        ]);
+        const result = await discoverEndpoint(env, target);
+        expect(result.endpointId).toBe(5);
+    });
+
+    // Issue #97: a non-array (error) proxy response must not crash discovery or
+    // be misreported - it is skipped, and a genuinely-absent container yields a
+    // clean null result that the caller turns into an actionable message.
+    test('skips an environment that returns a non-array error body (#97)', async () => {
+        route([
+            ['/endpoints?name=local', [{ Id: 1 }]],
+            ['/endpoints/1/docker/containers/json?all=true', { message: 'environment is down' }],
+        ]);
+        const result = await discoverEndpoint(env, target);
+        expect(result.endpointId).toBeNull();
+    });
+});
+
+describe('checkContainerState', () => {
+    const list = [{ Names: ['/c'], Id: 'abc' }];
+    function inspectRoute(info) {
+        route([
+            ['/endpoints/1/docker/containers/json?all=true', list],
+            ['/endpoints/1/docker/containers/abc/json', info],
+        ]);
+    }
+    test('reports ready when running the target image with a new image id', async () => {
+        inspectRoute({ Config: { Image: 'ghcr.io/x/c:2.0' }, State: { Status: 'running' }, Image: 'sha256:new' });
+        expect(await checkContainerState(env, 1, 'c', 'c:2.0', 'sha256:old')).toBe('ready');
+    });
+    test('reports sameimage when the image id is unchanged', async () => {
+        inspectRoute({ Config: { Image: 'ghcr.io/x/c:2.0' }, State: { Status: 'running' }, Image: 'sha256:old' });
+        expect(await checkContainerState(env, 1, 'c', 'c:2.0', 'sha256:old')).toBe('sameimage');
+    });
+    test('reports absent when the container is not listed', async () => {
+        route([['/endpoints/1/docker/containers/json?all=true', []]]);
+        expect(await checkContainerState(env, 1, 'c', 'c:2.0', '')).toBe('absent');
+    });
+});

--- a/docker-compose.example.yml
+++ b/docker-compose.example.yml
@@ -38,21 +38,20 @@ services:
 
       # ── One-click updates (Portainer) ───────────────────────────────────────
       # This is on by default: it puts an "Update" button on every container in the
-      # UI. The bundled script (image: /scripts/portainer_stack_update.sh) rewrites
-      # the container's Portainer stack to the new tag and redeploys via the
-      # Portainer API. INSTALL=true is all the button needs.
+      # UI. The built-in updater rewrites the container's Portainer stack to the new
+      # tag and redeploys via the Portainer API. INSTALL=true is all the button needs.
       #
       # >>> To make the button actually WORK, set the two vars below. <<<
       # Until you do, the button still shows; clicking it just reports a friendly
       # "set PORTAINER_API_ENDPOINT / PORTAINER_API_KEY" error in the UI log. These
-      # are plain env vars read by the script (not HOSAKA_*).
+      # are plain env vars read by the updater (not HOSAKA_*).
       - HOSAKA_TRIGGER_SCRIPT_PORTAINER_INSTALL=true
       # - PORTAINER_API_ENDPOINT=https://portainer.example.com:9443/api   # must include /api
       # - PORTAINER_API_KEY=ptr_xxxxxxxxxxxxxxxx                          # Portainer access token
       # - PORTAINER_INSECURE=true                                         # skip TLS verify (self-signed cert / IP)
-      # - UPDATE_TIMEOUT=300                                              # script: wait for healthy (s)
-      # - POLL_INTERVAL=5                                                 # script: health poll interval (s)
-      # - HOSAKA_TRIGGER_SCRIPT_PORTAINER_TIMEOUT=300000                  # hard kill the script after (ms)
+      # - UPDATE_TIMEOUT=300                                              # wait for healthy (s)
+      # - POLL_INTERVAL=5                                                 # health poll interval (s)
+      # - HOSAKA_TRIGGER_SCRIPT_PORTAINER_TIMEOUT=300000                  # time out the update after (ms)
       # Only ONE trigger may have install=true, else the button is disabled.
       # To turn the button off entirely, comment out the INSTALL line above.
 
@@ -149,7 +148,7 @@ services:
       # - HOSAKA_TRIGGER_<TYPE>_<NAME>_MODE=simple     # simple (per container) | batch (one digest)
       # - HOSAKA_TRIGGER_<TYPE>_<NAME>_ONCE=true       # fire only on first detection per update
       #
-      # Bundled Portainer one-click updater: configured in the "One-click updates"
+      # Built-in Portainer one-click updater: configured in the "One-click updates"
       # section near the top of this file (on by default).
       #
       # Docker auto-update (pull + recreate the container in place):

--- a/docs/README.md
+++ b/docs/README.md
@@ -32,9 +32,9 @@ See [How it works](how-it-works/) for the full watch-and-update cycle.
 
 ## Fork highlights
 
-- **One-click updates from the UI**, with the update script's output streamed
+- **One-click updates from the UI**, with the updater's output streamed
   live, line by line.
-- **A bundled Portainer stack updater**: rewrites the stack file to the new image
+- **A built-in Portainer stack updater**: rewrites the stack file to the new image
   tag and redeploys through the Portainer API, so your stack stays the source of
   truth and rollback is just redeploying the old tag.
 - **A responsive UI** that works on mobile, with live container state over SSE.

--- a/docs/configuration/triggers/script/README.md
+++ b/docs/configuration/triggers/script/README.md
@@ -1,9 +1,10 @@
 # Script
 
-The `script` trigger executes a local script file mounted inside the Hosaka container.
+The `script` trigger runs an action when an update is found: either Hosaka's
+built-in Portainer updater (the default) or a local script file you mount in.
 
-> Hosaka ships a ready-to-use Portainer update script as the default. If you just
-> want one-click Portainer updates, see [Portainer update script](configuration/triggers/script/portainer.md)
+> Hosaka's built-in Portainer updater is the default. If you just want one-click
+> Portainer updates, see [Portainer update script](configuration/triggers/script/portainer.md)
 > - you do not need to set `PATH` or mount anything.
 
 ## Notify mode vs install mode
@@ -23,10 +24,10 @@ configuring more than one causes the UI to surface an error.
 
 ## Live script output
 
-In install mode, the script's stdout and stderr are streamed line-by-line to the
-UI in real time over a Server-Sent Events connection. A console dialog opens
-automatically when the install starts and stays open until the script exits,
-letting you watch progress without polling.
+In install mode, the update output is streamed line-by-line to the UI in real
+time over a Server-Sent Events connection (for an external script, that is its
+stdout and stderr). A console dialog opens automatically when the install starts
+and stays open until the run finishes, letting you watch progress without polling.
 
 ## Script parameters
 
@@ -46,7 +47,7 @@ Supported shells for scripts are `/bin/bash`, `/bin/ash`, and `/bin/sh`.
 
 | Env var                                          |    Required    | Description                                                                                  | Supported values             | Default value when missing           |
 |--------------------------------------------------|:--------------:|----------------------------------------------------------------------------------------------|------------------------------|--------------------------------------|
-| `HOSAKA_TRIGGER_SCRIPT_{trigger_name}_PATH`      | :white_circle: | Absolute path to the script file inside the container. Omit to use the bundled Portainer script. | Any local path               | `/scripts/portainer_stack_update.sh` |
+| `HOSAKA_TRIGGER_SCRIPT_{trigger_name}_PATH`      | :white_circle: | Absolute path to a script file inside the container. Omit to use the built-in Portainer updater. | Any local path               | `built-in`                           |
 | `HOSAKA_TRIGGER_SCRIPT_{trigger_name}_INSTALL`   | :white_circle: | If `true`, switches to install mode (manual Update button only - see above)                  | `true`, `false`              | `false`                              |
 | `HOSAKA_TRIGGER_SCRIPT_{trigger_name}_TIMEOUT`   | :white_circle: | Milliseconds before the script execution is considered timed out                             | integer in ms                | `300000` (5 minutes)                 |
 

--- a/docs/configuration/triggers/script/portainer.md
+++ b/docs/configuration/triggers/script/portainer.md
@@ -1,15 +1,17 @@
 # Portainer update script
 
-Hosaka bundles a ready-to-use update script that performs in-place container
-updates through the Portainer API. It is shipped inside the image at
-`/scripts/portainer_stack_update.sh` and is the **default** script for the
-[`script` trigger](configuration/triggers/script/) - if you do not set a `PATH`,
-this is the script that runs.
+Hosaka has a built-in updater that performs in-place container updates through
+the Portainer API. It is the **default** action for the
+[`script` trigger](configuration/triggers/script/) - when `INSTALL=true` and you
+do not set a `PATH`, this is what runs, with nothing to write or mount. (A
+standalone copy of the equivalent script also ships in the image at
+`/scripts/portainer_stack_update.sh` if you want to point `PATH` at it or fork
+it.)
 
 ## How it works
 
 When you click **Update** on a container in the UI (the `script` trigger must
-have `INSTALL=true`), the script:
+have `INSTALL=true`), the updater:
 
 1. Locates the container's Portainer stack on the matching endpoint (using the
    watcher name and compose project passed in by Hosaka).
@@ -20,11 +22,11 @@ have `INSTALL=true`), the script:
    container is recreated on the target image and healthy.
 5. Confirms the old container is gone, then reports success.
 
-The full live log is streamed to the UI's script-output console.
+The full live log is streamed to the UI's update-output console.
 
 ## Designed for pinned versions
 
-This script is built for stacks that pin explicit image tags (for example
+This updater is built for stacks that pin explicit image tags (for example
 `nginx:1.27.1`) rather than moving tags like `latest`. That keeps you in control
 of updates: Hosaka detects a newer tag, and the update rewrites your stack file
 from the current pinned version to the new one. The stack definition always
@@ -33,27 +35,27 @@ roll back at any time by redeploying the previous tag.
 
 Because the update edits the stack file in place, that file **must contain the
 current `image:tag`** of the container being updated. If the stack pins a
-different tag, or uses a moving tag like `latest`, the script stops with an error
+different tag, or uses a moving tag like `latest`, the updater stops with an error
 rather than guessing - so pin the versions in your stack before using it.
 
 ## Configuration
 
 Two sets of variables are involved. The `HOSAKA_TRIGGER_SCRIPT_*` variables
 configure the generic trigger; the `PORTAINER_API_*` variables (and the optional
-timing ones) are read by the script itself.
+timing ones) are read by the updater itself.
 
 ### Trigger variables
 
 | Env var                                          |    Required    | Description                                                              | Default                                |
 |--------------------------------------------------|:--------------:|--------------------------------------------------------------------------|----------------------------------------|
 | `HOSAKA_TRIGGER_SCRIPT_{trigger_name}_INSTALL`   |  :red_circle:  | Set `true` to make this the manual "Update" button trigger in the UI\*   | `false`                                |
-| `HOSAKA_TRIGGER_SCRIPT_{trigger_name}_PATH`      | :white_circle: | Override the script. Omit to use the bundled Portainer script.           | `/scripts/portainer_stack_update.sh`   |
+| `HOSAKA_TRIGGER_SCRIPT_{trigger_name}_PATH`      | :white_circle: | Omit to use the built-in updater; set to a script path to run your own.   | `built-in`                             |
 | `HOSAKA_TRIGGER_SCRIPT_{trigger_name}_TIMEOUT`   | :white_circle: | Milliseconds before the trigger considers the script timed out.          | `300000` (5 minutes)                   |
 
 \* Only one `INSTALL` trigger may exist across all triggers; setting more than
 one makes the UI throw an error.
 
-### Script variables (read by the bundled script)
+### Portainer variables (read by the updater)
 
 | Env var                   |    Required    | Description                                                                            | Default |
 |---------------------------|:--------------:|---------------------------------------------------------------------------------------|---------|
@@ -88,8 +90,9 @@ services:
       - HOSAKA_TRIGGER_SCRIPT_PORTAINER_INSTALL=true
       - PORTAINER_API_ENDPOINT=https://portainer.example.com:9443/api
       - PORTAINER_API_KEY=ptr_xxxxxxxxxxxxxxxx
-      # PATH is optional; defaults to the bundled script:
-      # - HOSAKA_TRIGGER_SCRIPT_PORTAINER_PATH=/scripts/portainer_stack_update.sh
+      # PATH is optional; omit it to use the built-in updater. Set it only to
+      # run your own script instead:
+      # - HOSAKA_TRIGGER_SCRIPT_PORTAINER_PATH=/scripts/myscript.sh
 ```
 #### **Docker**
 ```bash
@@ -108,9 +111,5 @@ root (the Portainer script trigger is one of the documented sections there).
 
 Set `HOSAKA_TRIGGER_SCRIPT_{trigger_name}_PATH` to your own script's path and
 mount it in. See the [`script` trigger](configuration/triggers/script/) page for
-the arguments Hosaka passes.
-
-> **Mount caveat:** the bundled script lives at `/scripts/portainer_stack_update.sh`.
-> Bind-mounting an entire volume at `/scripts` shadows it. To keep the bundled
-> script available alongside your own, mount individual files
-> (`/host/mine.sh:/scripts/mine.sh`) rather than the whole directory.
+the arguments Hosaka passes. The bundled bash implementation still ships at
+`/scripts/portainer_stack_update.sh` if you want it as a starting point.


### PR DESCRIPTION
## Summary

Ports the Portainer stack-update logic from the bundled bash script (`scripts/portainer_stack_update.sh`) into a native Node module used by default by the `script` trigger. HTTP goes through the shared axios adapter, JSON is handled natively, and the Docker log demux uses `Buffer` frame parsing - so the jq/curl response-shape bugs the bash version suffered (e.g. #97) cannot recur, and the Portainer logic is unit-tested for the first time.

Follow-on to #98 (which fixed the endpoint-discovery bug in the bash script); this makes that whole class of bug structural.

## What changed

- **New `app/triggers/providers/script/portainerUpdate.js`** - native updater: preflight, endpoint discovery (no `local == env 1` assumption), stack-ownership lookup, stack-file rewrite, PUT, live Docker event-stream wait with an inspect backstop, and old-container-gone check. Surfaces the real Portainer API error on a non-array response.
- **`Script.js`** - the trigger `path` now defaults to the sentinel `built-in` (the Node updater). Any real `path` still execs an external script, so custom scripts keep working. The bundled `.sh` stays in the image as an opt-in / fork base.
- **Output** - each line is prefixed with an `HH:MM:SS` timestamp (was the container name), split so multi-line emits and blank separators render cleanly. The live-output UI streaming is preserved.
- **`request/index.js`** - adapter gains `insecure` / `responseType` / `signal` passthroughs (all off by default; `insecure` applies only when explicitly set, preserving the opt-in `PORTAINER_INSECURE` behaviour).
- **`UPDATE_TIMEOUT` / `POLL_INTERVAL`** - the built-in updater honours these env vars (falling back to the trigger `TIMEOUT` and a 5s poll), matching the bash so the documented variables keep working.
- **Docs** - trigger pages, the Portainer page, the compose example, and the README wording now describe the built-in updater as the default (`PATH` defaults to `built-in`); set `PATH` only to run your own script.

## Tests

- New `portainerUpdate.test.js`: endpoint discovery, the #97 non-array repro as a unit test, stack-file rewrite, log demux, and container-state checks.
- Full suite green: **47 suites / 459 tests**.

## Verification

Exercised end-to-end on the dev-test stack: rolled a real container back, then upgraded it through the built-in updater via `POST /api/containers/:id/install`. Confirmed native discovery, stack rewrite, event-stream wait to healthy, old-container cleanup, and live timestamped output streaming to the UI.