### PR TITLE
fix(registry): skip manifest list entries without a platform

### DIFF
--- a/app/registries/Registry.js
+++ b/app/registries/Registry.js
@@ -142,7 +142,8 @@ class Registry extends Component {
                     log.debug(`Filter manifest for [arch=${image.architecture}, os=${image.os}, variant=${image.variant}]`);
                     let manifestFound;
                     const manifestFounds = responseManifests.manifests
-                        .filter((manifest) => manifest.platform.architecture === image.architecture
+                        .filter((manifest) => manifest.platform
+                            && manifest.platform.architecture === image.architecture
                             && manifest.platform.os === image.os);
 
                     // 1 manifest matching al least? Get the first one (better than nothing)

--- a/app/registries/Registry.test.js
+++ b/app/registries/Registry.test.js
@@ -99,6 +99,62 @@ test('getImageManifestDigest should return digest for application/vnd.docker.dis
         });
 });
 
+test('getImageManifestDigest should ignore manifest list entries without a platform (buildx attestation manifests)', () => {
+    const registryMocked = new Registry();
+    registryMocked.log = log;
+    registryMocked.callRegistry = (options) => {
+        if (options.headers.Accept === 'application/vnd.docker.distribution.manifest.list.v2+json, application/vnd.oci.image.index.v1+json') {
+            return {
+                schemaVersion: 2,
+                mediaType: 'application/vnd.oci.image.index.v1+json',
+                manifests: [
+                    {
+                        platform: {
+                            architecture: 'amd64',
+                            os: 'linux',
+                        },
+                        digest: 'digest_x',
+                        mediaType: 'application/vnd.oci.image.manifest.v1+json',
+                    },
+                    {
+                        // Attestation manifest pushed by buildx: no platform
+                        digest: 'digest_attestation',
+                        mediaType: 'application/vnd.oci.image.manifest.v1+json',
+                        annotations: {
+                            'vnd.docker.reference.type': 'attestation-manifest',
+                            'vnd.docker.reference.digest': 'digest_x',
+                        },
+                    },
+                ],
+            };
+        }
+        if (options.headers.Accept === 'application/vnd.oci.image.manifest.v1+json') {
+            return {
+                headers: {
+                    'docker-content-digest': '123456789',
+                },
+            };
+        }
+        throw new Error('Boom!');
+    };
+    expect(registryMocked.getImageManifestDigest({
+        name: 'image',
+        architecture: 'amd64',
+        os: 'linux',
+        tag: {
+            value: 'tag',
+        },
+        registry: {
+            url: 'url',
+        },
+    }))
+        .resolves
+        .toStrictEqual({
+            version: 2,
+            digest: '123456789',
+        });
+});
+
 test('getImageManifestDigest should return digest for application/vnd.docker.distribution.manifest.list.v2+json then application/vnd.docker.container.image.v1+json', () => {
     const registryMocked = new Registry();
     registryMocked.log = log;


### PR DESCRIPTION
## Problem

Reported in #103. Multi-arch images built with **buildx** push extra non-image entries into the OCI image index alongside the real per-arch manifests: provenance/SBOM **attestation manifests** and signature/referrer entries. Those entries have no `platform` object.

The digest resolver in `Registry.getImageManifestDigest()` filtered the manifest list with `manifest.platform.architecture === ...`, which threw:

```
Cannot read properties of undefined (reading 'architecture')
```

The throw aborts the whole lookup, so the watcher records a per-container error and the container is never checked. This hit exactly the ghcr.io/buildx images in the report (hosaka, profilarr, seerr) while single-arch images were unaffected.

## Fix

Guard the manifest-list filter on `manifest.platform` so platform-less attestation entries are skipped and the real arch manifest is selected. One-line change; the variant refinement downstream only runs over already-filtered entries so it stays safe.

## Verification

- Added a test reproducing the crash (manifest index with an attestation entry that has no `platform`) — fails on old code with the exact error, passes with the fix.
- Full backend suite green: 47 suites / 461 tests.
- Live dev-test watch cycle against ghcr.io buildx images that previously failed: zero `architecture` errors, affected containers now resolve their digest cleanly.

Note: the other failures in #103 (Docker Hub 429 rate-limits, lscr.io ETIMEDOUT, an unsupported gitlab registry, latest-only images) are environmental/config, not this bug.