### PR TITLE
fix(deps): bump joi to 17.13.4 for CVE-2026-48038

### DIFF
--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -23,7 +23,7 @@
         "express-session": "1.19.0",
         "flat": "5.0.2",
         "getmac": "6.6.0",
-        "joi": "17.13.3",
+        "joi": "17.13.4",
         "joi-cron-expression": "1.0.1",
         "just-debounce": "1.1.0",
         "kafkajs": "2.2.4",
@@ -9237,9 +9237,9 @@
       }
     },
     "node_modules/joi": {
-      "version": "17.13.3",
-      "resolved": "https://registry.npmjs.org/joi/-/joi-17.13.3.tgz",
-      "integrity": "sha512-otDA4ldcIx+ZXsKHWmp0YizCweVRZG96J10b0FevjfuncLO1oX59THoAmHkNubYJ+9gWsYsp5k8v4ib6oDv1fA==",
+      "version": "17.13.4",
+      "resolved": "https://registry.npmjs.org/joi/-/joi-17.13.4.tgz",
+      "integrity": "sha512-1RuuER6kmt8K8I3nIWvPZKi5RQCb568ZPyY4Pwjlua+yo+63ZTmIwxLZH0heBmiKN4uxjvCiarDrjaeH84xicQ==",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@hapi/hoek": "^9.3.0",

--- a/app/package.json
+++ b/app/package.json
@@ -27,7 +27,7 @@
     "express-session": "1.19.0",
     "flat": "5.0.2",
     "getmac": "6.6.0",
-    "joi": "17.13.3",
+    "joi": "17.13.4",
     "joi-cron-expression": "1.0.1",
     "just-debounce": "1.1.0",
     "kafkajs": "2.2.4",


### PR DESCRIPTION
## Problem

`joi` < 17.13.4 throws an uncaught `RangeError` on deeply nested input passed through recursive `link()` schemas (CVE-2026-48038, GHSA-q7cg-457f-vx79, medium 5.3). The app ships joi 17.13.3 at runtime, so this surfaced as both a Dependabot alert (#123) and a Trivy code-scanning alert (#50).

## Fix

Patch bump joi 17.13.3 -> 17.13.4. The fix is a patch release with no API changes; the recursive-`link()` path no longer overflows.

## Verification

Lockfile regenerated, integrity hash updated. Full app suite green in a clean `node:18-alpine` container: 47 suites / 460 tests pass.