### PR TITLE
Skip manifest fetch for regex-excluded tags

### DIFF
--- a/app/watchers/providers/docker/Docker.js
+++ b/app/watchers/providers/docker/Docker.js
@@ -767,7 +767,24 @@ async watchContainer(container, skipRegistryCheck = false) {
         if (container.image.digest.watch) {
             imageDigestMap = new Map();
 
-            for (const tag of tags) {
+            // Narrow the (serial, per-tag) manifest fetch by the container's
+            // include/exclude regex before hitting the registry. Only applied
+            // when those labels are set; without a regex the full tag set is
+            // kept so alias/digest resolution (e.g. a `latest` tag mapping to a
+            // concrete version) is unchanged. Always keep the current tag so
+            // the alias lookup for the running image still resolves.
+            let tagsToManifest = tags;
+            if (container.includeTags) {
+                const includeTagsRegex = new RegExp(container.includeTags);
+                tagsToManifest = tagsToManifest.filter((tag) => includeTagsRegex.test(tag));
+            }
+            if (container.excludeTags) {
+                const excludeTagsRegex = new RegExp(container.excludeTags);
+                tagsToManifest = tagsToManifest.filter((tag) => !excludeTagsRegex.test(tag));
+            }
+            const manifestTags = new Set([...tagsToManifest, container.image.tag.value]);
+
+            for (const tag of manifestTags) {
                 const digest = await registryProvider.getImageManifestDigest({
                     ...container.image,
                     tag: { value: tag },

--- a/app/watchers/providers/docker/Docker.test.js
+++ b/app/watchers/providers/docker/Docker.test.js
@@ -971,3 +971,23 @@ test('findNewVersion (case A) only manifests include-matching tags', async () =>
     // trailing top-candidate digest resolution).
     expect(new Set(counter.tags)).toEqual(new Set(['8.1.0', '8.0.1', '8.0.0']));
 });
+
+// Efficiency: excludeTags set without includeTags. Excluded tags are skipped,
+// and the current running tag is always kept (needed for the alias digest
+// lookup) even though there is no include regex.
+test('findNewVersion (exclude only) skips excluded tags but keeps current', async () => {
+    const { fn, counter } = countingManifest({});
+    hub.getImageManifestDigest = fn;
+    hub.getTags = () => (['8.2.0', '8.1.0', '8.0.0', '8.0.0-rc1', '8.1.0-rc2']);
+    const container = buildDigestWatchContainer({
+        excludeTags: '-rc',
+        image: { tag: { value: '8.0.0', semver: true } },
+    });
+
+    await docker.findNewVersion(container, docker.log);
+
+    expect(counter.tags).not.toContain('8.0.0-rc1');
+    expect(counter.tags).not.toContain('8.1.0-rc2');
+    expect(counter.tags).toContain('8.0.0');
+    expect(new Set(counter.tags)).toEqual(new Set(['8.2.0', '8.1.0', '8.0.0']));
+});

--- a/app/watchers/providers/docker/Docker.test.js
+++ b/app/watchers/providers/docker/Docker.test.js
@@ -946,3 +946,28 @@ test('findNewVersion (case C: semver no regex) resolves to highest tag', async (
         digest: 'sha256:7.8.9',
     });
 });
+
+// Efficiency: with an include regex set, the manifest loop must skip tags that
+// the regex excludes. Today it manifests every tag; after the reorder it must
+// only touch matching tags + the current tag (+ the trailing top-candidate
+// digest lookup).
+test('findNewVersion (case A) only manifests include-matching tags', async () => {
+    const { fn, counter } = countingManifest({});
+    hub.getImageManifestDigest = fn;
+    hub.getTags = () => (['9.0.0', '8.1.0', '8.0.1', '8.0.0', '7.9.9', 'latest', 'foo.sig']);
+    const container = buildDigestWatchContainer({
+        includeTags: '^8\\.',
+        image: { tag: { value: '8.0.0', semver: true } },
+    });
+
+    await docker.findNewVersion(container, docker.log);
+
+    // Non-matching tags must never be manifested.
+    expect(counter.tags).not.toContain('9.0.0');
+    expect(counter.tags).not.toContain('7.9.9');
+    expect(counter.tags).not.toContain('latest');
+    expect(counter.tags).not.toContain('foo.sig');
+    // Only the three 8.x tags get manifested ('8.1.0' is also re-fetched by the
+    // trailing top-candidate digest resolution).
+    expect(new Set(counter.tags)).toEqual(new Set(['8.1.0', '8.0.1', '8.0.0']));
+});

--- a/app/watchers/providers/docker/Docker.test.js
+++ b/app/watchers/providers/docker/Docker.test.js
@@ -855,3 +855,94 @@ test.each(digestToWatchTestCases)(
         expect(isDigestToWatch(item.label, item.semver)).toEqual(item.result);
     },
 );
+
+// --- manifest pre-filter reorder: shared helpers ---------------------------
+
+// A getImageManifestDigest fake that records every tag it is asked about.
+function countingManifest(digestByTag) {
+    const counter = { calls: 0, tags: [] };
+    const fn = async (image) => {
+        counter.calls += 1;
+        counter.tags.push(image.tag.value);
+        const digest = digestByTag[image.tag.value] || `sha256:${image.tag.value}`;
+        return { digest, version: 2 };
+    };
+    return { fn, counter };
+}
+
+function buildDigestWatchContainer(overrides = {}) {
+    const imageOverrides = overrides.image || {};
+    return {
+        id: 'id',
+        name: 'name',
+        watcher: 'test',
+        includeTags: undefined,
+        excludeTags: undefined,
+        transformTags: undefined,
+        ...overrides,
+        image: {
+            id: 'image-id',
+            name: 'organization/image',
+            registry: { name: 'hub', url: 'http://registry' },
+            tag: { value: '8.0.0', semver: true },
+            digest: { watch: true, value: 'xxx', repo: 'yyy' },
+            architecture: 'arch',
+            os: 'os',
+            ...imageOverrides,
+        },
+    };
+}
+
+// Case A: include regex on a semver container. The alias branch stays dormant
+// (digest.value 'xxx' never matches a manifested digest), so result is driven
+// purely by the include regex + semver ordering.
+test('findNewVersion (case A: include regex) resolves to highest matching tag', async () => {
+    const { fn } = countingManifest({});
+    hub.getImageManifestDigest = fn;
+    hub.getTags = () => (['9.0.0', '8.1.0', '8.0.1', '8.0.0', '7.9.9', 'latest', 'foo.sig']);
+    const container = buildDigestWatchContainer({
+        includeTags: '^8\\.',
+        image: { tag: { value: '8.0.0', semver: true } },
+    });
+    await expect(docker.findNewVersion(container, docker.log)).resolves.toMatchObject({
+        tag: '8.1.0',
+        digest: 'sha256:8.1.0',
+    });
+});
+
+// Case B: non-semver 'latest' whose digest aliases a concrete version tag.
+// The alias branch resolves result.tag to the concrete version. This must NOT
+// change after the reorder (no regex -> full scan retained).
+test('findNewVersion (case B: latest alias) resolves to the aliased version', async () => {
+    const { fn } = countingManifest({
+        latest: 'sha256:shared',
+        '1.2.3': 'sha256:shared',
+        '1.2.2': 'sha256:old',
+    });
+    hub.getImageManifestDigest = fn;
+    hub.getTags = () => (['latest', '1.2.3', '1.2.2']);
+    const container = buildDigestWatchContainer({
+        image: {
+            tag: { value: 'latest', semver: false },
+            digest: { watch: true, value: 'sha256:shared', repo: 'yyy' },
+        },
+    });
+    await expect(docker.findNewVersion(container, docker.log)).resolves.toMatchObject({
+        tag: '1.2.3',
+    });
+});
+
+// Case C: plain semver, digest watch, no regex. The common path; guards against
+// regression on no-regex containers.
+test('findNewVersion (case C: semver no regex) resolves to highest tag', async () => {
+    const { fn } = countingManifest({});
+    hub.getImageManifestDigest = fn;
+    hub.getTags = () => (['7.8.9', '4.5.6', '3.0.0']);
+    const container = buildDigestWatchContainer({
+        image: { tag: { value: '4.5.6', semver: true }, digest: { watch: true, value: 'xxx', repo: 'yyy' } },
+    });
+    await expect(docker.findNewVersion(container, docker.log)).resolves.toMatchObject({
+        tag: '7.8.9',
+        digest: 'sha256:7.8.9',
+    });
+});


### PR DESCRIPTION
## Summary

- When a container has digest watching enabled, `findNewVersion` built its digest map by fetching an image manifest for **every** tag the registry returned, then applied the `hosaka.tag.include` / `hosaka.tag.exclude` regexes afterward in `getTagCandidates`. Tags that could never match were manifested and thrown away.
- The per-tag manifest loop now pre-filters by the container's include/exclude regex before hitting the registry, and only manifests the surviving tags plus the current running tag.
- The narrowing is applied **only when an include/exclude label is set**. With no regex, the full tag set is still scanned, so `latest`-style alias resolution (a tag whose digest matches a concrete version tag) is unchanged.

## Why

The manifest loop is serial (one round-trip per tag, two for multi-arch). A regex-pinned container watching a large-tag repository previously issued hundreds of manifest requests per cycle, which is slow and can exhaust registry pull rate limits (e.g. Docker Hub). For a container pinned to `^8\.`, fetches drop from "every tag" to just the matching candidates.

## Verified against a live registry

A `postgres:16.0` container labeled `hosaka.tag.include=^16\.` with digest watching, watched against Docker Hub:

```
[TagFilter] Starting with 1367 tags from registry
[TagFilter] After include regex: 96 tags (was 1367)
total tag-manifest GETs: 97 ; non-16.x: 0
Cron finished (1 containers watched, 0 errors, 1 available updates)
```

- Hub returned 1367 tags. The previous code manifested all 1367 (each multi-arch = manifest-list GET + HEAD, fully serial).
- This change manifested 97: the 96 `^16\.` matches plus the trailing top-candidate digest resolution. Zero fetches outside `16.`.
- ~93% fewer manifest requests on a real repository, and the update was still detected correctly.

## Test plan

- [x] New characterization tests pin current behavior for three shapes: include-regex semver, `latest` digest-alias, and plain semver with no regex.
- [x] New efficiency tests assert the manifest loop skips non-matching tags for both include-only and exclude-only configs, while always keeping the current tag.
- [x] Alias case (`latest` -> concrete version) verified unchanged by the reorder.
- [x] Full backend jest suite green (47 suites / 466 tests).
- [x] Verified live against Docker Hub (numbers above): 1367 -> 97 manifest fetches, none outside the regex, update still detected.