### PR TITLE
feat(ai): on-demand update analysis

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,12 @@ Hosaka sits in the middle, where most people actually want to be:
   going to look for it. A `hosaka.link.template` label turns each update into a
   direct link to that version's release notes, so you can read what changed
   without hunting down the changelog.
+- **Understand an update before you take it.** Hosaka can analyze an update on
+  demand: it reads the release notes between the version you run and the one on
+  offer, summarizes what changed, calls out breaking changes with the version
+  that introduced each one, and rates the overall upgrade risk. It runs only
+  when you click Analyze, and only once you have added an AI key, so a second
+  opinion is there when you want it and out of the way when you do not.
 - **Update on your terms.** Nothing changes until you click. Every update is
   classified as major, minor, patch, or prerelease, so you can take a patch and
   hold back a major.
@@ -68,6 +74,7 @@ Hosaka sits in the middle, where most people actually want to be:
 |------|-----|--------|
 | **Updating from the UI** | run a trigger from the container's Triggers tab | one-click **Update** on the container row |
 | **Update progress** | none | live console output of the update, streamed line by line |
+| **Update analysis** | none | on-demand AI summary of the release notes between your version and the target, flagging breaking changes and an overall risk level |
 | **Portainer stacks** | generic script trigger, write your own | built-in one-click updater that rewrites the stack file and redeploys through the Portainer API |
 | **Mobile** | desktop-oriented: permanent nav, no mobile layout | fully responsive: hamburger nav, mobile layouts, update from your phone |
 | **Live container state** | manual refresh | list updates in place over SSE, no full-page reload |
@@ -129,6 +136,16 @@ marked done until the new container comes back healthy.
 - Digest watching catches new images behind mutable tags like `latest`
 - Per-tag include/exclude regex and tag transforms to handle any versioning scheme
 - Scheduled (cron) scans plus instant detection from Docker events
+
+**Update analysis, on demand (AI)**
+- Click **Analyze** on any container with an update to get a structured summary
+  of the release notes between your version and the target
+- Breaking changes are called out and attributed to the version that introduced
+  them, with an overall risk level (none, low, medium, high)
+- Pulls notes straight from GitHub Releases, follows linked changelogs, and falls
+  back to the release page you point it at; results are cached and re-runnable
+- Off until you add a Google Gemini API key, and it runs only when you ask, never
+  on its own
 
 **Per-container control, no central config**
 - Drive everything with `hosaka.*` Docker labels: opt in/out, set tag filters,
@@ -213,6 +230,7 @@ Full docs are published at **[nopoz.github.io/hosaka](https://nopoz.github.io/ho
   - [Registries](https://nopoz.github.io/hosaka/#/configuration/registries/)
   - [Triggers](https://nopoz.github.io/hosaka/#/configuration/triggers/)
   - [Authentication](https://nopoz.github.io/hosaka/#/configuration/authentications/)
+  - [AI update analysis](https://nopoz.github.io/hosaka/#/configuration/ai/)
 - [UI](https://nopoz.github.io/hosaka/#/ui/)
 - [REST API](https://nopoz.github.io/hosaka/#/api/)
 - [Monitoring](https://nopoz.github.io/hosaka/#/monitoring/)
@@ -234,6 +252,8 @@ Keycloak, and other OIDC providers).
 
 **Monitoring:** Prometheus metrics and a `/health` endpoint, ready for Grafana.
 
+**AI analysis:** Google Gemini, for optional on-demand update analysis.
+
 **Home:** Home-Assistant.
 
 ## Security
@@ -254,6 +274,12 @@ a privileged tool.
 - **Keep secrets out of plain config.** Registry credentials and trigger tokens
   can be loaded from files with the `__FILE` env var suffix (Docker secrets)
   instead of being written in your compose file.
+- **AI analysis talks to a third party.** When you enable update analysis, Hosaka
+  sends the gathered release-note text, along with the image name and the two
+  version tags, to Google Gemini to summarize. It sends only public release
+  notes, never your container config or secrets, and only when you click Analyze.
+  The API key is a secret and supports `__FILE`; leave it unset to keep the
+  feature off entirely.
 
 ## More of my projects
 

--- a/app/ai/cache.js
+++ b/app/ai/cache.js
@@ -1,0 +1,24 @@
+const store = new Map();
+
+function key({ id, current, target, model }) {
+    return `${id}|${current}|${target}|${model}`;
+}
+
+function get(cacheKey) {
+    return store.get(cacheKey);
+}
+
+function set(cacheKey, value) {
+    store.set(cacheKey, value);
+}
+
+function clear() {
+    store.clear();
+}
+
+module.exports = {
+    key,
+    get,
+    set,
+    clear,
+};

--- a/app/ai/enrich.js
+++ b/app/ai/enrich.js
@@ -1,0 +1,63 @@
+const { fetchNotesFromUrl } = require('./webFallback');
+
+// A release body that just points elsewhere ("see the changelog at <url>")
+// carries no real notes. When a body is short or explicitly defers, follow the
+// first external link and pull its text so the model has something to work with.
+const THIN_BODY_CHARS = 280;
+const DEFER_RE = /(refer to|see (the )?changelog|full changelog|available at|release notes?\b[^.]{0,40}\bat\b)/i;
+const URL_RE = /https?:\/\/[^\s)\]<>"']+/gi;
+
+/**
+ * Pick the first link worth following: external (not GitHub, not a CI artifact).
+ * @param {string} body
+ * @returns {string|null}
+ */
+function pickExternalUrl(body) {
+    const urls = body.match(URL_RE) || [];
+    const external = urls.find((u) => !/github\.com|githubusercontent\.com|ci-tests\./i.test(u));
+    return external || null;
+}
+
+/**
+ * Enrich notes that defer to an external changelog by appending that page's
+ * text. Each distinct URL is fetched once and appended once; failures leave the
+ * note untouched. Returns a new array.
+ * @param {Array<{tag,body}>} notes
+ * @param {Object} log
+ * @returns {Promise<Array>}
+ */
+async function enrichNotes(notes, log) {
+    const fetched = new Map();
+    const appended = new Set();
+    const out = [];
+    for (let i = 0; i < notes.length; i += 1) {
+        const note = notes[i];
+        const body = note.body || '';
+        const defers = body.length < THIN_BODY_CHARS || DEFER_RE.test(body);
+        const url = defers ? pickExternalUrl(body) : null;
+        if (!url || appended.has(url)) {
+            out.push(note);
+        } else {
+            if (!fetched.has(url)) {
+                // eslint-disable-next-line no-await-in-loop
+                fetched.set(url, await fetchNotesFromUrl(url));
+            }
+            const text = fetched.get(url);
+            if (text) {
+                appended.add(url);
+                if (log) {
+                    log.info({ tag: note.tag, url }, 'enriched release note from external changelog');
+                }
+                out.push({ ...note, body: `${body}\n\n[External changelog: ${url}]\n${text}` });
+            } else {
+                out.push(note);
+            }
+        }
+    }
+    return out;
+}
+
+module.exports = {
+    enrichNotes,
+    pickExternalUrl,
+};

--- a/app/ai/enrich.test.js
+++ b/app/ai/enrich.test.js
@@ -1,0 +1,53 @@
+jest.mock('./webFallback');
+
+const { fetchNotesFromUrl } = require('./webFallback');
+const { enrichNotes, pickExternalUrl } = require('./enrich');
+
+beforeEach(() => {
+    jest.resetAllMocks();
+});
+
+test('pickExternalUrl prefers a non-github, non-ci link', () => {
+    expect(pickExternalUrl('see https://tailscale.com/changelog now'))
+        .toBe('https://tailscale.com/changelog');
+    expect(pickExternalUrl('https://github.com/x/y/compare/a...b')).toBeNull();
+    expect(pickExternalUrl('artifact https://ci-tests.linuxserver.io/x/index.html')).toBeNull();
+    expect(pickExternalUrl('no links here')).toBeNull();
+});
+
+test('enrichNotes appends external changelog text for a thin deferring note', async () => {
+    fetchNotesFromUrl.mockResolvedValue('FULL CHANGELOG TEXT');
+    const notes = [{
+        tag: 'v1.98.2',
+        body: 'Please refer to the changelog available at https://tailscale.com/changelog',
+    }];
+    const out = await enrichNotes(notes, null);
+    expect(fetchNotesFromUrl).toHaveBeenCalledWith('https://tailscale.com/changelog');
+    expect(out[0].body).toContain('FULL CHANGELOG TEXT');
+});
+
+test('enrichNotes leaves a substantial note untouched', async () => {
+    const big = `${'x'.repeat(500)} https://example.com/page`;
+    const out = await enrichNotes([{ tag: 'v1', body: big }], null);
+    expect(fetchNotesFromUrl).not.toHaveBeenCalled();
+    expect(out[0].body).toBe(big);
+});
+
+test('enrichNotes fetches a shared external url only once and appends once', async () => {
+    fetchNotesFromUrl.mockResolvedValue('SHARED');
+    const notes = [
+        { tag: 'v1.98.2', body: 'see https://tailscale.com/changelog' },
+        { tag: 'v1.98.3', body: 'see https://tailscale.com/changelog' },
+    ];
+    const out = await enrichNotes(notes, null);
+    expect(fetchNotesFromUrl).toHaveBeenCalledTimes(1);
+    expect(out[0].body).toContain('SHARED');
+    expect(out[1].body).not.toContain('SHARED');
+});
+
+test('enrichNotes leaves the note untouched when the fetch yields nothing', async () => {
+    fetchNotesFromUrl.mockResolvedValue('');
+    const notes = [{ tag: 'v1', body: 'see https://tailscale.com/changelog' }];
+    const out = await enrichNotes(notes, null);
+    expect(out[0].body).toBe('see https://tailscale.com/changelog');
+});

--- a/app/ai/github.js
+++ b/app/ai/github.js
@@ -55,6 +55,7 @@ async function listReleasesBetween(repo, current, target, token) {
         qs: { per_page: 100 },
         headers,
         resolveWithFullResponse: true,
+        timeout: 15000,
     });
     const releases = Array.isArray(response.body) ? response.body : [];
     const kept = [];
@@ -75,6 +76,7 @@ async function listReleasesBetween(repo, current, target, token) {
                 date: release.published_at || null,
                 body: release.body || '',
                 prerelease: Boolean(release.prerelease),
+                url: release.html_url || null,
             });
         }
     });

--- a/app/ai/github.js
+++ b/app/ai/github.js
@@ -1,0 +1,93 @@
+const request = require('../request');
+const { parse, isGreater } = require('../tag');
+
+const GITHUB_API = 'https://api.github.com';
+
+/**
+ * Locate the GitHub owner/repo for a container. The link is only a locator:
+ * a tag-specific URL still resolves to the repo so the full release range can
+ * be enumerated. Falls back to fuzzing ghcr.io image names.
+ * @param {Object} container
+ * @returns {{owner: string, repo: string}|null}
+ */
+function detectRepo(container) {
+    const candidates = [
+        container.linkTemplate,
+        container.link,
+        container.result && container.result.link,
+    ];
+    for (let i = 0; i < candidates.length; i += 1) {
+        const url = candidates[i];
+        if (typeof url === 'string') {
+            const match = url.match(/github\.com[/:]([^/\s]+)\/([^/\s#?]+)/i);
+            if (match) {
+                return { owner: match[1], repo: match[2].replace(/\.git$/, '') };
+            }
+        }
+    }
+    const registry = container.image && container.image.registry;
+    const registryUrl = (registry && (registry.url || registry.name)) || '';
+    const name = (container.image && container.image.name) || '';
+    if (/ghcr\.io/i.test(registryUrl) && name.includes('/')) {
+        const [owner, repo] = name.split('/');
+        return { owner, repo };
+    }
+    return null;
+}
+
+/**
+ * List GitHub releases with current < tag <= target, newest last. Drafts and
+ * non-semver tags are skipped. POC fetches up to 100 releases in one page.
+ * @returns {Promise<Array<{tag,name,date,body,prerelease}>>}
+ */
+async function listReleasesBetween(repo, current, target, token) {
+    const headers = {
+        Accept: 'application/vnd.github+json',
+        'X-GitHub-Api-Version': '2022-11-28',
+        'User-Agent': 'hosaka',
+    };
+    if (token) {
+        headers.Authorization = `Bearer ${token}`;
+    }
+    const response = await request({
+        uri: `${GITHUB_API}/repos/${repo.owner}/${repo.repo}/releases`,
+        method: 'GET',
+        qs: { per_page: 100 },
+        headers,
+        resolveWithFullResponse: true,
+    });
+    const releases = Array.isArray(response.body) ? response.body : [];
+    const kept = [];
+    releases.forEach((release) => {
+        if (release.draft) {
+            return;
+        }
+        const tag = release.tag_name;
+        if (!tag || parse(tag) === null) {
+            return;
+        }
+        const aboveCurrent = isGreater(tag, current) && !isGreater(current, tag);
+        const atOrBelowTarget = isGreater(target, tag);
+        if (aboveCurrent && atOrBelowTarget) {
+            kept.push({
+                tag,
+                name: release.name || tag,
+                date: release.published_at || null,
+                body: release.body || '',
+                prerelease: Boolean(release.prerelease),
+            });
+        }
+    });
+    kept.sort((a, b) => {
+        if (a.tag === b.tag) {
+            return 0;
+        }
+        return isGreater(a.tag, b.tag) ? 1 : -1;
+    });
+    return kept;
+}
+
+module.exports = {
+    detectRepo,
+    listReleasesBetween,
+};

--- a/app/ai/github.test.js
+++ b/app/ai/github.test.js
@@ -35,7 +35,9 @@ test('listReleasesBetween keeps current<tag<=target, excludes drafts and non-sem
         headers: {},
         body: [
             { tag_name: 'v1.5.0', body: 'too new' },
-            { tag_name: 'v1.4.2', name: 'r142', body: 'b142', published_at: '2026-01-02', prerelease: false },
+            {
+                tag_name: 'v1.4.2', name: 'r142', body: 'b142', published_at: '2026-01-02', prerelease: false, html_url: 'https://github.com/nopoz/hosaka/releases/tag/v1.4.2',
+            },
             { tag_name: 'v1.4.0', name: 'r140', body: 'b140', published_at: '2026-01-01' },
             { tag_name: 'v1.3.0', body: 'draft', draft: true },
             { tag_name: 'nightly', body: 'non-semver' },
@@ -47,7 +49,12 @@ test('listReleasesBetween keeps current<tag<=target, excludes drafts and non-sem
     );
     expect(result.map((r) => r.tag)).toStrictEqual(['v1.4.0', 'v1.4.2']);
     expect(result[1]).toStrictEqual({
-        tag: 'v1.4.2', name: 'r142', date: '2026-01-02', body: 'b142', prerelease: false,
+        tag: 'v1.4.2',
+        name: 'r142',
+        date: '2026-01-02',
+        body: 'b142',
+        prerelease: false,
+        url: 'https://github.com/nopoz/hosaka/releases/tag/v1.4.2',
     });
     expect(request).toHaveBeenCalledWith(expect.objectContaining({
         uri: 'https://api.github.com/repos/nopoz/hosaka/releases',

--- a/app/ai/github.test.js
+++ b/app/ai/github.test.js
@@ -1,0 +1,63 @@
+const request = require('../request');
+
+jest.mock('../request');
+const { detectRepo, listReleasesBetween } = require('./github');
+
+beforeEach(() => {
+    jest.resetAllMocks();
+});
+
+test('detectRepo extracts owner/repo from a tag-specific link', () => {
+    const container = {
+        linkTemplate: 'https://github.com/nopoz/hosaka/releases/tag/v1.2.2',
+        image: { name: 'nopoz/hosaka', registry: { url: 'ghcr.io' } },
+    };
+    expect(detectRepo(container)).toStrictEqual({ owner: 'nopoz', repo: 'hosaka' });
+});
+
+test('detectRepo fuzzes ghcr image name when no link is present', () => {
+    const container = {
+        image: { name: 'nopoz/hosaka', registry: { url: 'ghcr.io' } },
+    };
+    expect(detectRepo(container)).toStrictEqual({ owner: 'nopoz', repo: 'hosaka' });
+});
+
+test('detectRepo returns null for a non-github, non-ghcr image', () => {
+    const container = {
+        image: { name: 'library/nginx', registry: { url: 'registry-1.docker.io' } },
+    };
+    expect(detectRepo(container)).toBeNull();
+});
+
+test('listReleasesBetween keeps current<tag<=target, excludes drafts and non-semver', async () => {
+    request.mockResolvedValue({
+        statusCode: 200,
+        headers: {},
+        body: [
+            { tag_name: 'v1.5.0', body: 'too new' },
+            { tag_name: 'v1.4.2', name: 'r142', body: 'b142', published_at: '2026-01-02', prerelease: false },
+            { tag_name: 'v1.4.0', name: 'r140', body: 'b140', published_at: '2026-01-01' },
+            { tag_name: 'v1.3.0', body: 'draft', draft: true },
+            { tag_name: 'nightly', body: 'non-semver' },
+            { tag_name: 'v1.2.2', body: 'current' },
+        ],
+    });
+    const result = await listReleasesBetween(
+        { owner: 'nopoz', repo: 'hosaka' }, 'v1.2.2', 'v1.4.2', '',
+    );
+    expect(result.map((r) => r.tag)).toStrictEqual(['v1.4.0', 'v1.4.2']);
+    expect(result[1]).toStrictEqual({
+        tag: 'v1.4.2', name: 'r142', date: '2026-01-02', body: 'b142', prerelease: false,
+    });
+    expect(request).toHaveBeenCalledWith(expect.objectContaining({
+        uri: 'https://api.github.com/repos/nopoz/hosaka/releases',
+        method: 'GET',
+        resolveWithFullResponse: true,
+    }));
+});
+
+test('listReleasesBetween adds an auth header when a token is supplied', async () => {
+    request.mockResolvedValue({ statusCode: 200, headers: {}, body: [] });
+    await listReleasesBetween({ owner: 'a', repo: 'b' }, 'v1.0.0', 'v2.0.0', 'tok');
+    expect(request.mock.calls[0][0].headers.Authorization).toBe('Bearer tok');
+});

--- a/app/ai/index.js
+++ b/app/ai/index.js
@@ -1,0 +1,91 @@
+const { getAiConfiguration } = require('../configuration');
+const { detectRepo, listReleasesBetween } = require('./github');
+const { fetchNotesFromUrl } = require('./webFallback');
+const { buildPrompt } = require('./prompt');
+const { getProvider } = require('./providers');
+const cache = require('./cache');
+
+function makeError(message, code) {
+    const error = new Error(message);
+    error.code = code;
+    return error;
+}
+
+/**
+ * Analyze the release notes between a container's current and target version.
+ * On-demand only. Throws Error with .code AI_DISABLED or NO_UPDATE for the
+ * caller to map to HTTP status.
+ * @param {Object} container
+ * @param {{force?: boolean}} options
+ * @returns {Promise<Object>}
+ */
+async function analyzeUpdate(container, { force = false } = {}) {
+    const config = getAiConfiguration();
+    if (!config.enabled) {
+        throw makeError('AI analysis is not configured', 'AI_DISABLED');
+    }
+    if (!container.result) {
+        throw makeError('No update available for this container', 'NO_UPDATE');
+    }
+
+    const current = container.image.tag.value;
+    const target = container.result.tag;
+    const model = config.gemini.model;
+    const cacheKey = cache.key({ id: container.id, current, target, model });
+    if (!force) {
+        const cached = cache.get(cacheKey);
+        if (cached) {
+            return cached;
+        }
+    }
+
+    const repo = detectRepo(container);
+    let notes = [];
+    let source = 'none';
+    if (repo) {
+        notes = await listReleasesBetween(repo, current, target, config.github.token);
+        if (notes.length) {
+            source = 'github';
+        }
+    }
+    if (!notes.length) {
+        const url = (container.result && container.result.link) || container.link;
+        const text = url ? await fetchNotesFromUrl(url) : '';
+        if (text) {
+            notes = [{ tag: target, date: null, body: text }];
+            source = 'web';
+        }
+    }
+
+    if (!notes.length) {
+        const empty = {
+            riskLevel: 'unknown',
+            breakingChanges: [],
+            highlights: [],
+            overview: 'No release notes could be located for this update.',
+            versionsCovered: [],
+            source: 'none',
+            sourceNotes: [],
+        };
+        cache.set(cacheKey, empty);
+        return empty;
+    }
+
+    const provider = getProvider(config.provider);
+    const { system, user, schema } = buildPrompt(container, notes);
+    const result = await provider.generate({
+        system,
+        user,
+        schema,
+        model,
+        apiKey: config.gemini.apikey,
+    });
+    result.source = source;
+    result.sourceNotes = notes;
+    cache.set(cacheKey, result);
+    return result;
+}
+
+module.exports = {
+    analyzeUpdate,
+};

--- a/app/ai/index.js
+++ b/app/ai/index.js
@@ -1,6 +1,8 @@
+const log = require('../log').child({ component: 'ai' });
 const { getAiConfiguration } = require('../configuration');
 const { detectRepo, listReleasesBetween } = require('./github');
 const { fetchNotesFromUrl } = require('./webFallback');
+const { enrichNotes } = require('./enrich');
 const { buildPrompt } = require('./prompt');
 const { getProvider } = require('./providers');
 const cache = require('./cache');
@@ -31,10 +33,15 @@ async function analyzeUpdate(container, { force = false } = {}) {
     const current = container.image.tag.value;
     const target = container.result.tag;
     const model = config.gemini.model;
+    const image = container.image.name;
+    log.info({
+        image, current, target, force,
+    }, 'analyzing update');
     const cacheKey = cache.key({ id: container.id, current, target, model });
     if (!force) {
         const cached = cache.get(cacheKey);
         if (cached) {
+            log.debug({ image, current, target }, 'returning cached analysis');
             return cached;
         }
     }
@@ -43,21 +50,30 @@ async function analyzeUpdate(container, { force = false } = {}) {
     let notes = [];
     let source = 'none';
     if (repo) {
+        log.info({ owner: repo.owner, repo: repo.repo }, 'detected github repo');
         notes = await listReleasesBetween(repo, current, target, config.github.token);
+        log.info({ count: notes.length }, 'github releases in range');
         if (notes.length) {
             source = 'github';
+            notes = await enrichNotes(notes, log);
         }
+    } else {
+        log.info({ image }, 'no github repo detected');
     }
     if (!notes.length) {
         const url = (container.result && container.result.link) || container.link;
         const text = url ? await fetchNotesFromUrl(url) : '';
         if (text) {
-            notes = [{ tag: target, date: null, body: text }];
+            notes = [{
+                tag: target, date: null, body: text, url,
+            }];
             source = 'web';
+            log.info({ url }, 'using web fallback for notes');
         }
     }
 
     if (!notes.length) {
+        log.info({ image, current, target }, 'no release notes located');
         const empty = {
             riskLevel: 'unknown',
             breakingChanges: [],
@@ -72,14 +88,32 @@ async function analyzeUpdate(container, { force = false } = {}) {
     }
 
     const provider = getProvider(config.provider);
-    const { system, user, schema } = buildPrompt(container, notes);
-    const result = await provider.generate({
-        system,
-        user,
-        schema,
-        model,
-        apiKey: config.gemini.apikey,
-    });
+    const {
+        system, user, schema, dropped, chars,
+    } = buildPrompt(container, notes);
+    if (dropped) {
+        log.warn({ dropped, image }, 'release notes truncated to fit the prompt budget');
+    }
+    log.info({
+        provider: config.provider, model, source, notes: notes.length, chars,
+    }, 'requesting analysis from model');
+    const started = Date.now();
+    let result;
+    try {
+        result = await provider.generate({
+            system,
+            user,
+            schema,
+            model,
+            apiKey: config.gemini.apikey,
+        });
+    } catch (e) {
+        log.error({ image, err: e.message, ms: Date.now() - started }, 'model analysis failed');
+        throw e;
+    }
+    log.info({
+        image, riskLevel: result.riskLevel, ms: Date.now() - started,
+    }, 'analysis complete');
     result.source = source;
     result.sourceNotes = notes;
     cache.set(cacheKey, result);

--- a/app/ai/index.test.js
+++ b/app/ai/index.test.js
@@ -70,6 +70,23 @@ test('happy path: github notes -> provider -> structured result', async () => {
     expect(generate).toHaveBeenCalledTimes(1);
 });
 
+test('enriches a github note that defers to an external changelog', async () => {
+    getAiConfiguration.mockReturnValue(ENABLED);
+    detectRepo.mockReturnValue({ owner: 'tailscale', repo: 'tailscale' });
+    listReleasesBetween.mockResolvedValue([
+        {
+            tag: 'v1.98.2',
+            date: null,
+            body: 'Please refer to the changelog available at https://tailscale.com/changelog',
+        },
+    ]);
+    fetchNotesFromUrl.mockResolvedValue('REAL CHANGELOG CONTENT');
+    await analyzeUpdate(makeContainer(), {});
+    expect(fetchNotesFromUrl).toHaveBeenCalledWith('https://tailscale.com/changelog');
+    const sentUser = generate.mock.calls[0][0].user;
+    expect(sentUser).toContain('REAL CHANGELOG CONTENT');
+});
+
 test('caches by id+current+target+model; force bypasses', async () => {
     getAiConfiguration.mockReturnValue(ENABLED);
     detectRepo.mockReturnValue({ owner: 'nopoz', repo: 'hosaka' });

--- a/app/ai/index.test.js
+++ b/app/ai/index.test.js
@@ -1,0 +1,102 @@
+jest.mock('../configuration');
+jest.mock('./github');
+jest.mock('./providers');
+jest.mock('./webFallback');
+
+const { getAiConfiguration } = require('../configuration');
+const { detectRepo, listReleasesBetween } = require('./github');
+const { getProvider } = require('./providers');
+const { fetchNotesFromUrl } = require('./webFallback');
+const cache = require('./cache');
+const { analyzeUpdate } = require('./index');
+
+const ENABLED = {
+    enabled: true,
+    provider: 'gemini',
+    gemini: { apikey: 'k', model: 'gemini-2.5-flash-lite' },
+    github: { token: '' },
+};
+
+const MODEL_RESULT = {
+    riskLevel: 'medium',
+    breakingChanges: [{ title: 'Renamed FOO', detail: 'use BAR' }],
+    highlights: ['Faster startup'],
+    overview: 'Some changes',
+    versionsCovered: ['v1.4.0', 'v1.4.2'],
+};
+
+function makeContainer() {
+    return {
+        id: 'abc',
+        link: 'https://github.com/nopoz/hosaka/releases/tag/v1.2.2',
+        linkTemplate: 'https://github.com/nopoz/hosaka/releases/tag/v1.2.2',
+        image: { name: 'nopoz/hosaka', tag: { value: 'v1.2.2' }, registry: { url: 'ghcr.io' } },
+        result: { tag: 'v1.4.2', link: 'https://github.com/nopoz/hosaka/releases/tag/v1.4.2' },
+    };
+}
+
+let generate;
+
+beforeEach(() => {
+    jest.resetAllMocks();
+    cache.clear();
+    generate = jest.fn().mockResolvedValue({ ...MODEL_RESULT });
+    getProvider.mockReturnValue({ generate });
+});
+
+test('throws AI_DISABLED when not configured', async () => {
+    getAiConfiguration.mockReturnValue({ enabled: false, gemini: {} });
+    await expect(analyzeUpdate(makeContainer(), {})).rejects.toHaveProperty('code', 'AI_DISABLED');
+});
+
+test('throws NO_UPDATE when the container has no result', async () => {
+    getAiConfiguration.mockReturnValue(ENABLED);
+    const container = makeContainer();
+    delete container.result;
+    await expect(analyzeUpdate(container, {})).rejects.toHaveProperty('code', 'NO_UPDATE');
+});
+
+test('happy path: github notes -> provider -> structured result', async () => {
+    getAiConfiguration.mockReturnValue(ENABLED);
+    detectRepo.mockReturnValue({ owner: 'nopoz', repo: 'hosaka' });
+    listReleasesBetween.mockResolvedValue([
+        { tag: 'v1.4.0', date: '2026-01-01', body: 'b140' },
+        { tag: 'v1.4.2', date: '2026-01-02', body: 'b142' },
+    ]);
+    const result = await analyzeUpdate(makeContainer(), {});
+    expect(result.riskLevel).toBe('medium');
+    expect(result.source).toBe('github');
+    expect(result.sourceNotes).toHaveLength(2);
+    expect(generate).toHaveBeenCalledTimes(1);
+});
+
+test('caches by id+current+target+model; force bypasses', async () => {
+    getAiConfiguration.mockReturnValue(ENABLED);
+    detectRepo.mockReturnValue({ owner: 'nopoz', repo: 'hosaka' });
+    listReleasesBetween.mockResolvedValue([{ tag: 'v1.4.2', date: null, body: 'b' }]);
+    await analyzeUpdate(makeContainer(), {});
+    await analyzeUpdate(makeContainer(), {});
+    expect(generate).toHaveBeenCalledTimes(1);
+    await analyzeUpdate(makeContainer(), { force: true });
+    expect(generate).toHaveBeenCalledTimes(2);
+});
+
+test('falls back to web fetch when no repo is detected', async () => {
+    getAiConfiguration.mockReturnValue(ENABLED);
+    detectRepo.mockReturnValue(null);
+    fetchNotesFromUrl.mockResolvedValue('Some release page text');
+    const result = await analyzeUpdate(makeContainer(), {});
+    expect(fetchNotesFromUrl).toHaveBeenCalled();
+    expect(result.source).toBe('web');
+    expect(generate).toHaveBeenCalledTimes(1);
+});
+
+test('returns a no-notes payload when nothing can be gathered', async () => {
+    getAiConfiguration.mockReturnValue(ENABLED);
+    detectRepo.mockReturnValue(null);
+    fetchNotesFromUrl.mockResolvedValue('');
+    const result = await analyzeUpdate(makeContainer(), {});
+    expect(result.riskLevel).toBe('unknown');
+    expect(result.source).toBe('none');
+    expect(generate).not.toHaveBeenCalled();
+});

--- a/app/ai/prompt.js
+++ b/app/ai/prompt.js
@@ -1,0 +1,60 @@
+const RESPONSE_SCHEMA = {
+    type: 'object',
+    properties: {
+        riskLevel: { type: 'string' },
+        breakingChanges: {
+            type: 'array',
+            items: {
+                type: 'object',
+                properties: {
+                    title: { type: 'string' },
+                    detail: { type: 'string' },
+                },
+            },
+        },
+        highlights: { type: 'array', items: { type: 'string' } },
+        overview: { type: 'string' },
+        versionsCovered: { type: 'array', items: { type: 'string' } },
+    },
+};
+
+/**
+ * Build the Gemini prompt for an update analysis.
+ * @param {Object} container
+ * @param {Array<{tag,date,body}>} notes
+ * @returns {{system: string, user: string, schema: Object}}
+ */
+function buildPrompt(container, notes) {
+    const image = container.image.name;
+    const current = container.image.tag.value;
+    const target = container.result.tag;
+    const system = [
+        'You are a release-notes analyst for container image upgrades.',
+        'Summarize what changed between the current version and the target version,',
+        'and flag any potentially breaking changes such as renamed or removed config/env',
+        'keys, changed volume or data layouts, API/CLI changes, dropped platforms, or',
+        'required manual migration steps.',
+        'riskLevel must be one of: none, low, medium, high.',
+        'Be concise and specific. Use only the provided release notes; never invent changes.',
+    ].join(' ');
+    const notesText = notes
+        .map((note) => {
+            const header = note.date ? `## ${note.tag} (${note.date})` : `## ${note.tag}`;
+            return `${header}\n${note.body || ''}`;
+        })
+        .join('\n\n');
+    const user = [
+        `Image: ${image}`,
+        `Current version: ${current}`,
+        `Target version: ${target}`,
+        '',
+        'Release notes:',
+        notesText,
+    ].join('\n');
+    return { system, user, schema: RESPONSE_SCHEMA };
+}
+
+module.exports = {
+    buildPrompt,
+    RESPONSE_SCHEMA,
+};

--- a/app/ai/prompt.js
+++ b/app/ai/prompt.js
@@ -1,28 +1,99 @@
+// Bound the prompt so a noisy image (many releases, huge bodies) can't blow up
+// latency or cost. Per-note first, then an overall budget keeping the most
+// recent notes (closest to the target) that fit.
+const MAX_NOTE_CHARS = 4000;
+const MAX_TOTAL_CHARS = 20000;
+
 const RESPONSE_SCHEMA = {
     type: 'object',
     properties: {
-        riskLevel: { type: 'string' },
+        riskLevel: {
+            type: 'string',
+            enum: ['none', 'low', 'medium', 'high'],
+            description: 'Overall upgrade risk: high if manual migration or breaking config/data changes are required, none if purely additive/bugfix.',
+        },
         breakingChanges: {
             type: 'array',
+            description: 'Changes that can break an existing deployment. Empty if none.',
             items: {
                 type: 'object',
                 properties: {
-                    title: { type: 'string' },
-                    detail: { type: 'string' },
+                    title: {
+                        type: 'string',
+                        description: 'Short label for the breaking change (a few words).',
+                    },
+                    detail: {
+                        type: 'string',
+                        description: 'One concise factual sentence: what changed and the action the user must take. No reasoning, no commentary, no questions.',
+                    },
+                    version: {
+                        type: 'string',
+                        description: 'The exact version tag from the notes where this change appears, if identifiable. Omit if unclear.',
+                    },
                 },
             },
         },
-        highlights: { type: 'array', items: { type: 'string' } },
-        overview: { type: 'string' },
-        versionsCovered: { type: 'array', items: { type: 'string' } },
+        highlights: {
+            type: 'array',
+            description: 'Notable non-breaking changes.',
+            items: {
+                type: 'object',
+                properties: {
+                    text: {
+                        type: 'string',
+                        description: 'One short sentence describing the change.',
+                    },
+                    version: {
+                        type: 'string',
+                        description: 'The exact version tag from the notes where this change appears, if identifiable. Omit if unclear.',
+                    },
+                },
+            },
+        },
+        overview: {
+            type: 'string',
+            description: 'Two or three plain sentences summarizing the upgrade.',
+        },
+        versionsCovered: {
+            type: 'array',
+            description: 'The version tags these notes cover.',
+            items: { type: 'string' },
+        },
     },
+    required: ['riskLevel', 'overview'],
 };
 
 /**
- * Build the Gemini prompt for an update analysis.
+ * Truncate each note body, then keep the most recent notes (input is sorted
+ * oldest-first) that fit the total budget.
+ * @returns {{kept: Array, dropped: number}}
+ */
+function capNotes(notes) {
+    const truncated = notes.map((note) => {
+        const body = note.body || '';
+        return body.length > MAX_NOTE_CHARS
+            ? { ...note, body: `${body.slice(0, MAX_NOTE_CHARS)}\n...[truncated]` }
+            : note;
+    });
+    const kept = [];
+    let total = 0;
+    for (let i = truncated.length - 1; i >= 0; i -= 1) {
+        const len = (truncated[i].body || '').length;
+        if (total + len > MAX_TOTAL_CHARS && kept.length) {
+            break;
+        }
+        total += len;
+        kept.unshift(truncated[i]);
+    }
+    return { kept, dropped: notes.length - kept.length };
+}
+
+/**
+ * Build the Gemini prompt for an update analysis. Returns the (possibly capped)
+ * notes that were actually sent so the caller can log what was used.
  * @param {Object} container
  * @param {Array<{tag,date,body}>} notes
- * @returns {{system: string, user: string, schema: Object}}
+ * @returns {{system: string, user: string, schema: Object, dropped: number, chars: number}}
  */
 function buildPrompt(container, notes) {
     const image = container.image.name;
@@ -30,14 +101,22 @@ function buildPrompt(container, notes) {
     const target = container.result.tag;
     const system = [
         'You are a release-notes analyst for container image upgrades.',
-        'Summarize what changed between the current version and the target version,',
-        'and flag any potentially breaking changes such as renamed or removed config/env',
-        'keys, changed volume or data layouts, API/CLI changes, dropped platforms, or',
-        'required manual migration steps.',
+        'You are given the release notes for the versions released after the user\'s',
+        'current version, up to and including the target version. Every change in',
+        'these notes is part of this upgrade - do not question or speculate about',
+        'which version is current or target.',
+        'Summarize what changed and flag potentially breaking changes such as renamed',
+        'or removed config/env keys, changed volume or data layouts, API/CLI changes,',
+        'dropped platforms, or required manual migration steps.',
         'riskLevel must be one of: none, low, medium, high.',
-        'Be concise and specific. Use only the provided release notes; never invent changes.',
+        'For each breaking change and highlight, set version to the exact version tag',
+        'from the notes where it appears, when identifiable.',
+        'Output only the structured fields. Do not include your reasoning,',
+        'meta-commentary, or questions in any field. Be concise and specific, and use',
+        'only the provided release notes; never invent changes.',
     ].join(' ');
-    const notesText = notes
+    const { kept, dropped } = capNotes(notes);
+    const notesText = kept
         .map((note) => {
             const header = note.date ? `## ${note.tag} (${note.date})` : `## ${note.tag}`;
             return `${header}\n${note.body || ''}`;
@@ -51,7 +130,9 @@ function buildPrompt(container, notes) {
         'Release notes:',
         notesText,
     ].join('\n');
-    return { system, user, schema: RESPONSE_SCHEMA };
+    return {
+        system, user, schema: RESPONSE_SCHEMA, dropped, chars: user.length,
+    };
 }
 
 module.exports = {

--- a/app/ai/prompt.js
+++ b/app/ai/prompt.js
@@ -10,7 +10,7 @@ const RESPONSE_SCHEMA = {
         riskLevel: {
             type: 'string',
             enum: ['none', 'low', 'medium', 'high'],
-            description: 'Overall upgrade risk: high if manual migration or breaking config/data changes are required, none if purely additive/bugfix.',
+            description: 'Overall upgrade risk. none: purely additive or bug-fix, no action and nothing deprecated. low: minor default/behavior tweaks or newly deprecated-but-still-working options; review optional. medium: behavior changes or deprecations that likely need a config review or small adjustment, but remain backward compatible with no forced migration. high: breaking config/data/API changes, removed options, dropped platforms, or required manual migration. Pick the highest level any change in the notes justifies.',
         },
         breakingChanges: {
             type: 'array',
@@ -109,7 +109,13 @@ function buildPrompt(container, notes) {
         'Summarize what changed and flag potentially breaking changes such as renamed',
         'or removed config/env keys, changed volume or data layouts, API/CLI changes,',
         'dropped platforms, or required manual migration steps.',
-        'riskLevel must be one of: none, low, medium, high.',
+        'riskLevel must be one of: none (purely additive or bug-fix, no action),',
+        'low (minor default/behavior tweaks or deprecations that still work; review',
+        'optional), medium (behavior changes or deprecations that likely need a config',
+        'review or small adjustment but stay backward compatible with no forced',
+        'migration), high (breaking config/data/API changes, removed options, dropped',
+        'platforms, or required manual migration). Pick the highest level any change',
+        'in the notes justifies.',
         'For each breaking change and highlight, set version to the exact version tag',
         'from the notes where it appears, when identifiable.',
         'Output only the structured fields. Do not include your reasoning,',

--- a/app/ai/prompt.js
+++ b/app/ai/prompt.js
@@ -31,6 +31,7 @@ const RESPONSE_SCHEMA = {
                         description: 'The exact version tag from the notes where this change appears, if identifiable. Omit if unclear.',
                     },
                 },
+                required: ['title', 'detail'],
             },
         },
         highlights: {

--- a/app/ai/prompt.test.js
+++ b/app/ai/prompt.test.js
@@ -21,3 +21,44 @@ test('RESPONSE_SCHEMA declares the structured fields', () => {
         'riskLevel', 'breakingChanges', 'highlights', 'overview', 'versionsCovered',
     ]);
 });
+
+test('RESPONSE_SCHEMA constrains riskLevel to an enum and requires core fields', () => {
+    expect(RESPONSE_SCHEMA.properties.riskLevel.enum).toStrictEqual(['none', 'low', 'medium', 'high']);
+    expect(RESPONSE_SCHEMA.required).toEqual(expect.arrayContaining(['riskLevel', 'overview']));
+});
+
+test('RESPONSE_SCHEMA carries optional version refs on changes', () => {
+    expect(RESPONSE_SCHEMA.properties.breakingChanges.items.properties.version.type).toBe('string');
+    expect(RESPONSE_SCHEMA.properties.highlights.items.properties.version.type).toBe('string');
+    expect(RESPONSE_SCHEMA.properties.highlights.items.properties.text.type).toBe('string');
+});
+
+test('system prompt forbids meta-reasoning and frames the version range', () => {
+    const container = {
+        image: { name: 'x/y', tag: { value: 'v1' } },
+        result: { tag: 'v2' },
+    };
+    const { system } = buildPrompt(container, []);
+    expect(system.toLowerCase()).toContain('do not include your reasoning');
+    expect(system.toLowerCase()).toContain('do not question');
+});
+
+test('buildPrompt truncates an over-long note body', () => {
+    const container = {
+        image: { name: 'x/y', tag: { value: 'v1' } },
+        result: { tag: 'v2' },
+    };
+    const { user } = buildPrompt(container, [{ tag: 'v2', date: null, body: 'a'.repeat(9000) }]);
+    expect(user).toContain('[truncated]');
+});
+
+test('buildPrompt drops oldest notes past the total budget', () => {
+    const container = {
+        image: { name: 'x/y', tag: { value: 'v1' } },
+        result: { tag: 'v9' },
+    };
+    const notes = Array.from({ length: 30 }, (unused, i) => ({ tag: `v${i}`, date: null, body: 'z'.repeat(3000) }));
+    const { user, dropped } = buildPrompt(container, notes);
+    expect(dropped).toBeGreaterThan(0);
+    expect(user.length).toBeLessThanOrEqual(21000);
+});

--- a/app/ai/prompt.test.js
+++ b/app/ai/prompt.test.js
@@ -27,6 +27,11 @@ test('RESPONSE_SCHEMA constrains riskLevel to an enum and requires core fields',
     expect(RESPONSE_SCHEMA.required).toEqual(expect.arrayContaining(['riskLevel', 'overview']));
 });
 
+test('RESPONSE_SCHEMA requires a title and detail on each breaking change', () => {
+    expect(RESPONSE_SCHEMA.properties.breakingChanges.items.required)
+        .toStrictEqual(['title', 'detail']);
+});
+
 test('RESPONSE_SCHEMA carries optional version refs on changes', () => {
     expect(RESPONSE_SCHEMA.properties.breakingChanges.items.properties.version.type).toBe('string');
     expect(RESPONSE_SCHEMA.properties.highlights.items.properties.version.type).toBe('string');

--- a/app/ai/prompt.test.js
+++ b/app/ai/prompt.test.js
@@ -1,0 +1,23 @@
+const { buildPrompt, RESPONSE_SCHEMA } = require('./prompt');
+
+test('buildPrompt embeds image, versions and notes', () => {
+    const container = {
+        image: { name: 'nopoz/hosaka', tag: { value: 'v1.2.2' } },
+        result: { tag: 'v1.4.2' },
+    };
+    const notes = [{ tag: 'v1.4.0', date: '2026-01-01', body: 'Added a dark mode' }];
+    const { system, user, schema } = buildPrompt(container, notes);
+    expect(user).toContain('nopoz/hosaka');
+    expect(user).toContain('v1.2.2');
+    expect(user).toContain('v1.4.2');
+    expect(user).toContain('v1.4.0');
+    expect(user).toContain('Added a dark mode');
+    expect(system.toLowerCase()).toContain('breaking');
+    expect(schema).toBe(RESPONSE_SCHEMA);
+});
+
+test('RESPONSE_SCHEMA declares the structured fields', () => {
+    expect(Object.keys(RESPONSE_SCHEMA.properties)).toStrictEqual([
+        'riskLevel', 'breakingChanges', 'highlights', 'overview', 'versionsCovered',
+    ]);
+});

--- a/app/ai/providers/gemini.js
+++ b/app/ai/providers/gemini.js
@@ -1,0 +1,45 @@
+const request = require('../../request');
+
+const GEMINI_BASE = 'https://generativelanguage.googleapis.com/v1beta/models';
+
+/**
+ * Call Gemini's generateContent endpoint with JSON-mode output.
+ * @param {{system?:string, user:string, schema:Object, model:string, apiKey:string}} args
+ * @returns {Promise<Object>}
+ */
+async function generate({
+    system, user, schema, model, apiKey,
+}) {
+    const body = {
+        contents: [{ role: 'user', parts: [{ text: user }] }],
+        generationConfig: {
+            responseMimeType: 'application/json',
+            responseSchema: schema,
+            temperature: 0.2,
+        },
+    };
+    if (system) {
+        body.systemInstruction = { parts: [{ text: system }] };
+    }
+    const response = await request({
+        uri: `${GEMINI_BASE}/${model}:generateContent`,
+        method: 'POST',
+        headers: { 'x-goog-api-key': apiKey },
+        body,
+    });
+    const text = response
+        && response.candidates
+        && response.candidates[0]
+        && response.candidates[0].content
+        && response.candidates[0].content.parts
+        && response.candidates[0].content.parts[0]
+        && response.candidates[0].content.parts[0].text;
+    if (!text) {
+        throw new Error('Gemini returned no content');
+    }
+    return JSON.parse(text);
+}
+
+module.exports = {
+    generate,
+};

--- a/app/ai/providers/gemini.js
+++ b/app/ai/providers/gemini.js
@@ -1,9 +1,52 @@
 const request = require('../../request');
 
+const log = require('../../log').child({ component: 'ai.gemini' });
+
 const GEMINI_BASE = 'https://generativelanguage.googleapis.com/v1beta/models';
+// Per-attempt cap so a slow/hung upstream can't spin the UI loader forever.
+// Gemini normally answers in a few seconds; a hit on this means trouble, so a
+// timeout is NOT retried (that only stacks more long waits) - we fail fast and
+// let the user retry. Fast-failing overload statuses ARE retried.
+const TIMEOUT_MS = 20000;
+// Gemini (especially the -lite tiers) intermittently returns 503 "overloaded";
+// a couple of short retries clears most of them before the user sees an error.
+const MAX_ATTEMPTS = 3;
+const RETRY_DELAYS_MS = [800, 2500];
+const RETRYABLE_STATUS = new Set([429, 500, 502, 503, 504]);
+
+function sleep(ms) {
+    return new Promise((resolve) => {
+        setTimeout(resolve, ms);
+    });
+}
+
+function isTimeout(error) {
+    return error.code === 'ECONNABORTED' || /timeout/i.test(error.message || '');
+}
+
+function isRetryable(error) {
+    const status = error.response && error.response.status;
+    return RETRYABLE_STATUS.has(status);
+}
 
 /**
- * Call Gemini's generateContent endpoint with JSON-mode output.
+ * Map raw axios/network failures to a user-facing message. Unknown errors pass
+ * through unchanged.
+ */
+function friendlyError(error) {
+    const status = error.response && error.response.status;
+    if (status === 503 || status === 429) {
+        return new Error('The AI service is busy right now. Please try again in a moment.');
+    }
+    if (isTimeout(error)) {
+        return new Error('The AI service took too long to respond. Please try again.');
+    }
+    return error;
+}
+
+/**
+ * Call Gemini's generateContent endpoint with JSON-mode output. Retries
+ * transient errors (overload/timeout) with a short backoff.
  * @param {{system?:string, user:string, schema:Object, model:string, apiKey:string}} args
  * @returns {Promise<Object>}
  */
@@ -21,23 +64,41 @@ async function generate({
     if (system) {
         body.systemInstruction = { parts: [{ text: system }] };
     }
-    const response = await request({
-        uri: `${GEMINI_BASE}/${model}:generateContent`,
-        method: 'POST',
-        headers: { 'x-goog-api-key': apiKey },
-        body,
-    });
-    const text = response
-        && response.candidates
-        && response.candidates[0]
-        && response.candidates[0].content
-        && response.candidates[0].content.parts
-        && response.candidates[0].content.parts[0]
-        && response.candidates[0].content.parts[0].text;
-    if (!text) {
-        throw new Error('Gemini returned no content');
+
+    let lastError;
+    for (let attempt = 1; attempt <= MAX_ATTEMPTS; attempt += 1) {
+        try {
+            // eslint-disable-next-line no-await-in-loop
+            const response = await request({
+                uri: `${GEMINI_BASE}/${model}:generateContent`,
+                method: 'POST',
+                headers: { 'x-goog-api-key': apiKey },
+                body,
+                timeout: TIMEOUT_MS,
+            });
+            const text = response
+                && response.candidates
+                && response.candidates[0]
+                && response.candidates[0].content
+                && response.candidates[0].content.parts
+                && response.candidates[0].content.parts[0]
+                && response.candidates[0].content.parts[0].text;
+            if (!text) {
+                throw new Error('Gemini returned no content');
+            }
+            return JSON.parse(text);
+        } catch (error) {
+            lastError = error;
+            if (attempt >= MAX_ATTEMPTS || !isRetryable(error)) {
+                throw friendlyError(error);
+            }
+            const status = error.response && error.response.status;
+            log.warn({ attempt, status, model }, 'gemini call failed, retrying');
+            // eslint-disable-next-line no-await-in-loop
+            await sleep(RETRY_DELAYS_MS[attempt - 1]);
+        }
     }
-    return JSON.parse(text);
+    throw friendlyError(lastError);
 }
 
 module.exports = {

--- a/app/ai/providers/gemini.test.js
+++ b/app/ai/providers/gemini.test.js
@@ -5,12 +5,22 @@ const gemini = require('./gemini');
 
 beforeEach(() => {
     jest.resetAllMocks();
+    // Skip the real backoff delay so retry tests run instantly.
+    gemini.__set__('sleep', () => Promise.resolve());
 });
 
+function content(json) {
+    return { candidates: [{ content: { parts: [{ text: json }] } }] };
+}
+
+function httpError(status) {
+    const error = new Error(`Request failed with status code ${status}`);
+    error.response = { status };
+    return error;
+}
+
 test('generate posts to gemini with the api-key header and parses JSON content', async () => {
-    request.mockResolvedValue({
-        candidates: [{ content: { parts: [{ text: '{"riskLevel":"low","overview":"ok"}' }] } }],
-    });
+    request.mockResolvedValue(content('{"riskLevel":"low","overview":"ok"}'));
     const result = await gemini.generate({
         system: 'sys',
         user: 'usr',
@@ -23,6 +33,7 @@ test('generate posts to gemini with the api-key header and parses JSON content',
         uri: 'https://generativelanguage.googleapis.com/v1beta/models/gemini-2.5-flash-lite:generateContent',
         method: 'POST',
         headers: { 'x-goog-api-key': 'KEY' },
+        timeout: 20000,
     }));
     const body = request.mock.calls[0][0].body;
     expect(body.contents[0].parts[0].text).toBe('usr');
@@ -33,6 +44,44 @@ test('generate posts to gemini with the api-key header and parses JSON content',
 
 test('generate throws when the model returns no content', async () => {
     request.mockResolvedValue({ candidates: [] });
-    await expect(gemini.generate({ user: 'u', schema: {}, model: 'm', apiKey: 'k' }))
-        .rejects.toThrow('Gemini returned no content');
+    await expect(gemini.generate({
+        user: 'u', schema: {}, model: 'm', apiKey: 'k',
+    })).rejects.toThrow('Gemini returned no content');
+});
+
+test('generate retries a transient 503 then succeeds', async () => {
+    request
+        .mockRejectedValueOnce(httpError(503))
+        .mockResolvedValueOnce(content('{"riskLevel":"high"}'));
+    const result = await gemini.generate({
+        user: 'u', schema: {}, model: 'm', apiKey: 'k',
+    });
+    expect(result).toStrictEqual({ riskLevel: 'high' });
+    expect(request).toHaveBeenCalledTimes(2);
+});
+
+test('generate gives a friendly overload message after exhausting retries on 503', async () => {
+    request.mockRejectedValue(httpError(503));
+    await expect(gemini.generate({
+        user: 'u', schema: {}, model: 'm', apiKey: 'k',
+    })).rejects.toThrow('The AI service is busy right now. Please try again in a moment.');
+    expect(request).toHaveBeenCalledTimes(3);
+});
+
+test('generate fails fast on a timeout without retrying', async () => {
+    const timeoutError = new Error('timeout of 20000ms exceeded');
+    timeoutError.code = 'ECONNABORTED';
+    request.mockRejectedValue(timeoutError);
+    await expect(gemini.generate({
+        user: 'u', schema: {}, model: 'm', apiKey: 'k',
+    })).rejects.toThrow('The AI service took too long to respond. Please try again.');
+    expect(request).toHaveBeenCalledTimes(1);
+});
+
+test('generate does not retry a non-transient error', async () => {
+    request.mockRejectedValue(httpError(400));
+    await expect(gemini.generate({
+        user: 'u', schema: {}, model: 'm', apiKey: 'k',
+    })).rejects.toThrow('Request failed with status code 400');
+    expect(request).toHaveBeenCalledTimes(1);
 });

--- a/app/ai/providers/gemini.test.js
+++ b/app/ai/providers/gemini.test.js
@@ -1,0 +1,38 @@
+const request = require('../../request');
+
+jest.mock('../../request');
+const gemini = require('./gemini');
+
+beforeEach(() => {
+    jest.resetAllMocks();
+});
+
+test('generate posts to gemini with the api-key header and parses JSON content', async () => {
+    request.mockResolvedValue({
+        candidates: [{ content: { parts: [{ text: '{"riskLevel":"low","overview":"ok"}' }] } }],
+    });
+    const result = await gemini.generate({
+        system: 'sys',
+        user: 'usr',
+        schema: { type: 'object' },
+        model: 'gemini-2.5-flash-lite',
+        apiKey: 'KEY',
+    });
+    expect(result).toStrictEqual({ riskLevel: 'low', overview: 'ok' });
+    expect(request).toHaveBeenCalledWith(expect.objectContaining({
+        uri: 'https://generativelanguage.googleapis.com/v1beta/models/gemini-2.5-flash-lite:generateContent',
+        method: 'POST',
+        headers: { 'x-goog-api-key': 'KEY' },
+    }));
+    const body = request.mock.calls[0][0].body;
+    expect(body.contents[0].parts[0].text).toBe('usr');
+    expect(body.systemInstruction.parts[0].text).toBe('sys');
+    expect(body.generationConfig.responseMimeType).toBe('application/json');
+    expect(body.generationConfig.responseSchema).toStrictEqual({ type: 'object' });
+});
+
+test('generate throws when the model returns no content', async () => {
+    request.mockResolvedValue({ candidates: [] });
+    await expect(gemini.generate({ user: 'u', schema: {}, model: 'm', apiKey: 'k' }))
+        .rejects.toThrow('Gemini returned no content');
+});

--- a/app/ai/providers/index.js
+++ b/app/ai/providers/index.js
@@ -1,0 +1,20 @@
+const gemini = require('./gemini');
+
+/**
+ * Resolve an AI provider by name. New providers implement the same
+ * generate({ system, user, schema, model, apiKey }) contract.
+ * @param {string} name
+ * @returns {{generate: Function}}
+ */
+function getProvider(name) {
+    switch (name) {
+        case 'gemini':
+            return gemini;
+        default:
+            throw new Error(`Unsupported AI provider: ${name}`);
+    }
+}
+
+module.exports = {
+    getProvider,
+};

--- a/app/ai/webFallback.js
+++ b/app/ai/webFallback.js
@@ -14,6 +14,7 @@ async function fetchNotesFromUrl(url) {
             uri: url,
             method: 'GET',
             headers: { Accept: 'text/html', 'User-Agent': 'hosaka' },
+            timeout: 15000,
         });
         const text = String(html)
             .replace(/<script[\s\S]*?<\/script>/gi, ' ')

--- a/app/ai/webFallback.js
+++ b/app/ai/webFallback.js
@@ -1,0 +1,32 @@
+const request = require('../request');
+
+const MAX_CHARS = 12000;
+
+/**
+ * Fetch a URL and reduce it to plain text for the model. Used only when a
+ * GitHub repo can't be located. Returns '' on any failure.
+ * @param {string} url
+ * @returns {Promise<string>}
+ */
+async function fetchNotesFromUrl(url) {
+    try {
+        const html = await request({
+            uri: url,
+            method: 'GET',
+            headers: { Accept: 'text/html', 'User-Agent': 'hosaka' },
+        });
+        const text = String(html)
+            .replace(/<script[\s\S]*?<\/script>/gi, ' ')
+            .replace(/<style[\s\S]*?<\/style>/gi, ' ')
+            .replace(/<[^>]+>/g, ' ')
+            .replace(/\s+/g, ' ')
+            .trim();
+        return text.slice(0, MAX_CHARS);
+    } catch (e) {
+        return '';
+    }
+}
+
+module.exports = {
+    fetchNotesFromUrl,
+};

--- a/app/ai/webFallback.js
+++ b/app/ai/webFallback.js
@@ -17,8 +17,8 @@ async function fetchNotesFromUrl(url) {
             timeout: 15000,
         });
         const text = String(html)
-            .replace(/<script[\s\S]*?<\/script>/gi, ' ')
-            .replace(/<style[\s\S]*?<\/style>/gi, ' ')
+            .replace(/<script[\s\S]*?<\/script[^>]*>/gi, ' ')
+            .replace(/<style[\s\S]*?<\/style[^>]*>/gi, ' ')
             .replace(/<[^>]+>/g, ' ')
             .replace(/\s+/g, ' ')
             .trim();

--- a/app/ai/webFallback.test.js
+++ b/app/ai/webFallback.test.js
@@ -1,0 +1,24 @@
+const request = require('../request');
+
+jest.mock('../request');
+const { fetchNotesFromUrl } = require('./webFallback');
+
+beforeEach(() => {
+    jest.resetAllMocks();
+});
+
+test('strips html and script content to plain text', async () => {
+    request.mockResolvedValue(
+        '<html><body><h1>Notes</h1><p>Hello <b>world</b></p><script>evil()</script></body></html>',
+    );
+    const text = await fetchNotesFromUrl('http://x');
+    expect(text).toContain('Notes');
+    expect(text).toContain('Hello world');
+    expect(text).not.toContain('<');
+    expect(text).not.toContain('evil()');
+});
+
+test('returns an empty string on request error', async () => {
+    request.mockRejectedValue(new Error('boom'));
+    expect(await fetchNotesFromUrl('http://x')).toBe('');
+});

--- a/app/ai/webFallback.test.js
+++ b/app/ai/webFallback.test.js
@@ -18,6 +18,16 @@ test('strips html and script content to plain text', async () => {
     expect(text).not.toContain('evil()');
 });
 
+test('strips script blocks whose end tag has whitespace or trailing chars', async () => {
+    request.mockResolvedValue(
+        '<p>Keep</p><script>evil()</script ><script type="x">bad()</script\n>',
+    );
+    const text = await fetchNotesFromUrl('http://x');
+    expect(text).toContain('Keep');
+    expect(text).not.toContain('evil()');
+    expect(text).not.toContain('bad()');
+});
+
 test('returns an empty string on request error', async () => {
     request.mockRejectedValue(new Error('boom'));
     expect(await fetchNotesFromUrl('http://x')).toBe('');

--- a/app/api/container.js
+++ b/app/api/container.js
@@ -11,6 +11,7 @@ const { getServerConfiguration, getTriggerConfigurations } = require('../configu
 const HttpTrigger = require('../triggers/providers/http/Http');
 const ScriptTrigger = require('../triggers/providers/script/Script');
 const { scriptOutputEmitter } = ScriptTrigger;
+const ai = require('../ai');
 
 const router = express.Router();
 
@@ -174,6 +175,32 @@ async function installContainer(req, res) {
         res.status(500).json({
             error: `Error when installing container ${id} (${e.message})`,
         });
+    }
+}
+
+/**
+ * Run an on-demand AI analysis of the update for a container.
+ * @param {Object} req
+ * @param {Object} res
+ */
+async function analyzeUpdateContainer(req, res) {
+    const { id } = req.params;
+    const container = storeContainer.getContainer(id);
+    if (!container) {
+        return res.sendStatus(404);
+    }
+    const force = req.query.force === 'true' || req.query.force === true;
+    try {
+        const result = await ai.analyzeUpdate(container, { force });
+        return res.status(200).json(result);
+    } catch (e) {
+        if (e.code === 'AI_DISABLED') {
+            return res.status(503).json({ error: e.message });
+        }
+        if (e.code === 'NO_UPDATE') {
+            return res.status(400).json({ error: e.message });
+        }
+        return res.status(502).json({ error: `Error analyzing update for ${id} (${e.message})` });
     }
 }
 
@@ -541,6 +568,7 @@ function init() {
     router.delete('/:id', deleteContainer);
     router.post('/:id/watch', watchContainer);
     router.post('/:id/install', installContainer);
+    router.post('/:id/analyze-update', analyzeUpdateContainer);
     router.post('/:id/clear-notification', clearContainerNotification);
     router.get('/:id/install/logs', streamInstallLogs);
     router.post('/refresh', refreshContainer);

--- a/app/api/server.js
+++ b/app/api/server.js
@@ -1,6 +1,6 @@
 const express = require('express');
 const nocache = require('nocache');
-const { getServerConfiguration } = require('../configuration');
+const { getServerConfiguration, getAiPublicConfiguration } = require('../configuration');
 
 const router = express.Router();
 
@@ -11,7 +11,10 @@ const router = express.Router();
  */
 function getServer(req, res) {
     res.status(200).json({
-        configuration: getServerConfiguration(),
+        configuration: {
+            ...getServerConfiguration(),
+            ai: getAiPublicConfiguration(),
+        },
     });
 }
 

--- a/app/configuration/index.js
+++ b/app/configuration/index.js
@@ -131,6 +131,55 @@ function getServerConfiguration() {
     return configurationToValidate.value;
 }
 
+/**
+ * Get AI configuration (full, includes secrets — backend use only).
+ */
+function getAiConfiguration() {
+    const configurationFromEnv = get('hosaka.ai', hosakaEnvVars);
+    const configurationSchema = joi.object().keys({
+        provider: joi.string(),
+        gemini: joi.object({
+            apikey: joi.string().allow(''),
+            model: joi.string(),
+        }),
+        github: joi.object({
+            token: joi.string().allow(''),
+        }),
+    });
+
+    const configurationToValidate = configurationSchema.validate(configurationFromEnv || {});
+    if (configurationToValidate.error) {
+        throw configurationToValidate.error;
+    }
+    const { value } = configurationToValidate;
+    const provider = value.provider || 'gemini';
+    const gemini = {
+        apikey: (value.gemini && value.gemini.apikey) || '',
+        model: (value.gemini && value.gemini.model) || 'gemini-2.5-flash-lite',
+    };
+    const github = {
+        token: (value.github && value.github.token) || '',
+    };
+    return {
+        provider,
+        gemini,
+        github,
+        enabled: Boolean(gemini.apikey),
+    };
+}
+
+/**
+ * Get the sanitized AI configuration exposed to the UI (no secrets).
+ */
+function getAiPublicConfiguration() {
+    const config = getAiConfiguration();
+    return {
+        enabled: config.enabled,
+        provider: config.provider,
+        model: config.gemini.model,
+    };
+}
+
 function getPublicUrl(req) {
     const publicUrl = hosakaEnvVars.HOSAKA_PUBLIC_URL;
     if (publicUrl) {
@@ -152,5 +201,7 @@ module.exports = {
     getRegistryConfigurations,
     getAuthenticationConfigurations,
     getServerConfiguration,
+    getAiConfiguration,
+    getAiPublicConfiguration,
     getPublicUrl,
 };

--- a/app/configuration/index.js
+++ b/app/configuration/index.js
@@ -137,10 +137,10 @@ function getServerConfiguration() {
 function getAiConfiguration() {
     const configurationFromEnv = get('hosaka.ai', hosakaEnvVars);
     const configurationSchema = joi.object().keys({
-        provider: joi.string(),
+        provider: joi.string().allow(''),
         gemini: joi.object({
             apikey: joi.string().allow(''),
-            model: joi.string(),
+            model: joi.string().allow(''),
         }),
         github: joi.object({
             token: joi.string().allow(''),

--- a/app/configuration/index.js
+++ b/app/configuration/index.js
@@ -155,7 +155,7 @@ function getAiConfiguration() {
     const provider = value.provider || 'gemini';
     const gemini = {
         apikey: (value.gemini && value.gemini.apikey) || '',
-        model: (value.gemini && value.gemini.model) || 'gemini-2.5-flash-lite',
+        model: (value.gemini && value.gemini.model) || 'gemini-3.1-flash-lite',
     };
     const github = {
         token: (value.github && value.github.token) || '',

--- a/app/configuration/index.test.js
+++ b/app/configuration/index.test.js
@@ -109,7 +109,7 @@ test('getAiConfiguration returns defaults and disabled when no key', () => {
     delete configuration.hosakaEnvVars.HOSAKA_AI_GITHUB_TOKEN;
     expect(configuration.getAiConfiguration()).toStrictEqual({
         provider: 'gemini',
-        gemini: { apikey: '', model: 'gemini-2.5-flash-lite' },
+        gemini: { apikey: '', model: 'gemini-3.1-flash-lite' },
         github: { token: '' },
         enabled: false,
     });
@@ -138,6 +138,6 @@ test('getAiPublicConfiguration omits the api key and token', () => {
 test('getAiConfiguration falls back to default model when the env value is empty', () => {
     configuration.hosakaEnvVars.HOSAKA_AI_GEMINI_MODEL = '';
     const config = configuration.getAiConfiguration();
-    expect(config.gemini.model).toBe('gemini-2.5-flash-lite');
+    expect(config.gemini.model).toBe('gemini-3.1-flash-lite');
     delete configuration.hosakaEnvVars.HOSAKA_AI_GEMINI_MODEL;
 });

--- a/app/configuration/index.test.js
+++ b/app/configuration/index.test.js
@@ -101,3 +101,36 @@ test('replaceSecrets must read secret in file', () => {
         HOSAKA_SERVER_X: 'super_secret',
     });
 });
+
+test('getAiConfiguration returns defaults and disabled when no key', () => {
+    delete configuration.hosakaEnvVars.HOSAKA_AI_PROVIDER;
+    delete configuration.hosakaEnvVars.HOSAKA_AI_GEMINI_APIKEY;
+    delete configuration.hosakaEnvVars.HOSAKA_AI_GEMINI_MODEL;
+    delete configuration.hosakaEnvVars.HOSAKA_AI_GITHUB_TOKEN;
+    expect(configuration.getAiConfiguration()).toStrictEqual({
+        provider: 'gemini',
+        gemini: { apikey: '', model: 'gemini-2.5-flash-lite' },
+        github: { token: '' },
+        enabled: false,
+    });
+});
+
+test('getAiConfiguration is enabled when an api key is set', () => {
+    configuration.hosakaEnvVars.HOSAKA_AI_GEMINI_APIKEY = 'secret';
+    const config = configuration.getAiConfiguration();
+    expect(config.enabled).toBe(true);
+    expect(config.gemini.apikey).toBe('secret');
+    delete configuration.hosakaEnvVars.HOSAKA_AI_GEMINI_APIKEY;
+});
+
+test('getAiPublicConfiguration omits the api key and token', () => {
+    configuration.hosakaEnvVars.HOSAKA_AI_GEMINI_APIKEY = 'secret';
+    configuration.hosakaEnvVars.HOSAKA_AI_GEMINI_MODEL = 'gemini-2.5-flash';
+    expect(configuration.getAiPublicConfiguration()).toStrictEqual({
+        enabled: true,
+        provider: 'gemini',
+        model: 'gemini-2.5-flash',
+    });
+    delete configuration.hosakaEnvVars.HOSAKA_AI_GEMINI_APIKEY;
+    delete configuration.hosakaEnvVars.HOSAKA_AI_GEMINI_MODEL;
+});

--- a/app/configuration/index.test.js
+++ b/app/configuration/index.test.js
@@ -134,3 +134,10 @@ test('getAiPublicConfiguration omits the api key and token', () => {
     delete configuration.hosakaEnvVars.HOSAKA_AI_GEMINI_APIKEY;
     delete configuration.hosakaEnvVars.HOSAKA_AI_GEMINI_MODEL;
 });
+
+test('getAiConfiguration falls back to default model when the env value is empty', () => {
+    configuration.hosakaEnvVars.HOSAKA_AI_GEMINI_MODEL = '';
+    const config = configuration.getAiConfiguration();
+    expect(config.gemini.model).toBe('gemini-2.5-flash-lite');
+    delete configuration.hosakaEnvVars.HOSAKA_AI_GEMINI_MODEL;
+});

--- a/app/request/index.js
+++ b/app/request/index.js
@@ -28,6 +28,7 @@ async function request(options = {}) {
         insecure = false,
         responseType,
         signal,
+        timeout,
     } = options;
 
     const config = {
@@ -41,6 +42,9 @@ async function request(options = {}) {
     }
     if (signal !== undefined) {
         config.signal = signal;
+    }
+    if (timeout !== undefined) {
+        config.timeout = timeout;
     }
     // Opt-in skip of TLS verification for self-signed / IP-addressed endpoints.
     // Off by default so verification stays on; callers pass insecure: true only

--- a/docker-compose.example.yml
+++ b/docker-compose.example.yml
@@ -67,6 +67,16 @@ services:
       # - HOSAKA_SERVER_TLS_KEY=/certs/server.key
       # - HOSAKA_SERVER_TLS_CERT=/certs/server.crt
 
+      # ── AI update analysis (optional, off by default) ───────────────────────
+      # Adds an "Analyze" button to each container that has an update. On click,
+      # Hosaka gathers the release notes between the running version and the target
+      # and asks Google Gemini to summarize them: an overall risk level, breaking
+      # changes, and what changed. On-demand only; nothing is sent anywhere until you
+      # click. The feature (and the button) stay off until you set an API key.
+      # - HOSAKA_AI_GEMINI_APIKEY=AIza...                # Google Gemini API key; enabling the feature (__FILE supported)
+      # - HOSAKA_AI_GEMINI_MODEL=gemini-3.1-flash-lite   # override the Gemini model (this is the default)
+      # - HOSAKA_AI_GITHUB_TOKEN=ghp_xxxxxxxx            # optional: raise the GitHub API rate limit for fetching release notes (__FILE supported)
+
       # ── Store (LokiJS state) ────────────────────────────────────────────────
       # - HOSAKA_STORE_PATH=/store               # directory for the state DB (default /store)
       # - HOSAKA_STORE_FILE=hosaka.json          # state DB filename

--- a/docs/configuration/README.md
+++ b/docs/configuration/README.md
@@ -2,6 +2,8 @@
 Hosaka is relying on **Environment Variables** and **[Docker labels](https://docs.docker.com/config/labels-custom-metadata/)** to configure all the components.
 
 Please find below the documentation for each of them:
+> [**AI update analysis**](/configuration/ai/)
+
 > [**Authentication**](/configuration/authentications/)
 
 > [**Logs**](/configuration/logs/)

--- a/docs/configuration/ai/README.md
+++ b/docs/configuration/ai/README.md
@@ -1,0 +1,103 @@
+# AI update analysis
+
+Hosaka can analyze an available update on demand and tell you what changed
+between the version you run and the one on offer. It is **off by default** and
+runs **only when you ask** for it.
+
+When configured, every container row with an available update shows an
+**Analyze** button (a search-eye icon). Clicking it opens a dialog that shows:
+
+- an overall **risk level**: `none`, `low`, `medium`, or `high`
+- a short **overview** of the upgrade
+- the **breaking changes**, each attributed to the version that introduced it
+- the notable non-breaking **changes**
+- links to the **source** release notes
+
+Behind the scenes Hosaka gathers the release notes between your current and
+target version (from GitHub Releases, following linked changelogs, with a
+fallback to the release page a `hosaka.link.template` points at) and asks
+[Google Gemini](https://ai.google.dev/) to summarize them into the structured
+result above. Results are cached per container and version pair; **Regenerate**
+in the dialog re-runs the analysis.
+
+The button only appears when an API key is set. Without one, the feature stays
+hidden and no AI calls are ever made.
+
+### Variables
+
+| Env var                    | Required       | Description                                                                                  | Supported values                | Default value when missing |
+| -------------------------- |:--------------:|--------------------------------------------------------------------------------------------- | ------------------------------- | -------------------------- |
+| `HOSAKA_AI_GEMINI_APIKEY`  | :white_circle: | Google Gemini API key. Setting it enables the feature and shows the **Analyze** button       | A Gemini API key                |                            |
+| `HOSAKA_AI_GEMINI_MODEL`   | :white_circle: | Gemini model used for the analysis                                                            | A Gemini model id               | `gemini-3.1-flash-lite`    |
+| `HOSAKA_AI_GITHUB_TOKEN`   | :white_circle: | GitHub token used when fetching release notes; raises the GitHub API rate limit              | A GitHub personal access token  |                            |
+| `HOSAKA_AI_PROVIDER`       | :white_circle: | AI provider                                                                                   | `gemini`                        | `gemini`                   |
+
+All of these support the `__FILE` suffix (Docker secrets); see
+[Secret management](/configuration/#secret-management).
+
+### Getting a key
+
+Create a Google Gemini API key in
+[Google AI Studio](https://aistudio.google.com/apikey) and set it as
+`HOSAKA_AI_GEMINI_APIKEY`. A `GITHUB_TOKEN` is optional: unauthenticated GitHub
+API calls are rate-limited, so a token helps if you analyze many updates in a
+short window.
+
+### Privacy
+
+Enabling this feature sends the gathered release-note text, the image name, and
+the two version tags to Google Gemini for summarization. It sends only public
+release notes, never your container configuration or secrets, and only when you
+click **Analyze**. Leave `HOSAKA_AI_GEMINI_APIKEY` unset to keep the feature off
+entirely.
+
+### Examples
+
+#### Enable update analysis
+
+<!-- tabs:start -->
+#### **Docker Compose**
+```yaml
+version: '3'
+
+services:
+  hosaka:
+    image: ghcr.io/nopoz/hosaka
+    ...
+    environment:
+      - HOSAKA_AI_GEMINI_APIKEY=AIza...
+      # Optional:
+      # - HOSAKA_AI_GEMINI_MODEL=gemini-3.1-flash-lite
+      # - HOSAKA_AI_GITHUB_TOKEN=ghp_xxxxxxxx
+```
+#### **Docker**
+```bash
+docker run \
+  -e "HOSAKA_AI_GEMINI_APIKEY=AIza..." \
+  ...
+  ghcr.io/nopoz/hosaka
+```
+<!-- tabs:end -->
+
+#### Load the key from a Docker secret
+
+<!-- tabs:start -->
+#### **Docker Compose**
+```yaml
+version: '3'
+
+services:
+  hosaka:
+    image: ghcr.io/nopoz/hosaka
+    ...
+    environment:
+      - HOSAKA_AI_GEMINI_APIKEY__FILE=/run/secrets/gemini_api_key
+```
+#### **Docker**
+```bash
+docker run \
+  -e "HOSAKA_AI_GEMINI_APIKEY__FILE=/run/secrets/gemini_api_key" \
+  ...
+  ghcr.io/nopoz/hosaka
+```
+<!-- tabs:end -->

--- a/docs/configuration/sidebar.md
+++ b/docs/configuration/sidebar.md
@@ -1,6 +1,7 @@
 - [Introduction](/)
 - [Quick start](quickstart/)
 - [Configuration](configuration/)
+    - [AI update analysis](configuration/ai/)
     - [Authentication](configuration/authentications/)    
     - [Logs](configuration/logs/)
     - [Registries](configuration/registries/)

--- a/docs/ui/README.md
+++ b/docs/ui/README.md
@@ -21,6 +21,20 @@ in real time over a Server-Sent Events connection at
 exits, so you can follow the progress of a Portainer stack redeploy or any
 other update script without polling.
 
+## AI update analysis
+
+When AI analysis is configured, each container row with an available update also
+shows an **Analyze** button (a search-eye icon). Clicking it opens a dialog and
+calls `POST /api/containers/:id/analyze-update`, which gathers the release notes
+between the running version and the update target and asks the configured AI
+provider to summarize them. The dialog shows an overall risk level, a short
+overview, the breaking changes (each linked to the version that introduced it),
+the notable non-breaking changes, and links to the source release notes.
+
+Results are cached per container and version pair; **Regenerate** re-runs the
+analysis (`?force=true`). The button only appears when an API key is set; see
+[AI update analysis](configuration/ai/) for setup.
+
 ## Live container state
 
 The container list updates in place without a full-page refresh. The UI holds an

--- a/ui/src/App.vue
+++ b/ui/src/App.vue
@@ -69,8 +69,17 @@ export default {
      * Save current user when authenticated.
      * @param user
      */
-    onAuthenticated(user) {
+    async onAuthenticated(user) {
       this.user = user;
+      // Fetch the server config here, when auth is known, rather than in a
+      // render hook: anonymous auth has no /login -> /containers bounce, so the
+      // App re-render that beforeUpdate relied on never happened and the config
+      // (feature flags, ai.enabled) stayed undefined. This fires on every nav,
+      // so the guard keeps it to a single fetch.
+      if (!this.$serverConfig) {
+        const server = await getServer();
+        this.$setServerConfig(server.configuration);
+      }
     },
 
     /**
@@ -114,13 +123,6 @@ export default {
     this.$bus.off("authenticated", this.onAuthenticated);
     this.$bus.off("notify", this.notify);
     this.$bus.off("notify:close", this.notifyClose);
-  },
-
-  async beforeUpdate() {
-    if (this.authenticated && !this.$serverConfig) {
-      const server = await getServer();
-      this.$serverConfig = server.configuration;
-    }
   },
 };
 </script>

--- a/ui/src/components/ContainerItem.vue
+++ b/ui/src/components/ContainerItem.vue
@@ -160,6 +160,17 @@
             <container-image :image="container.image" />
           </v-window-item>
           <v-window-item v-if="container.result">
+            <div v-if="aiEnabled" class="text-center pa-2">
+              <v-btn
+                size="small"
+                color="info"
+                variant="outlined"
+                @click="showUpdateAnalysis = true"
+              >
+                <v-icon start>ri-magic-line</v-icon>
+                Analyze update
+              </v-btn>
+            </div>
             <container-update
               :result="container.result"
               :semver="container.image.tag.semver"
@@ -245,6 +256,10 @@
       @update-complete="handleUpdateComplete"
       @dialog-closed="handleDialogClosed"
     />
+    <update-analysis-dialog
+      v-model="showUpdateAnalysis"
+      :container="container"
+    />
   </v-card>
 </template>
 
@@ -258,6 +273,7 @@ import { getRegistryProviderIcon } from "@/services/registry";
 import { date, short } from "@/filters";
 import { copyTextToClipboard } from "@/utils/clipboard";
 import ScriptOutputDialog from './ScriptOutputDialog.vue';
+import UpdateAnalysisDialog from './UpdateAnalysisDialog.vue';
 
 export default {
   components: {
@@ -265,7 +281,8 @@ export default {
     ContainerImage,
     ContainerUpdate,
     ContainerError,
-    ScriptOutputDialog
+    ScriptOutputDialog,
+    UpdateAnalysisDialog,
   },
 
   props: {
@@ -281,6 +298,7 @@ export default {
       tab: 0,
       showScriptOutput: false,
       updateInProgress: false,
+      showUpdateAnalysis: false,
     };
   },
   computed: {
@@ -290,6 +308,10 @@ export default {
     // reveals the Delete control once the feature flag arrives.
     deleteEnabled() {
       return this.$serverConfig?.feature?.delete ?? false;
+    },
+
+    aiEnabled() {
+      return this.$serverConfig?.ai?.enabled ?? false;
     },
 
     containerIcon() {

--- a/ui/src/components/ContainerItem.vue
+++ b/ui/src/components/ContainerItem.vue
@@ -59,7 +59,7 @@
         @click.stop="showUpdateAnalysis = true"
         class="mr-1"
       >
-        <v-icon start>ri-magic-line</v-icon>
+        <v-icon start>ri-search-eye-line</v-icon>
         Analyze
       </v-chip>
       <v-tooltip location="bottom">
@@ -140,7 +140,7 @@
           class="ml-2 flex-shrink-0"
           @click.stop="showUpdateAnalysis = true"
         >
-          <v-icon start>ri-magic-line</v-icon>
+          <v-icon start>ri-search-eye-line</v-icon>
           Analyze
         </v-btn>
       </div>

--- a/ui/src/components/ContainerItem.vue
+++ b/ui/src/components/ContainerItem.vue
@@ -51,6 +51,17 @@
         <v-icon start>ri-arrow-up-circle-line</v-icon>
         Update
       </v-chip>
+      <v-chip
+        v-if="aiEnabled && container.updateAvailable"
+        label
+        color="info"
+        variant="outlined"
+        @click.stop="showUpdateAnalysis = true"
+        class="mr-1"
+      >
+        <v-icon start>ri-magic-line</v-icon>
+        Analyze
+      </v-chip>
       <v-tooltip location="bottom">
         <template v-slot:activator="{ props }">
           <v-chip
@@ -121,6 +132,17 @@
           <v-icon start>ri-arrow-up-circle-line</v-icon>
           Update
         </v-btn>
+        <v-btn
+          v-if="aiEnabled"
+          color="info"
+          variant="outlined"
+          size="small"
+          class="ml-2 flex-shrink-0"
+          @click.stop="showUpdateAnalysis = true"
+        >
+          <v-icon start>ri-magic-line</v-icon>
+          Analyze
+        </v-btn>
       </div>
     </div>
     <v-expand-transition>
@@ -160,17 +182,6 @@
             <container-image :image="container.image" />
           </v-window-item>
           <v-window-item v-if="container.result">
-            <div v-if="aiEnabled" class="text-center pa-2">
-              <v-btn
-                size="small"
-                color="info"
-                variant="outlined"
-                @click="showUpdateAnalysis = true"
-              >
-                <v-icon start>ri-magic-line</v-icon>
-                Analyze update
-              </v-btn>
-            </div>
             <container-update
               :result="container.result"
               :semver="container.image.tag.semver"

--- a/ui/src/components/InlineMarkup.vue
+++ b/ui/src/components/InlineMarkup.vue
@@ -1,0 +1,54 @@
+<template>
+  <span
+    ><template v-for="(seg, i) in segments" :key="i"
+      ><code v-if="seg.code" class="inline-code">{{ seg.text }}</code
+      ><template v-else>{{ seg.text }}</template></template
+    ></span
+  >
+</template>
+
+<script>
+// Render the model's `backtick` spans as inline code. Deliberately not a full
+// markdown renderer (kept dependency-free) and avoids v-html so model output
+// can never inject markup.
+export default {
+  name: "InlineMarkup",
+
+  props: {
+    text: {
+      type: String,
+      default: "",
+    },
+  },
+
+  computed: {
+    segments() {
+      const source = this.text || "";
+      const out = [];
+      let last = 0;
+      [...source.matchAll(/`([^`]+)`/g)].forEach((match) => {
+        if (match.index > last) {
+          out.push({ text: source.slice(last, match.index), code: false });
+        }
+        out.push({ text: match[1], code: true });
+        last = match.index + match[0].length;
+      });
+      if (last < source.length) {
+        out.push({ text: source.slice(last), code: false });
+      }
+      return out;
+    },
+  },
+};
+</script>
+
+<style scoped>
+.inline-code {
+  font-family: "JetBrains Mono", ui-monospace, monospace;
+  font-size: 0.85em;
+  background: rgba(var(--v-theme-on-surface), 0.1);
+  padding: 0.1em 0.35em;
+  border-radius: 4px;
+  overflow-wrap: anywhere;
+}
+</style>

--- a/ui/src/components/UpdateAnalysisDialog.vue
+++ b/ui/src/components/UpdateAnalysisDialog.vue
@@ -98,15 +98,15 @@
 
           <div v-if="sources.length" class="text-caption text-medium-emphasis">
             <span class="me-1">Sources:</span>
-            <template v-for="(s, i) in sources" :key="s.tag + i">
+            <template v-for="(s, i) in sources" :key="s.label + i">
               <a
                 v-if="s.url"
                 :href="s.url"
                 target="_blank"
                 rel="noopener"
                 class="version-ref"
-              >{{ s.tag }}</a>
-              <span v-else>{{ s.tag }}</span
+              >{{ s.label }}</a>
+              <span v-else>{{ s.label }}</span
               ><span v-if="i < sources.length - 1">,&nbsp;</span>
             </template>
           </div>
@@ -181,11 +181,21 @@ export default {
 
     // The gathered notes are the authoritative, linkable list of sources (each
     // carries the release/changelog URL). The model's versionsCovered is only
-    // free text, so we link from these instead.
+    // free text, so we link from these instead. GitHub notes link a version tag
+    // to that release; the web fallback is a single flat changelog page, so we
+    // label it by its page (host/path) rather than imply a version-specific link.
     sources() {
-      return ((this.result && this.result.sourceNotes) || [])
+      if (!this.result) {
+        return [];
+      }
+      const isWeb = this.result.source === 'web';
+      return (this.result.sourceNotes || [])
         .filter((note) => note && note.tag)
-        .map((note) => ({ tag: note.tag, url: note.url || null }));
+        .map((note) => ({
+          tag: note.tag,
+          label: isWeb ? (this.urlLabel(note.url) || note.tag) : note.tag,
+          url: note.url || null,
+        }));
     },
 
     // Key by both the raw tag and a v-stripped form: the model often emits
@@ -226,6 +236,20 @@ export default {
   },
 
   methods: {
+    // Host + path of a URL (no protocol/query), used to label a flat changelog
+    // source so it doesn't masquerade as a version-specific link.
+    urlLabel(url) {
+      if (!url) {
+        return null;
+      }
+      try {
+        const u = new URL(url);
+        return `${u.hostname}${u.pathname.replace(/\/$/, '')}`;
+      } catch (e) {
+        return null;
+      }
+    },
+
     versionUrl(version) {
       if (!version) {
         return null;

--- a/ui/src/components/UpdateAnalysisDialog.vue
+++ b/ui/src/components/UpdateAnalysisDialog.vue
@@ -51,53 +51,65 @@
             </v-chip>
           </div>
 
-          <div v-if="result.breakingChanges && result.breakingChanges.length" class="mb-4">
-            <div class="text-subtitle-2 mb-1">Breaking changes</div>
-            <v-list density="compact" class="bg-transparent">
-              <v-list-item
-                v-for="(bc, i) in result.breakingChanges"
-                :key="i"
-                class="px-0"
-              >
-                <v-list-item-title class="font-weight-medium text-wrap">
-                  {{ bc.title }}
-                </v-list-item-title>
-                <v-list-item-subtitle v-if="bc.detail" class="text-wrap">
-                  {{ bc.detail }}
-                </v-list-item-subtitle>
-              </v-list-item>
-            </v-list>
+          <p v-if="result.overview" class="text-body-2 mb-4">
+            <inline-markup :text="result.overview" />
+          </p>
+
+          <div v-if="sortedBreakingChanges.length" class="mb-4">
+            <div class="text-subtitle-2 mb-2">Breaking changes</div>
+            <div v-for="(bc, i) in sortedBreakingChanges" :key="i" class="mb-3">
+              <div class="font-weight-medium">
+                <inline-markup :text="bc.title" />
+                <a
+                  v-if="bc.version && versionUrl(bc.version)"
+                  :href="versionUrl(bc.version)"
+                  target="_blank"
+                  rel="noopener"
+                  class="version-ref ms-1"
+                >{{ bc.version }}</a>
+                <span v-else-if="bc.version" class="version-ref-plain ms-1">
+                  {{ bc.version }}
+                </span>
+              </div>
+              <div v-if="bc.detail" class="text-body-2">
+                <inline-markup :text="bc.detail" />
+              </div>
+            </div>
           </div>
 
-          <div v-if="result.highlights && result.highlights.length" class="mb-4">
-            <div class="text-subtitle-2 mb-1">What changed</div>
-            <ul class="ms-4">
-              <li v-for="(h, i) in result.highlights" :key="i">{{ h }}</li>
+          <div v-if="sortedHighlights.length" class="mb-4">
+            <div class="text-subtitle-2 mb-2">What changed</div>
+            <ul class="highlight-list">
+              <li v-for="(h, i) in sortedHighlights" :key="i" class="mb-1">
+                <inline-markup :text="highlightText(h)" />
+                <a
+                  v-if="highlightVersion(h) && versionUrl(highlightVersion(h))"
+                  :href="versionUrl(highlightVersion(h))"
+                  target="_blank"
+                  rel="noopener"
+                  class="version-ref ms-1"
+                >{{ highlightVersion(h) }}</a>
+                <span v-else-if="highlightVersion(h)" class="version-ref-plain ms-1">
+                  {{ highlightVersion(h) }}
+                </span>
+              </li>
             </ul>
           </div>
 
-          <p v-if="result.overview" class="text-body-2 mb-4">{{ result.overview }}</p>
-
-          <div
-            v-if="result.versionsCovered && result.versionsCovered.length"
-            class="text-caption text-medium-emphasis mb-2"
-          >
-            Covers {{ result.versionsCovered.join(', ') }}
+          <div v-if="sources.length" class="text-caption text-medium-emphasis">
+            <span class="me-1">Sources:</span>
+            <template v-for="(s, i) in sources" :key="s.tag + i">
+              <a
+                v-if="s.url"
+                :href="s.url"
+                target="_blank"
+                rel="noopener"
+                class="version-ref"
+              >{{ s.tag }}</a>
+              <span v-else>{{ s.tag }}</span
+              ><span v-if="i < sources.length - 1">,&nbsp;</span>
+            </template>
           </div>
-
-          <v-expansion-panels
-            v-if="result.sourceNotes && result.sourceNotes.length"
-            variant="accordion"
-          >
-            <v-expansion-panel title="Source release notes">
-              <template #text>
-                <div v-for="(note, i) in result.sourceNotes" :key="i" class="mb-3">
-                  <div class="text-subtitle-2">{{ note.tag }}</div>
-                  <pre class="source-note">{{ note.body }}</pre>
-                </div>
-              </template>
-            </v-expansion-panel>
-          </v-expansion-panels>
         </div>
 
         <div v-else class="text-center text-medium-emphasis py-8">
@@ -110,9 +122,14 @@
 
 <script>
 import axios from 'axios';
+import InlineMarkup from './InlineMarkup.vue';
 
 export default {
   name: 'UpdateAnalysisDialog',
+
+  components: {
+    InlineMarkup,
+  },
 
   props: {
     modelValue: {
@@ -161,6 +178,43 @@ export default {
           return 'secondary';
       }
     },
+
+    // The gathered notes are the authoritative, linkable list of sources (each
+    // carries the release/changelog URL). The model's versionsCovered is only
+    // free text, so we link from these instead.
+    sources() {
+      return ((this.result && this.result.sourceNotes) || [])
+        .filter((note) => note && note.tag)
+        .map((note) => ({ tag: note.tag, url: note.url || null }));
+    },
+
+    // Key by both the raw tag and a v-stripped form: the model often emits
+    // "2.10.0" while the release tag is "v2.10.0", and we still want those
+    // inline refs to link.
+    sourceUrlByTag() {
+      const map = {};
+      this.sources.forEach((s) => {
+        if (s.url) {
+          map[s.tag] = s.url;
+          map[s.tag.replace(/^v/i, '')] = s.url;
+        }
+      });
+      return map;
+    },
+
+    // Newest version first; entries without an identifiable version sink to the
+    // bottom. Array.sort is stable, so same-version items keep the model's order.
+    sortedBreakingChanges() {
+      const list = (this.result && this.result.breakingChanges) || [];
+      return [...list].sort((a, b) => this.compareVersionsDesc(a.version, b.version));
+    },
+
+    sortedHighlights() {
+      const list = (this.result && this.result.highlights) || [];
+      return [...list].sort(
+        (a, b) => this.compareVersionsDesc(this.highlightVersion(a), this.highlightVersion(b)),
+      );
+    },
   },
 
   watch: {
@@ -172,6 +226,54 @@ export default {
   },
 
   methods: {
+    versionUrl(version) {
+      if (!version) {
+        return null;
+      }
+      return this.sourceUrlByTag[version]
+        || this.sourceUrlByTag[String(version).replace(/^v/i, '')]
+        || null;
+    },
+
+    // highlights may be {text, version} objects or plain strings (older output).
+    highlightText(h) {
+      return typeof h === 'string' ? h : (h && h.text) || '';
+    },
+
+    highlightVersion(h) {
+      return typeof h === 'object' && h ? h.version : null;
+    },
+
+    parseVersion(version) {
+      if (!version) {
+        return null;
+      }
+      const parts = String(version).replace(/^v/i, '').match(/\d+/g);
+      return parts ? parts.map(Number) : null;
+    },
+
+    // Descending comparator; null versions sort last.
+    compareVersionsDesc(a, b) {
+      const pa = this.parseVersion(a);
+      const pb = this.parseVersion(b);
+      if (!pa && !pb) {
+        return 0;
+      }
+      if (!pa) {
+        return 1;
+      }
+      if (!pb) {
+        return -1;
+      }
+      for (let i = 0; i < Math.max(pa.length, pb.length); i += 1) {
+        const diff = (pb[i] || 0) - (pa[i] || 0);
+        if (diff !== 0) {
+          return diff;
+        }
+      }
+      return 0;
+    },
+
     async analyze(force) {
       this.loading = true;
       this.error = null;
@@ -196,11 +298,24 @@ export default {
 </script>
 
 <style scoped>
-.source-note {
-  white-space: pre-wrap;
-  overflow-wrap: anywhere;
-  font-family: "JetBrains Mono", monospace;
-  font-size: 12px;
-  margin: 0;
+.highlight-list {
+  padding-left: 1.25rem;
+}
+
+.version-ref {
+  color: rgb(var(--v-theme-info));
+  text-decoration: none;
+  font-size: 0.85em;
+  white-space: nowrap;
+}
+
+.version-ref:hover {
+  text-decoration: underline;
+}
+
+.version-ref-plain {
+  color: rgba(var(--v-theme-on-surface), 0.6);
+  font-size: 0.85em;
+  white-space: nowrap;
 }
 </style>

--- a/ui/src/components/UpdateAnalysisDialog.vue
+++ b/ui/src/components/UpdateAnalysisDialog.vue
@@ -1,0 +1,206 @@
+<template>
+  <v-dialog
+    v-model="dialogVisible"
+    width="70%"
+    max-width="900px"
+    :fullscreen="$vuetify.display.smAndDown"
+    scrollable
+  >
+    <v-card>
+      <v-toolbar flat density="compact" color="surface-light">
+        <v-toolbar-title class="text-body-1">
+          Update analysis: {{ container.displayName }}
+        </v-toolbar-title>
+        <v-chip label size="small" variant="outlined" class="mr-2">
+          {{ container.image.tag.value }}
+          <v-icon size="small" class="mx-1">ri-arrow-right-line</v-icon>
+          {{ targetVersion }}
+        </v-chip>
+        <v-btn
+          size="small"
+          variant="text"
+          :disabled="loading"
+          @click="analyze(true)"
+        >
+          <v-icon start>ri-refresh-line</v-icon>
+          Regenerate
+        </v-btn>
+        <v-btn icon size="small" variant="text" @click="dialogVisible = false">
+          <v-icon>ri-close-line</v-icon>
+        </v-btn>
+      </v-toolbar>
+
+      <v-card-text style="min-height: 240px">
+        <div v-if="loading" class="text-center py-8">
+          <v-progress-circular indeterminate color="info" />
+          <div class="mt-3 text-medium-emphasis">Analyzing release notes...</div>
+        </div>
+
+        <v-alert v-else-if="error" type="error" variant="tonal" class="mb-2">
+          {{ error }}
+          <template #append>
+            <v-btn size="small" variant="text" @click="analyze(false)">Retry</v-btn>
+          </template>
+        </v-alert>
+
+        <div v-else-if="result">
+          <div class="d-flex align-center mb-4">
+            <span class="text-overline mr-2">Risk</span>
+            <v-chip :color="riskColor" label size="small" variant="flat">
+              {{ (result.riskLevel || 'unknown').toUpperCase() }}
+            </v-chip>
+          </div>
+
+          <div v-if="result.breakingChanges && result.breakingChanges.length" class="mb-4">
+            <div class="text-subtitle-2 mb-1">Breaking changes</div>
+            <v-list density="compact" class="bg-transparent">
+              <v-list-item
+                v-for="(bc, i) in result.breakingChanges"
+                :key="i"
+                class="px-0"
+              >
+                <v-list-item-title class="font-weight-medium text-wrap">
+                  {{ bc.title }}
+                </v-list-item-title>
+                <v-list-item-subtitle v-if="bc.detail" class="text-wrap">
+                  {{ bc.detail }}
+                </v-list-item-subtitle>
+              </v-list-item>
+            </v-list>
+          </div>
+
+          <div v-if="result.highlights && result.highlights.length" class="mb-4">
+            <div class="text-subtitle-2 mb-1">What changed</div>
+            <ul class="ms-4">
+              <li v-for="(h, i) in result.highlights" :key="i">{{ h }}</li>
+            </ul>
+          </div>
+
+          <p v-if="result.overview" class="text-body-2 mb-4">{{ result.overview }}</p>
+
+          <div
+            v-if="result.versionsCovered && result.versionsCovered.length"
+            class="text-caption text-medium-emphasis mb-2"
+          >
+            Covers {{ result.versionsCovered.join(', ') }}
+          </div>
+
+          <v-expansion-panels
+            v-if="result.sourceNotes && result.sourceNotes.length"
+            variant="accordion"
+          >
+            <v-expansion-panel title="Source release notes">
+              <template #text>
+                <div v-for="(note, i) in result.sourceNotes" :key="i" class="mb-3">
+                  <div class="text-subtitle-2">{{ note.tag }}</div>
+                  <pre class="source-note">{{ note.body }}</pre>
+                </div>
+              </template>
+            </v-expansion-panel>
+          </v-expansion-panels>
+        </div>
+
+        <div v-else class="text-center text-medium-emphasis py-8">
+          No analysis available.
+        </div>
+      </v-card-text>
+    </v-card>
+  </v-dialog>
+</template>
+
+<script>
+import axios from 'axios';
+
+export default {
+  name: 'UpdateAnalysisDialog',
+
+  props: {
+    modelValue: {
+      type: Boolean,
+      default: false,
+    },
+    container: {
+      type: Object,
+      required: true,
+    },
+  },
+
+  data() {
+    return {
+      loading: false,
+      error: null,
+      result: null,
+    };
+  },
+
+  computed: {
+    dialogVisible: {
+      get() {
+        return this.modelValue;
+      },
+      set(value) {
+        this.$emit('update:modelValue', value);
+      },
+    },
+
+    targetVersion() {
+      return this.container.result ? this.container.result.tag : '';
+    },
+
+    riskColor() {
+      switch (this.result && this.result.riskLevel) {
+        case 'high':
+          return 'error';
+        case 'medium':
+          return 'warning';
+        case 'low':
+          return 'info';
+        case 'none':
+          return 'success';
+        default:
+          return 'secondary';
+      }
+    },
+  },
+
+  watch: {
+    modelValue(open) {
+      if (open && !this.result) {
+        this.analyze(false);
+      }
+    },
+  },
+
+  methods: {
+    async analyze(force) {
+      this.loading = true;
+      this.error = null;
+      if (force) {
+        this.result = null;
+      }
+      try {
+        const response = await axios.post(
+          `/api/containers/${this.container.id}/analyze-update`,
+          null,
+          { params: force ? { force: true } : {} },
+        );
+        this.result = response.data;
+      } catch (e) {
+        this.error = e.response?.data?.error || e.message || 'Analysis failed';
+      } finally {
+        this.loading = false;
+      }
+    },
+  },
+};
+</script>
+
+<style scoped>
+.source-note {
+  white-space: pre-wrap;
+  overflow-wrap: anywhere;
+  font-family: "JetBrains Mono", monospace;
+  font-size: 12px;
+  margin: 0;
+}
+</style>

--- a/ui/src/main.js
+++ b/ui/src/main.js
@@ -7,16 +7,19 @@ import "./styles/cyberpunk.css";
 
 const app = createApp(App);
 
-// Live, reactive $serverConfig accessible as `this.$serverConfig` in any
-// component. App.vue assigns it once authenticated; the getter/setter keep all
-// existing `this.$serverConfig` read/write sites working under Vue 3.
+// Live, reactive $serverConfig readable as `this.$serverConfig` in any
+// component. App.vue sets it once authenticated via $setServerConfig(): Vue 3's
+// component proxy does not forward `this.$serverConfig = x` to a globalProperties
+// setter (it shadows the value on the writing component's own ctx instead), so
+// every other component would keep reading undefined. A setter method sidesteps
+// that and writes the shared reactive state directly.
 const state = reactive({ serverConfig: undefined });
 Object.defineProperty(app.config.globalProperties, "$serverConfig", {
   get: () => state.serverConfig,
-  set: (value) => {
-    state.serverConfig = value;
-  },
 });
+app.config.globalProperties.$setServerConfig = (value) => {
+  state.serverConfig = value;
+};
 
 // Shared event bus (mitt) replacing the Vue 2 `$root` event bus.
 app.config.globalProperties.$bus = bus;


### PR DESCRIPTION
## Summary

Adds **on-demand AI update analysis**: for any container with an available
update, a new **Analyze** button summarizes what changed between the running
version and the update target, flags breaking changes, and rates the overall
upgrade risk. It is off by default, runs only when clicked, and never acts on
its own.

## What it does (UI)

Each updatable container row shows an **Analyze** button (search-eye icon).
Clicking it opens a dialog that renders, natively (no markdown dependency):

- an overall **risk level**: none / low / medium / high
- a short **overview** of the upgrade
- **breaking changes**, each attributed to the version that introduced it
- the notable non-breaking **changes**
- links to the **source** release notes

Results are cached per container + version pair; **Regenerate** re-runs it.

## How it works (backend)

`POST /api/containers/:id/analyze-update` runs a small pipeline in `app/ai/`:

1. Detect the GitHub repo from the image / `hosaka.link.template`.
2. Pull GitHub Releases strictly between current and target; follow thin notes
   out to their linked changelog; fall back to fetching the release page when
   there are no GitHub releases.
3. Cap the notes to a prompt budget and ask Google Gemini for a structured
   (schema-validated) result.

The feature is gated by an API key: `/api/server` exposes only
`{enabled, provider, model}`, secrets stay backend-side, and the button is
hidden unless configured.

## Configuration

| Env var | Description | Default |
|---|---|---|
| `HOSAKA_AI_GEMINI_APIKEY` | Google Gemini key; enables the feature | (unset) |
| `HOSAKA_AI_GEMINI_MODEL` | Gemini model | `gemini-3.1-flash-lite` |
| `HOSAKA_AI_GITHUB_TOKEN` | optional; raises the GitHub API rate limit | (unset) |

All support the `__FILE` suffix. Only public release notes plus the image name
and the two version tags are sent to the provider, and only on click.

## Model + prompt quality

The default model was chosen by comparing four Gemini models across five
containers: `gemini-3.1-flash-lite` gives full release-range coverage at the
fastest latency. The prompt requires `title`/`detail` on each breaking change
and defines all four risk buckets so levels are consistent and explanatory.

## Notable fixes on this branch

- Reliable `$serverConfig` propagation so the feature flag reaches every row.
- Adapter timeouts + transient-status retries for the Gemini call, with friendly
  error messages; phase logging throughout `app/ai`.
- Dialog readability: wrapping detail text, hyperlinked sources, inline-code
  rendering, newest-version-first ordering.
- Web-fallback sources are labeled by their page (host/path) instead of a
  misleading version tag.

## Testing

Backend suite green (53 suites / 506 tests) in a clean `node:18-alpine`
container; UI builds clean. Validated end-to-end on a dev-test stack across the
GitHub-releases, external-changelog-enrichment, and no-notes-fallback paths.

## Docs

README (Why Hosaka, What's different from WUD, Features, Works with, Security),
a new `configuration/ai` docs page, the UI docs, and the reference
`docker-compose.example.yml`.
