### PR TITLE
Speed up web first load and fix container row UX

### DIFF
--- a/app/api/index.js
+++ b/app/api/index.js
@@ -1,6 +1,7 @@
 const fs = require('fs');
 const https = require('https');
 const express = require('express');
+const compression = require('compression');
 const cors = require('cors');
 const bodyParser = require('body-parser');
 const log = require('../log').child({ component: 'api' });
@@ -27,6 +28,18 @@ async function init() {
 
         // Trust proxy (helpful to resolve public facing hostname & protocol)
         app.set('trust proxy', true);
+
+        // Compress responses (the UI bundle/CSS dominate first-load transfer).
+        // Skip Server-Sent Events: compression buffers chunks, which would stall
+        // the live container stream and the install-log console.
+        app.use(compression({
+            filter: (req, res) => {
+                if (req.headers.accept && req.headers.accept.includes('text/event-stream')) {
+                    return false;
+                }
+                return compression.filter(req, res);
+            },
+        }));
 
         // Replace undefined values by null to prevent them from being removed from json responses
         app.set('json replacer', (key, value) => (value === undefined ? null : value));

--- a/app/api/ui.js
+++ b/app/api/ui.js
@@ -7,7 +7,18 @@ const express = require('express');
  */
 function init() {
     const router = express.Router();
-    router.use(express.static(path.join(__dirname, '..', 'ui')));
+    router.use(express.static(path.join(__dirname, '..', 'ui'), {
+        setHeaders: (res, filePath) => {
+            // Vite emits content-hashed files under /assets/ => safe to cache
+            // forever. Everything else (index.html, service worker, manifest)
+            // must revalidate so a new build is picked up.
+            if (/[/\\]assets[/\\]/.test(filePath)) {
+                res.setHeader('Cache-Control', 'public, max-age=31536000, immutable');
+            } else {
+                res.setHeader('Cache-Control', 'no-cache');
+            }
+        },
+    }));
 
     // Redirect all 404 to index.html (for vue history mode)
     router.get('/{*splat}', (req, res) => {

--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -15,6 +15,7 @@
         "body-parser": "1.20.5",
         "bunyan": "1.8.15",
         "capitalize": "2.0.4",
+        "compression": "1.8.1",
         "connect-loki": "1.2.0",
         "cors": "2.8.6",
         "dockerode": "5.0.0",
@@ -3938,6 +3939,60 @@
       "resolved": "https://registry.npmjs.org/commist/-/commist-3.2.0.tgz",
       "integrity": "sha512-4PIMoPniho+LqXmpS5d3NuGYncG6XWlkBSVGiWycL22dd42OYdUGil2CWuzklaJoNxyxUSpO4MKIBU94viWNAw==",
       "license": "MIT"
+    },
+    "node_modules/compressible": {
+      "version": "2.0.18",
+      "resolved": "https://registry.npmjs.org/compressible/-/compressible-2.0.18.tgz",
+      "integrity": "sha512-AF3r7P5dWxL8MxyITRMlORQNaOA2IkAFaTr4k7BUumjPtRpGDTZpl0Pb1XCO6JeDCBdp126Cgs9sMxqSjgYyRg==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": ">= 1.43.0 < 2"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/compression": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/compression/-/compression-1.8.1.tgz",
+      "integrity": "sha512-9mAqGPHLakhCLeNyxPkK4xVo746zQ/czLH1Ky+vkitMnWfWZps8r0qXuwhwizagCRttsL4lfG4pIOvaWLpAP0w==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "3.1.2",
+        "compressible": "~2.0.18",
+        "debug": "2.6.9",
+        "negotiator": "~0.6.4",
+        "on-headers": "~1.1.0",
+        "safe-buffer": "5.2.1",
+        "vary": "~1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/compression/node_modules/debug": {
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "2.0.0"
+      }
+    },
+    "node_modules/compression/node_modules/ms": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
+      "license": "MIT"
+    },
+    "node_modules/compression/node_modules/negotiator": {
+      "version": "0.6.4",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.4.tgz",
+      "integrity": "sha512-myRT3DiWPHqho5PrJaIRyaMv2kgYf0mUVgBNOYMuCH5Ki1yEiQaf/ZJuQ62nvpc44wL5WDbTX7yGJi1Neevw8w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
     },
     "node_modules/concat-map": {
       "version": "0.0.1",

--- a/app/package.json
+++ b/app/package.json
@@ -19,6 +19,7 @@
     "body-parser": "1.20.5",
     "bunyan": "1.8.15",
     "capitalize": "2.0.4",
+    "compression": "1.8.1",
     "connect-loki": "1.2.0",
     "cors": "2.8.6",
     "dockerode": "5.0.0",

--- a/ui/src/components/ContainerItem.vue
+++ b/ui/src/components/ContainerItem.vue
@@ -14,15 +14,6 @@
           >{{ container.watcher }}
         </v-chip>
         /
-        <span v-if="!selfhstContainerIconUrl">
-          <v-chip label color="info" variant="outlined" disabled
-            ><v-icon start>{{
-              registryIcon
-            }}</v-icon
-            >{{ container.image.registry.name }}
-          </v-chip>
-          /
-        </span>
         <v-chip label color="info" variant="outlined" disabled>
           <img
             :src="selfhstContainerIconUrl"
@@ -146,7 +137,7 @@
       </div>
     </div>
     <v-expand-transition>
-      <div v-show="showDetail">
+      <div v-if="showDetail">
         <v-tabs fixed-tabs v-model="tab" ref="tabs">
           <v-tab>
             <span v-if="$vuetify.display.mdAndUp" class="me-2">Container</span>
@@ -280,7 +271,6 @@ import ContainerDetail from "@/components/ContainerDetail";
 import ContainerImage from "@/components/ContainerImage";
 import ContainerUpdate from "@/components/ContainerUpdate";
 import ContainerError from "@/components/ContainerError";
-import { getRegistryProviderIcon } from "@/services/registry";
 import { date, short } from "@/filters";
 import { copyTextToClipboard } from "@/utils/clipboard";
 import ScriptOutputDialog from './ScriptOutputDialog.vue';
@@ -359,10 +349,6 @@ export default {
         .replace("sh-", "")
         .replace("sh:", "");
       return `https://cdn.jsdelivr.net/gh/selfhst/icons/png/${iconName}.png`;
-    },
-
-    registryIcon() {
-      return getRegistryProviderIcon();
     },
 
     osIcon() {
@@ -493,10 +479,7 @@ export default {
     },
 
     collapseDetail() {
-      // Prevent collapse when selecting text only
-      if (window.getSelection().type !== "Range") {
-        this.showDetail = !this.showDetail;
-      }
+      this.showDetail = !this.showDetail;
 
       // Hack because of a render bug on tabs inside a collapsible element
       this.$refs.tabs?.onResize?.();
@@ -526,11 +509,6 @@ export default {
 
       try {
         this.showScriptOutput = true;
-        this.$bus.emit('notify', {
-          message: `Update started for ${this.container.displayName}.`,
-          level: 'info',
-          timeout: 5000,
-        });
 
         await axios.post(`/api/containers/${this.container.id}/install`);
 
@@ -595,6 +573,14 @@ export default {
    tightened row, keeping just a small gap from the edge. */
 .v-toolbar :deep(.v-toolbar__content) {
   padding-inline: 8px;
+}
+/* The row header toggles the detail on click; keep its separators non-selectable
+   so rapid clicks can't catch a text selection on the `/` and `:` glyphs. The
+   expanded detail stays selectable for copying values. */
+.v-toolbar :deep(.v-toolbar__content),
+.mobile-header {
+  -webkit-user-select: none;
+  user-select: none;
 }
 /* Let the title reserve its content width and grow into the leftover space so it
    pushes the right-hand chips to the edge on its own. Without a v-spacer (which

--- a/ui/src/views/ContainersView.vue
+++ b/ui/src/views/ContainersView.vue
@@ -65,6 +65,7 @@ export default {
       updateAvailableSelected: false,
       sortSelected: "name",
       eventSource: null,
+      streamConnected: false,
       busyKeys: new Set(),
     };
   },
@@ -242,9 +243,14 @@ export default {
     },
     connectStream() {
       this.eventSource = new EventSource("/api/containers/stream");
-      // On (re)connect, resync the full list to recover any missed events.
+      // The initial list is loaded by beforeRouteEnter, so the first open needs
+      // no resync. Only resync on a *re*connect, to recover events missed while
+      // the stream was down.
       this.eventSource.onopen = () => {
-        this.resyncContainers();
+        if (this.streamConnected) {
+          this.resyncContainers();
+        }
+        this.streamConnected = true;
       };
       // A row with an open install dialog is pinned: skip stream-driven churn
       // (the script recreates the container, which would otherwise remove/


### PR DESCRIPTION
## Summary

Reduces first-load time of the web UI and cleans up several container-row interactions. Backend changes are network-layer only; frontend changes are scoped to the containers page and row component.

### Performance
- **Response compression** (`app/api/index.js`): serve responses through gzip. Server-Sent Events are explicitly excluded (the live container stream and the install-log console must stream unbuffered). Main CSS drops ~1.1MB -> ~0.2MB and JS ~300KB -> ~105KB over the wire.
- **Immutable asset caching** (`app/api/ui.js`): content-hashed `/assets` files get long-lived `immutable` cache headers; `index.html`, the service worker and manifest stay revalidated so new builds are still picked up.
- **Lazy row detail** (`ContainerItem.vue`): each row's detail panel now mounts on expand (`v-if`) instead of every collapsed row keeping its tabs and sub-views in the DOM. On a large list this cuts initial DOM nodes ~75% and first contentful paint from ~4.2s to ~1.2s.
- **Single initial fetch** (`ContainersView.vue`): the list loads once on entry; the SSE stream now resyncs only on reconnect, not on the initial open.

### Row UX
- Drop the registry chip from the collapsed row header (still shown in the expanded detail) to reduce visual noise.
- Remove the redundant "update started" toast now that the install console streams progress live.
- Fix the expand/collapse toggle getting stuck when a rapid click selects header separator text: the header is now non-selectable and the global text-selection guard is removed.

## Verification
Validated on a dev build: compression confirmed on static assets and absent on SSE (which streams live), cache headers correct per file type, render metrics measured before/after, and the row toggle exercised under the previously-stuck condition. Backend unit suite green.