### PR TITLE
fix(prometheus): drop notification_timestamp from container gauge labels

### DIFF
--- a/app/prometheus/container.js
+++ b/app/prometheus/container.js
@@ -17,6 +17,7 @@ function populateGauge() {
       // Exclude notification fields from labels
       delete labels.notification_message;
       delete labels.notification_level;
+      delete labels.notification_timestamp;
 
       gaugeContainer.set(labels, 1);
     } catch (e) {

--- a/app/prometheus/container.test.js
+++ b/app/prometheus/container.test.js
@@ -58,6 +58,64 @@ test('gauge must be populated when containers are in the store', () => {
     }, 1);
 });
 
+test('gauge must exclude notification fields from labels', () => {
+    jest.useFakeTimers();
+    store.getContainers = () => ([
+        {
+            id: 'container-123456789',
+            name: 'test',
+            watcher: 'test',
+            image: {
+                id: 'image-123456789',
+                registry: {
+                    name: 'registry',
+                    url: 'https://hub',
+                },
+                name: 'organization/image',
+                tag: {
+                    value: 'version',
+                    semver: false,
+                },
+                digest: {
+                    watch: false,
+                    repo: undefined,
+                },
+                architecture: 'arch',
+                os: 'os',
+                created: '2021-06-12T05:33:38.440Z',
+            },
+            result: {
+                tag: 'version',
+            },
+            notification: {
+                message: 'an update is available',
+                level: 'info',
+                timestamp: 1623475418440,
+            },
+        },
+    ]);
+    const gauge = container.init();
+    const spySet = jest.spyOn(gauge, 'set');
+    jest.runOnlyPendingTimers();
+    expect(spySet).toHaveBeenCalledWith({
+        id: 'container-123456789',
+        image_architecture: 'arch',
+        image_created: '2021-06-12T05:33:38.440Z',
+        image_digest_repo: undefined,
+        image_digest_watch: false,
+        image_id: 'image-123456789',
+        image_name: 'organization/image',
+        image_os: 'os',
+        image_registry_name: 'registry',
+        image_registry_url: 'https://hub',
+        image_tag_semver: false,
+        image_tag_value: 'version',
+        name: 'test',
+        result_tag: 'version',
+        watcher: 'test',
+    }, 1);
+});
+
 test('gauge must warn when data don\'t match expected labels', () => {
     store.getContainers = () => ([{
         extra: 'extra',


### PR DESCRIPTION
## Problem

`populateGauge()` in `app/prometheus/container.js` excluded `notification_message` and `notification_level` from the flattened container labels but not `notification_timestamp`. The fork's notification object carries a `timestamp` field, so that label survived the flatten. It is not declared in the gauge `labelNames`, so prom-client throws:

```
Added label "notification_timestamp" is not included in initial labelset
```

This fires every 5s (the `setInterval(populateGauge, 5000)` cycle) for any container that has a notification set, e.g. after an install via the script trigger. Noisy logs, and the affected container is skipped from metrics that cycle.

## Fix

Delete `notification_timestamp` alongside the other two notification labels (matches the existing "exclude notification fields" intent).

## Verification

Added a test that sets a container notification with a timestamp and asserts the exact emitted label set (deep-equal, so a stray label fails it). All 3 `prometheus/container` tests pass in a clean `node:18-alpine` container.