### PR TITLE
Phosphor glow and stable filter layout for Sprawl Terminal

### DIFF
--- a/ui/src/components/ContainerFilter.vue
+++ b/ui/src/components/ContainerFilter.vue
@@ -1,5 +1,5 @@
 <template>
-  <v-container fluid class="ma-0 mb-3 pa-0">
+  <v-container fluid class="filter-bar ma-0 mb-3 pa-0">
     <!-- Mobile: collapse the filters behind a toggle so the bar is a single
          compact row by default; keep Watch now always reachable. -->
     <div v-if="$vuetify.display.smAndDown" class="d-flex align-center mb-2">
@@ -23,7 +23,7 @@
     </div>
 
     <v-expand-transition>
-      <v-row dense v-show="$vuetify.display.mdAndUp || showFilters">
+      <v-row dense class="filter-row" v-show="$vuetify.display.mdAndUp || showFilters">
       <v-col cols="6" sm="4" md="2">
         <v-select
           :hide-details="true"
@@ -206,5 +206,37 @@ export default {
 <style scoped>
 .switch-top {
   margin-top: 4px;
+}
+
+/* Desktop filter layout. The equal-width Vuetify columns made the bar height
+   depend on the content width: when the nav rail expands it narrows the content,
+   the "Update available" switch label wrapped to two lines, the bar grew, and
+   the container list below it shifted down. Near the mobile breakpoint the same
+   squeeze collided the switch label into the Watch now button.
+   Fix: keep the bar on one row, give the switch and button fixed widths sized to
+   their content, and let the four selects flex to fill the rest. The bar height
+   then depends only on the window breakpoint (not the content width), so the rail
+   toggle never reflows it. The mobile layout (smAndDown) is a separate stacked
+   toggle and is unaffected. */
+@media (min-width: 960px) {
+  .filter-row {
+    flex-wrap: nowrap;
+  }
+  .filter-row > [class*="v-col"] {
+    flex: 1 1 0;
+    min-width: 0;
+    max-width: none;
+  }
+  /* Switch column: wide enough for the single-line "Update available" label. */
+  .filter-row > [class*="v-col"]:nth-child(5) {
+    flex: 0 0 180px;
+  }
+  /* Watch now button column. */
+  .filter-row > [class*="v-col"]:nth-child(6) {
+    flex: 0 0 130px;
+  }
+  .filter-row :deep(.v-switch .v-label) {
+    white-space: nowrap;
+  }
 }
 </style>

--- a/ui/src/components/ScriptOutputDialog.vue
+++ b/ui/src/components/ScriptOutputDialog.vue
@@ -387,6 +387,11 @@ export default {
   padding: 12px;
   margin: 0;
   line-height: 1.2;
+  /* Firefox ignores the ::-webkit-scrollbar rules below and would fall back to a
+     grey scrollbar; the standard properties theme it there too. */
+  scrollbar-width: thin;
+  scrollbar-color: rgba(var(--v-theme-on-surface), 0.35)
+    rgb(var(--v-theme-surface-light));
 }
 
 /* Wrap long lines instead of forcing horizontal scroll. */

--- a/ui/src/styles/cyberpunk.css
+++ b/ui/src/styles/cyberpunk.css
@@ -129,3 +129,84 @@ pre,
   filter: drop-shadow(0 0 4px rgba(255, 176, 0, 0.55))
     drop-shadow(0 0 10px rgba(255, 176, 0, 0.3));
 }
+
+/* ---- Sprawl Terminal: phosphor glow on the amber elements ----
+   Models a monochrome CRT: the bloom tracks how much "light" an element emits.
+   Text glyphs and solid amber fills emit the most (brighter glow); thin outlined
+   borders and hairlines emit little (subtle glow). Boxes get an inner AND outer
+   shadow so the bloom spills both ways and no edge stays razor-crisp. Structural
+   brown chrome (surfaces, dividers, the app-shell hairline) stays flat -- only
+   the phosphor colour blooms. */
+
+/* Text -- outer glow only (glyphs emit a moderate, even light). Covers the nav
+   icons + labels, the app-bar view title, and the console icons. */
+.v-theme--sprawl-terminal .v-navigation-drawer .v-icon,
+.v-theme--sprawl-terminal .console-window .v-icon {
+  text-shadow: 0 0 4px rgba(255, 176, 0, 0.5), 0 0 9px rgba(255, 176, 0, 0.28);
+}
+.v-theme--sprawl-terminal .v-navigation-drawer .nav-title,
+.v-theme--sprawl-terminal .v-app-bar .v-toolbar-title {
+  text-shadow: 0 0 4px rgba(255, 176, 0, 0.5), 0 0 9px rgba(255, 176, 0, 0.3);
+}
+
+/* Container-row chips. Outlined chips are a thin border + label, so a subtle
+   inner+outer bloom (little light). The filled `major` anchor emits across its
+   whole face -> brighter outer halo, no inner glow (amber-on-amber is moot and
+   its text is black). */
+.v-theme--sprawl-terminal .v-card .v-toolbar .v-chip {
+  text-shadow: 0 0 4px rgba(255, 176, 0, 0.45);
+  box-shadow: 0 0 5px rgba(255, 176, 0, 0.2),
+    inset 0 0 5px rgba(255, 176, 0, 0.13);
+}
+.v-theme--sprawl-terminal .v-card .v-toolbar .v-chip.sev-major {
+  text-shadow: none;
+  box-shadow: 0 0 10px rgba(255, 176, 0, 0.55), 0 0 4px rgba(255, 176, 0, 0.4);
+}
+
+/* Filter bar. Outlined selects get the thin-border inner+outer bloom. The
+   labels sit at 0.7 opacity, which dims their glow, so they need a higher alpha
+   to read. The filled Watch now button emits across its face -> brighter outer
+   halo. */
+.v-theme--sprawl-terminal .filter-bar .v-field {
+  border-radius: 4px;
+  box-shadow: 0 0 5px rgba(255, 176, 0, 0.2),
+    inset 0 0 5px rgba(255, 176, 0, 0.13);
+}
+.v-theme--sprawl-terminal .filter-bar .v-field__input,
+.v-theme--sprawl-terminal .filter-bar .v-label,
+.v-theme--sprawl-terminal .filter-bar .v-select__selection-text,
+.v-theme--sprawl-terminal .filter-bar .v-icon {
+  text-shadow: 0 0 4px rgba(255, 176, 0, 0.75), 0 0 9px rgba(255, 176, 0, 0.4);
+}
+.v-theme--sprawl-terminal .filter-bar .v-btn {
+  box-shadow: 0 0 10px rgba(255, 176, 0, 0.5), 0 0 4px rgba(255, 176, 0, 0.35);
+}
+
+/* Switch: the on-thumb is a solid amber dot (bright -> outer halo); the off
+   track is a thin dim bar (little light -> only a faint glow). */
+.v-theme--sprawl-terminal .v-switch .v-selection-control--dirty .v-switch__thumb {
+  box-shadow: 0 0 8px 1px rgba(255, 176, 0, 0.6);
+}
+.v-theme--sprawl-terminal
+  .v-switch
+  .v-selection-control:not(.v-selection-control--dirty)
+  .v-switch__track {
+  background-color: rgba(255, 176, 0, 0.3);
+  opacity: 1;
+  box-shadow: 0 0 4px rgba(255, 176, 0, 0.18);
+}
+
+/* Console: the screen text glows (outer); the window carries a soft inner
+   phosphor wash. Its outer frame is a thin 1px border, so its outer halo is
+   kept faint (a thin line emits little light). */
+.v-theme--sprawl-terminal .log-output {
+  text-shadow: 0 0 4px rgba(255, 176, 0, 0.4), 0 0 8px rgba(255, 176, 0, 0.2);
+  box-shadow: inset 0 0 24px rgba(255, 176, 0, 0.06),
+    0 0 4px rgba(255, 176, 0, 0.07);
+}
+/* The console action buttons ("Close Script Output" / "Close") are solid amber
+   fills -> bright outer halo, matching the other filled buttons. The text-only
+   X button keeps just its icon glow (covered by .console-window .v-icon). */
+.v-theme--sprawl-terminal .console-window .v-btn--variant-flat {
+  box-shadow: 0 0 10px rgba(255, 176, 0, 0.5), 0 0 4px rgba(255, 176, 0, 0.35);
+}


### PR DESCRIPTION
Polishes the Sprawl Terminal theme with a CRT phosphor bloom and fixes a couple of layout/theming gaps.

## Phosphor glow
A monochrome-CRT bloom on the theme's amber elements, with intensity scaled to how much "light" each emits:
- Text and solid amber fills (filled chips, the filled buttons, the on-switch thumb) get the brightest halo.
- Thin outlined borders and hairlines get only a faint halo.
- Boxes get an inner + outer shadow so no edge stays razor-crisp.
- Structural brown chrome (surfaces, dividers, the app-shell hairline) stays flat.

Covered surfaces: left-nav icons and labels, the app-bar view title, container-row chips, the filter controls, the switch, and the install console (window, text, and action buttons).

## Theming fixes
- Switch off-state track was grey; now a dim amber that matches the palette.
- Console scrollbar was grey; now amber. Uses the standard `scrollbar-color` so it themes in Firefox too, not just the webkit pseudo-elements.

## Filter layout stability
The desktop filter bar used equal-width grid columns, so its height depended on the content width. Expanding the nav rail narrowed the content, wrapped the "Update available" switch label to a second line, grew the bar, and nudged the container list down; near the mobile breakpoint the same squeeze collided the label into the Watch now button.

Fix: give the switch and Watch now button fixed widths and let the selects flex to fill. The bar height now depends only on the window breakpoint, so the rail toggle no longer reflows it and the controls no longer collide. Verified at 960 / 976 / 1241px in both rail states.

Verified live in the dev-test stack against the Sprawl Terminal theme.