### PR TITLE
Stop script console vanishing on a successful upgrade

### DIFF
--- a/app/triggers/providers/script/portainerUpdate.js
+++ b/app/triggers/providers/script/portainerUpdate.js
@@ -209,6 +209,15 @@ async function checkContainerState(env, endpointId, containerName, expectedImage
     return 'waiting';
 }
 
+// A container with a healthcheck commonly flaps 'unhealthy' during warmup right
+// after start, before its first check passes. Treat the first sighting as the
+// start of a grace window and only fail once it has stayed unhealthy past
+// graceSec - otherwise a successful update gets reported as a failure.
+function unhealthyVerdict(unhealthySince, now, graceSec) {
+    if (unhealthySince === null) return 'start-grace';
+    return (now - unhealthySince >= graceSec) ? 'fail' : 'wait';
+}
+
 async function fetchContainerLogs(env, endpointId, containerName, lines, emit) {
     emit(`Fetching last ${lines} lines of logs for "${containerName}"...`);
     const list = await api(env, { path: `/endpoints/${endpointId}/docker/containers/json?all=true` });
@@ -235,10 +244,11 @@ async function fetchContainerLogs(env, endpointId, containerName, lines, emit) {
 
 // Wait for the container to reach the target image via the live Docker event
 // stream, with an inspect backstop (events can be missed) and an overall timeout.
-function waitForContainerUpdate(env, { endpointId, containerName, expectedImage, timeoutSec, initialImageId, pollIntervalSec }, emit) {
+function waitForContainerUpdate(env, { endpointId, containerName, expectedImage, timeoutSec, initialImageId, pollIntervalSec, healthGraceSec }, emit) {
     return new Promise((resolve, reject) => {
         const controller = new AbortController();
         let settled = false;
+        let unhealthySince = null;
         const since = nowSec();
         const filters = encodeURIComponent(JSON.stringify({ container: [containerName] }));
 
@@ -268,7 +278,17 @@ function waitForContainerUpdate(env, { endpointId, containerName, expectedImage,
                 emit('  WARNING: running target tag but image ID unchanged - may have already been at target');
                 done('sameimage');
             } else if (st === 'unhealthy') {
-                fail(new Error('container running but health check is unhealthy'));
+                const verdict = unhealthyVerdict(unhealthySince, nowSec(), healthGraceSec);
+                if (verdict === 'start-grace') {
+                    unhealthySince = nowSec();
+                    emit(`  WARNING: target image running but health check is unhealthy; allowing ${healthGraceSec}s to recover...`);
+                } else if (verdict === 'fail') {
+                    fail(new Error(`container running but health check stayed unhealthy for ${healthGraceSec}s`));
+                }
+            } else {
+                // 'waiting' or a recovered check - reset the grace window so a
+                // later flap starts counting fresh.
+                unhealthySince = null;
             }
         };
 
@@ -285,6 +305,11 @@ function waitForContainerUpdate(env, { endpointId, containerName, expectedImage,
             full: true,
         }).then(({ body: stream }) => {
             const rl = readline.createInterface({ input: stream });
+            // Settling aborts the request mid-read, which makes the input stream
+            // emit 'error' (aborted); readline re-emits it on the interface. With
+            // no listener Node treats it as an unhandled 'error' and crashes the
+            // whole process, so swallow it the same way as the stream error.
+            rl.on('error', () => {});
             rl.on('line', (line) => {
                 let ev;
                 try { ev = JSON.parse(line); } catch (err) { return; }
@@ -346,6 +371,9 @@ async function runPortainerUpdate(params, emitLine) {
     const timeoutSec = parseInt(process.env.UPDATE_TIMEOUT, 10)
         || Math.round((params.timeout || 300000) / 1000);
     const pollIntervalSec = parseInt(process.env.POLL_INTERVAL, 10) || params.pollInterval || 5;
+    // Grace given to a freshly-started container that reports 'unhealthy' before
+    // its healthcheck settles; overridable via HEALTH_GRACE (seconds).
+    const healthGraceSec = parseInt(process.env.HEALTH_GRACE, 10) || params.healthGrace || 30;
 
     if (!containerName || !imageName || !currentVersion || !targetVersion || !composeProject) {
         throw new Error(
@@ -439,7 +467,7 @@ async function runPortainerUpdate(params, emitLine) {
     const expectedImage = `${imageName}:${targetVersion}`;
     try {
         await waitForContainerUpdate(env, {
-            endpointId, containerName, expectedImage, timeoutSec, initialImageId, pollIntervalSec,
+            endpointId, containerName, expectedImage, timeoutSec, initialImageId, pollIntervalSec, healthGraceSec,
         }, emit);
     } catch (err) {
         emit(`\nERROR: ${err.message}`);
@@ -457,4 +485,5 @@ async function runPortainerUpdate(params, emitLine) {
 module.exports = runPortainerUpdate;
 module.exports.internals = {
     requireArray, demuxDockerStream, rewriteStackFile, discoverEndpoint, checkContainerState, readEnv,
+    unhealthyVerdict,
 };

--- a/app/triggers/providers/script/portainerUpdate.js
+++ b/app/triggers/providers/script/portainerUpdate.js
@@ -209,10 +209,8 @@ async function checkContainerState(env, endpointId, containerName, expectedImage
     return 'waiting';
 }
 
-// A container with a healthcheck commonly flaps 'unhealthy' during warmup right
-// after start, before its first check passes. Treat the first sighting as the
-// start of a grace window and only fail once it has stayed unhealthy past
-// graceSec - otherwise a successful update gets reported as a failure.
+// Tolerate the unhealthy flap common during container warmup: only fail once a
+// container has stayed unhealthy past graceSec, not on the first sighting.
 function unhealthyVerdict(unhealthySince, now, graceSec) {
     if (unhealthySince === null) return 'start-grace';
     return (now - unhealthySince >= graceSec) ? 'fail' : 'wait';
@@ -286,8 +284,6 @@ function waitForContainerUpdate(env, { endpointId, containerName, expectedImage,
                     fail(new Error(`container running but health check stayed unhealthy for ${healthGraceSec}s`));
                 }
             } else {
-                // 'waiting' or a recovered check - reset the grace window so a
-                // later flap starts counting fresh.
                 unhealthySince = null;
             }
         };
@@ -305,10 +301,8 @@ function waitForContainerUpdate(env, { endpointId, containerName, expectedImage,
             full: true,
         }).then(({ body: stream }) => {
             const rl = readline.createInterface({ input: stream });
-            // Settling aborts the request mid-read, which makes the input stream
-            // emit 'error' (aborted); readline re-emits it on the interface. With
-            // no listener Node treats it as an unhandled 'error' and crashes the
-            // whole process, so swallow it the same way as the stream error.
+            // Settling aborts the stream mid-read; without this handler readline's
+            // re-emitted 'error' goes unhandled and crashes the process.
             rl.on('error', () => {});
             rl.on('line', (line) => {
                 let ev;
@@ -371,8 +365,7 @@ async function runPortainerUpdate(params, emitLine) {
     const timeoutSec = parseInt(process.env.UPDATE_TIMEOUT, 10)
         || Math.round((params.timeout || 300000) / 1000);
     const pollIntervalSec = parseInt(process.env.POLL_INTERVAL, 10) || params.pollInterval || 5;
-    // Grace given to a freshly-started container that reports 'unhealthy' before
-    // its healthcheck settles; overridable via HEALTH_GRACE (seconds).
+    // Seconds an updated container may report unhealthy before it counts as a failure.
     const healthGraceSec = parseInt(process.env.HEALTH_GRACE, 10) || params.healthGrace || 30;
 
     if (!containerName || !imageName || !currentVersion || !targetVersion || !composeProject) {

--- a/app/triggers/providers/script/portainerUpdate.test.js
+++ b/app/triggers/providers/script/portainerUpdate.test.js
@@ -138,8 +138,6 @@ describe('checkContainerState', () => {
 });
 
 describe('unhealthyVerdict', () => {
-    // First unhealthy sighting starts the grace window instead of failing - a
-    // freshly-started container often flaps unhealthy during warmup.
     test('starts the grace window on the first unhealthy sighting', () => {
         expect(unhealthyVerdict(null, 1000, 30)).toBe('start-grace');
     });

--- a/app/triggers/providers/script/portainerUpdate.test.js
+++ b/app/triggers/providers/script/portainerUpdate.test.js
@@ -3,6 +3,7 @@ const runPortainerUpdate = require('./portainerUpdate');
 
 const {
     requireArray, demuxDockerStream, rewriteStackFile, discoverEndpoint, checkContainerState,
+    unhealthyVerdict,
 } = runPortainerUpdate.internals;
 
 jest.mock('../../../request');
@@ -133,5 +134,19 @@ describe('checkContainerState', () => {
     test('reports absent when the container is not listed', async () => {
         route([['/endpoints/1/docker/containers/json?all=true', []]]);
         expect(await checkContainerState(env, 1, 'c', 'c:2.0', '')).toBe('absent');
+    });
+});
+
+describe('unhealthyVerdict', () => {
+    // First unhealthy sighting starts the grace window instead of failing - a
+    // freshly-started container often flaps unhealthy during warmup.
+    test('starts the grace window on the first unhealthy sighting', () => {
+        expect(unhealthyVerdict(null, 1000, 30)).toBe('start-grace');
+    });
+    test('keeps waiting while still inside the grace window', () => {
+        expect(unhealthyVerdict(1000, 1020, 30)).toBe('wait');
+    });
+    test('fails once unhealthy persists past the grace window', () => {
+        expect(unhealthyVerdict(1000, 1031, 30)).toBe('fail');
     });
 });

--- a/ui/src/components/ContainerItem.vue
+++ b/ui/src/components/ContainerItem.vue
@@ -503,6 +503,22 @@ export default {
 
       } catch (error) {
         console.error('Install error:', error);
+        // If the script already started streaming, the console dialog owns the
+        // outcome: it renders the failure (exit-code footer / error line) and its
+        // own Close button. The install POST rejecting is just the same failure
+        // arriving on a second channel - don't yank the console out from under
+        // the logs or flash a duplicate toast. A momentary post-update verifier
+        // hiccup (e.g. a healthcheck flap) lands here too, so tearing the window
+        // down would hide an upgrade that actually succeeded.
+        const dialog = this.$refs.scriptOutput;
+        const scriptStarted = dialog
+          && (dialog.logs.length > 0 || dialog.isComplete || dialog.scriptExitCode !== null);
+        if (scriptStarted) {
+          return;
+        }
+
+        // Pre-flight failure (install disabled, container gone, multiple
+        // triggers): nothing streamed, so close the empty console and surface it.
         this.updateInProgress = false;
         this.showScriptOutput = false;
         const errorMessage = error.response?.data?.error || error.message || 'Unknown error';

--- a/ui/src/components/ContainerItem.vue
+++ b/ui/src/components/ContainerItem.vue
@@ -503,13 +503,8 @@ export default {
 
       } catch (error) {
         console.error('Install error:', error);
-        // If the script already started streaming, the console dialog owns the
-        // outcome: it renders the failure (exit-code footer / error line) and its
-        // own Close button. The install POST rejecting is just the same failure
-        // arriving on a second channel - don't yank the console out from under
-        // the logs or flash a duplicate toast. A momentary post-update verifier
-        // hiccup (e.g. a healthcheck flap) lands here too, so tearing the window
-        // down would hide an upgrade that actually succeeded.
+        // Once output is streaming the dialog renders the failure itself, so a
+        // rejected request is a duplicate signal - leave the console in place.
         const dialog = this.$refs.scriptOutput;
         const scriptStarted = dialog
           && (dialog.logs.length > 0 || dialog.isComplete || dialog.scriptExitCode !== null);
@@ -517,8 +512,7 @@ export default {
           return;
         }
 
-        // Pre-flight failure (install disabled, container gone, multiple
-        // triggers): nothing streamed, so close the empty console and surface it.
+        // Pre-flight failure that never streamed: close the empty console and toast.
         this.updateInProgress = false;
         this.showScriptOutput = false;
         const errorMessage = error.response?.data?.error || error.message || 'Unknown error';


### PR DESCRIPTION
## What

The live script-output console could disappear near the end of an upgrade, flashing a brief red error toast, even when the container actually updated. Root cause was a race between two completion channels (the SSE log stream and the awaited install request), amplified by an over-eager verifier and a process crash.

## Changes

**Backend — `portainerUpdate.js`**
- **Healthcheck grace window.** The post-update verifier hard-failed the instant a freshly-started container reported `unhealthy`. Containers routinely flap unhealthy during warmup right after start, so a successful update intermittently threw. Now the first unhealthy sighting starts a grace window (default 30s, override via `HEALTH_GRACE`); only a sustained unhealthy fails. A recovered/`waiting` check resets the window.
- **Crash fix.** The `readline` interface over the Docker events stream had no `error` handler. Settling the verify aborts the stream mid-read, which made readline emit an unhandled `'error'` and crash the whole process, dropping both the log stream and the install request. Now swallowed like the existing stream error.

**Frontend — `ContainerItem.vue`**
- The install request rejecting force-closed the console even though the dialog already renders the failure (exit-code footer + Close button). Now it only closes and toasts on a pre-flight failure that never streamed (install disabled, container gone, multiple triggers); once output is flowing, the dialog owns the outcome.

## Verification

Backend suite green (47 suites / 469 tests), including 3 new grace-decision unit tests.

Exercised end to end against a live stack driving real upgrades:
- Successful upgrade: console streams, shows success, stays open, no toast.
- Forced verification failure (failing healthcheck + short timeout): grace window logged, then the console stays open showing the error, no toast, backend stays up (previously this path crashed the process).