### PR TITLE
Harden CI/CD against supply-chain worms

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -117,6 +117,14 @@ jobs:
     permissions:
       contents: read
     steps:
+      # Supply-chain guard on the dep-install/build jobs: baseline egress + file
+      # integrity monitoring so a malicious dependency install script's network
+      # calls surface. Audit (non-blocking) for now; switch egress-policy to
+      # block with an allowlist to enforce.
+      - name: Harden runner
+        uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411  # v2.19.4
+        with:
+          egress-policy: audit
       - name: Checkout
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6.0.3
         with:
@@ -129,7 +137,7 @@ jobs:
           cache-dependency-path: app/package-lock.json
       - name: Install deps
         working-directory: app
-        run: npm ci --no-audit --no-fund
+        run: npm ci --ignore-scripts --no-audit --no-fund
       - name: Run jest
         working-directory: app
         run: npm test
@@ -140,6 +148,10 @@ jobs:
     permissions:
       contents: read
     steps:
+      - name: Harden runner
+        uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411  # v2.19.4
+        with:
+          egress-policy: audit
       - name: Checkout
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6.0.3
         with:
@@ -152,7 +164,7 @@ jobs:
           cache-dependency-path: ui/package-lock.json
       - name: Install deps
         working-directory: ui
-        run: npm ci --no-audit --no-fund
+        run: npm ci --ignore-scripts --no-audit --no-fund
       - name: Build
         working-directory: ui
         run: npm run build
@@ -164,6 +176,10 @@ jobs:
       contents: read
       security-events: write  # upload Trivy SARIF to code scanning
     steps:
+      - name: Harden runner
+        uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411  # v2.19.4
+        with:
+          egress-policy: audit
       - name: Checkout
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6.0.3
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -117,14 +117,22 @@ jobs:
     permissions:
       contents: read
     steps:
-      # Supply-chain guard on the dep-install/build jobs: baseline egress + file
-      # integrity monitoring so a malicious dependency install script's network
-      # calls surface. Audit (non-blocking) for now; switch egress-policy to
-      # block with an allowlist to enforce.
+      # Supply-chain guard: block all runner egress except the endpoints this
+      # job needs (checkout, setup-node, npm, actions cache). A compromised
+      # dependency install script can no longer phone home. Allowlist derived
+      # from harden-runner audit telemetry; the *.blob.core.windows.net entry
+      # covers the rotating Actions-cache hostnames.
       - name: Harden runner
         uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411  # v2.19.4
         with:
-          egress-policy: audit
+          egress-policy: block
+          allowed-endpoints: >
+            api.github.com:443
+            github.com:443
+            registry.npmjs.org:443
+            release-assets.githubusercontent.com:443
+            results-receiver.actions.githubusercontent.com:443
+            *.blob.core.windows.net:443
       - name: Checkout
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6.0.3
         with:
@@ -151,7 +159,14 @@ jobs:
       - name: Harden runner
         uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411  # v2.19.4
         with:
-          egress-policy: audit
+          egress-policy: block
+          allowed-endpoints: >
+            api.github.com:443
+            github.com:443
+            registry.npmjs.org:443
+            release-assets.githubusercontent.com:443
+            results-receiver.actions.githubusercontent.com:443
+            *.blob.core.windows.net:443
       - name: Checkout
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6.0.3
         with:
@@ -179,7 +194,25 @@ jobs:
       - name: Harden runner
         uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411  # v2.19.4
         with:
-          egress-policy: audit
+          egress-policy: block
+          # Adds the image-build endpoints on top of the install set: Docker Hub
+          # (base images), ghcr + pkg-containers (Trivy DB), Alpine apk mirror,
+          # Trivy version check.
+          allowed-endpoints: >
+            api.github.com:443
+            github.com:443
+            objects.githubusercontent.com:443
+            release-assets.githubusercontent.com:443
+            results-receiver.actions.githubusercontent.com:443
+            *.blob.core.windows.net:443
+            registry.npmjs.org:443
+            registry-1.docker.io:443
+            auth.docker.io:443
+            production.cloudfront.docker.com:443
+            ghcr.io:443
+            pkg-containers.githubusercontent.com:443
+            check.trivy.dev:443
+            dl-cdn.alpinelinux.org:443
       - name: Checkout
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6.0.3
         with:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -26,9 +26,12 @@ jobs:
       attestations: write      # write the attestation
       security-events: write   # upload Trivy SARIF
     steps:
-      # Supply-chain guard on the release build: baseline egress + file
-      # integrity monitoring. Audit (non-blocking); switch egress-policy to
-      # block with an allowlist to enforce.
+      # Supply-chain guard on the release build: egress + file-integrity
+      # monitoring. Kept on audit (not block) deliberately: this job runs only
+      # on `release: published`, so an allowlist can't be validated by PR CI the
+      # way the block-mode CI jobs are, and a missing endpoint (Sigstore/OIDC
+      # attestation, ghcr push) would break a real release mid-push. Flip to
+      # block once a release run has baselined its egress set.
       - name: Harden runner
         uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411  # v2.19.4
         with:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -26,6 +26,13 @@ jobs:
       attestations: write      # write the attestation
       security-events: write   # upload Trivy SARIF
     steps:
+      # Supply-chain guard on the release build: baseline egress + file
+      # integrity monitoring. Audit (non-blocking); switch egress-policy to
+      # block with an allowlist to enforce.
+      - name: Harden runner
+        uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411  # v2.19.4
+        with:
+          egress-policy: audit
       - name: Checkout
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6.0.3
         with:

--- a/Dockerfile
+++ b/Dockerfile
@@ -29,8 +29,9 @@ FROM base as dependencies
 # Copy backend package files
 COPY app/package*.json ./
 
-# Install backend dependencies
-RUN npm ci --omit=dev --omit=optional --no-audit --no-fund --no-update-notifier
+# Install backend dependencies. --ignore-scripts blocks dependency lifecycle
+# hooks (the npm supply-chain worm execution vector); no runtime dep needs them.
+RUN npm ci --omit=dev --omit=optional --ignore-scripts --no-audit --no-fund --no-update-notifier
 
 # Frontend Build Stage
 # Vite + vite-plugin-pwa service-worker minification needs a global Web Crypto,
@@ -44,8 +45,9 @@ WORKDIR /home/node/ui
 # Copy UI package files
 COPY ui/package*.json ./
 
-# Install UI dependencies
-RUN npm install
+# Install UI dependencies from the lockfile (npm ci, not install, so the shipped
+# build is pinned), with dependency lifecycle hooks blocked.
+RUN npm ci --ignore-scripts --no-audit --no-fund --no-update-notifier
 
 # Copy all UI source files
 COPY ui/ ./

--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -42,7 +42,7 @@
         "pushover-notifications": "1.2.3",
         "semver": "7.8.1",
         "set-value": "4.1.0",
-        "shell-escape": "^0.2.0",
+        "shell-escape": "0.2.0",
         "snake-case": "3.0.4",
         "sort-es": "1.7.18",
         "uuid": "11.1.1",

--- a/app/package.json
+++ b/app/package.json
@@ -50,7 +50,7 @@
     "sort-es": "1.7.18",
     "uuid": "11.1.1",
     "yaml": "2.9.0",
-    "shell-escape": "^0.2.0"
+    "shell-escape": "0.2.0"
   },
   "overrides": {
     "fast-xml-parser": "5.8.0",

--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "@fortawesome/fontawesome-free": "6.6.0",
-        "axios": "^1.16.1",
+        "axios": "1.17.0",
         "mitt": "3.0.1",
         "remixicon": "4.5.0",
         "simple-icons-font": "13.9.0",

--- a/ui/package.json
+++ b/ui/package.json
@@ -13,7 +13,7 @@
   },
   "dependencies": {
     "@fortawesome/fontawesome-free": "6.6.0",
-    "axios": "^1.16.1",
+    "axios": "1.17.0",
     "mitt": "3.0.1",
     "remixicon": "4.5.0",
     "simple-icons-font": "13.9.0",


### PR DESCRIPTION
Build-time hardening against the npm supply-chain worm class (Shai-Hulud and its mini/OIDC variants). The worm's kill chain is: a dependency lifecycle script runs on `npm install`, harvests secrets, exfiltrates over the network, and self-replicates. This PR closes the two residual gaps in our build and tightens dependency pinning.

## Changes

1. **Block dependency install scripts** (`--ignore-scripts`) on every install: the CI `app-test` and `ui-build` jobs, and both Dockerfile stages. A compromised package's `pre`/`postinstall` hook never executes. This is the worm's primary execution vector.

2. **Monitor runner egress** with `step-security/harden-runner` (SHA-pinned, `egress-policy: audit`) on the dep-install/build jobs (`app-test`, `ui-build`, `docker-build`) and the release `publish` job. Audit mode is non-blocking and immediately adds egress + file-integrity telemetry and tamper detection. The egress allowlist can be tightened and flipped to `block` once the baseline is reviewed.

3. **Pin the UI image build to the lockfile**: the `ui-builder` Dockerfile stage now uses `npm ci` instead of `npm install`, so the shipped artifact matches the committed `ui/package-lock.json`.

4. **Pin the last two caret ranges** to exact versions: `app` `shell-escape` `^0.2.0` -> `0.2.0`, `ui` `axios` `^1.16.1` -> `1.17.0` (resolved versions unchanged; one-line lockfile updates).

## Verification

All exercised in clean containers / a full image build:
- app jest: **507/507 pass** with `npm ci --ignore-scripts`.
- ui: `npm ci --ignore-scripts` + `npm run build` succeed (build + PWA generation).
- full `docker build` (both stages on `--ignore-scripts`) succeeds and the container starts cleanly (store load, registry registration, Docker watcher init, API listening on 3000).

## Not in scope

The worm's propagation path (steal npm token / abuse npm trusted-publisher OIDC, then republish) does not apply here: this project publishes a Docker image to ghcr via the ephemeral `GITHUB_TOKEN`, has no `NPM_TOKEN` and no npm OIDC binding, publishes only on `release: published` (human-gated), and has no auto-merge. Existing controls (full-SHA action pins, `permissions: {}` default, `persist-credentials: false`, zizmor/actionlint/CodeQL/gitleaks/Trivy, provenance + SBOM) remain unchanged.